### PR TITLE
Add stop codes to Fortran runner and update C return codes

### DIFF
--- a/smiol_runner.F90
+++ b/smiol_runner.F90
@@ -8,81 +8,83 @@ program smiol_runner
 
     if (SMIOLf_init() /= SMIOL_SUCCESS) then
         write(0,*) "ERROR: 'SMIOLf_init' was not called successfully"
-        stop
+        stop 1
     endif 
 
     if (SMIOLf_finalize() /= SMIOL_SUCCESS) then
         write(0,*) "ERROR: 'SMIOLf_finalize' was not called successfully"
-        stop
+        stop 1
     endif
 
     if (SMIOLf_inquire() /= SMIOL_SUCCESS) then
         write(0,*) "ERROR: 'SMIOLf_inquire' was not called successfully"
-        stop
+        stop 1
     endif
 
     if (SMIOLf_open_file() /= SMIOL_SUCCESS) then
         write(0,*) "ERROR: 'SMIOLf_open_file' was not called successfully"
-        stop
+        stop 1
     endif
 
     if (SMIOLf_close_file() /= SMIOL_SUCCESS) then
         write(0,*) "ERROR: 'SMIOLf_close_file' was not called successfully"
-        stop
+        stop 1
     endif
 
     if (SMIOLf_define_dim() /= SMIOL_SUCCESS) then 
         write(0,*) "ERROR: 'SMIOLf_define_dim' was not called successfully"
-        stop
+        stop 1
     endif
 
     if (SMIOLf_inquire_dim() /= SMIOL_SUCCESS) then
         write(0,*) "ERROR: 'SMIOLf_inquire_dim' was not called successfully"
-        stop
+        stop 1
     endif
 
     if (SMIOLf_define_var() /= SMIOL_SUCCESS) then
         write(0,*) "ERROR: 'SMIOLf_define_var' was not called successfully"
-        stop
+        stop 1
     endif
 
     if (SMIOLf_inquire_var() /= SMIOL_SUCCESS) then
         write(0,*) "ERROR: 'SMIOLf_inquire_var' was not called successfully"
-        stop
+        stop 1
     endif
 
     if (SMIOLf_put_var() /= SMIOL_SUCCESS) then
         write(0,*) "ERROR: 'SMIOLf_put_var' was not called successfully"
-        stop
+        stop 1
     endif
 
     if (SMIOLf_get_var() /= SMIOL_SUCCESS) then
         write(0,*) "ERROR: 'SMIOLf_get_var' was not called successfully"
-        stop
+        stop 1
     endif
 
     if (SMIOLf_define_att() /= SMIOL_SUCCESS) then
         write(0,*) "ERROR: 'SMIOLf_define_att' was not called successfully"
-        stop
+        stop 1
     endif
 
     if (SMIOLf_inquire_att() /= SMIOL_SUCCESS) then
         write(0,*) "ERROR: 'SMIOLf_inquire_att' was not called successfully"
-        stop
+        stop 1
     endif
 
     if (SMIOLf_file_sync() /= SMIOL_SUCCESS) then
         write(0,*) "ERROR: 'SMIOLf_file_sync' was not called successfully"
-        stop
+        stop 1
     endif
 
     if (SMIOLf_set_option() /= SMIOL_SUCCESS) then
         write(0,*) "ERROR: 'SMIOLf_set_option' was not called successfully"
-        stop
+        stop 1
     endif
 
     write(0,*) "Testing SMIOLf_error_string success: ", SMIOLf_error_string(0)
     write(0,*) "Testing SMIOLf_error_string unkown error: ", SMIOLf_error_string(1)
     write(0,*) "SUCCESS"
+
+    stop 0
 
 end program smiol_runner

--- a/smiol_runner.c
+++ b/smiol_runner.c
@@ -11,72 +11,72 @@ int main(int argc, char **argv) {
 
 	if ((ierr = SMIOL_init()) != SMIOL_SUCCESS) {
 		printf("ERROR: SMIOL_init: %s ", SMIOL_error_string(ierr));
-		return -1;
+		return 1;
 	} 
 
 	if ((ierr = SMIOL_finalize()) != SMIOL_SUCCESS) {
 		printf("ERROR: SMIOL_finalize: %s ", SMIOL_error_string(ierr));
-		return -1;
+		return 1;
 	}
 
 	if ((ierr = SMIOL_inquire()) != SMIOL_SUCCESS) {
 		printf("ERROR: SMIOL_inquire: %s ", SMIOL_error_string(ierr));
-		return -1;
+		return 1;
 	}
 
 	if ((ierr = SMIOL_open_file()) != SMIOL_SUCCESS) {
 		printf("ERROR: SMIOL_open_file: %s ", SMIOL_error_string(ierr));
-		return -1;
+		return 1;
 	}
 
 	if ((ierr = SMIOL_close_file()) != SMIOL_SUCCESS) {
 		printf("ERROR: SMIOL_close_file: %s ", SMIOL_error_string(ierr));
-		return -1;
+		return 1;
 	}
 
 	if ((ierr = SMIOL_define_dim()) != SMIOL_SUCCESS) {
 		printf("ERROR: SMIOL_define_dim: %s ", SMIOL_error_string(ierr));
-		return -1;
+		return 1;
 	}
 
 	if ((ierr = SMIOL_inquire_dim()) != SMIOL_SUCCESS) {
 		printf("ERROR: SMIOL_inquire_dim: %s ", SMIOL_error_string(ierr));
-		return -1;
+		return 1;
 	}
 
 	if ((ierr = SMIOL_define_var()) != SMIOL_SUCCESS) {
 		printf("ERROR: SMIOL_define_var: %s ", SMIOL_error_string(ierr));
-		return -1;
+		return 1;
 	}
 
 	if ((ierr = SMIOL_put_var()) != SMIOL_SUCCESS) {
 		printf("ERROR: SMIOL_put_var: %s ", SMIOL_error_string(ierr));
-		return -1;
+		return 1;
 	}
 
 	if ((ierr = SMIOL_get_var()) != SMIOL_SUCCESS) {
 		printf("ERROR: SMIOL_get_var: %s ", SMIOL_error_string(ierr));
-		return -1;
+		return 1;
 	}
 		
 	if ((ierr = SMIOL_define_att()) != SMIOL_SUCCESS) {
 		printf("ERROR: SMIOL_define_att: %s ", SMIOL_error_string(ierr));
-		return -1;
+		return 1;
 	}
 
 	if ((ierr = SMIOL_inquire_att()) != SMIOL_SUCCESS) {
 		printf("ERROR: SMIOL_inquire_att: %s ", SMIOL_error_string(ierr));
-		return -1;
+		return 1;
 	}
 	
 	if ((ierr = SMIOL_file_sync()) != SMIOL_SUCCESS) {
 		printf("ERROR: SMIOL_file_sync: %s ", SMIOL_error_string(ierr));
-		return -1;
+		return 1;
 	}
 
 	if ((ierr = SMIOL_set_option()) != SMIOL_SUCCESS) {
 		printf("ERROR: SMIOL_set_option: %s ", SMIOL_error_string(ierr));
-		return -1;
+		return 1;
 	}
 
 	printf("SMIOL_error_string test 'Unknown error': %s\n", SMIOL_error_string(-1));


### PR DESCRIPTION
To help with automated testing, the Fortran runner, smiol_runner.F90, has been
updated to return 1 if an error and 0 on success. The C smiol runner has been
updated to match the Fortran error return value.

1 was chosen over -1 as a stop code of -1 in Fortran returns 255 (signed
character) instead of 1.