### PR TITLE
Implementation of SMIOL_create_decomp and SMIOL_free_decomp

### DIFF
--- a/smiol_runner.c
+++ b/smiol_runner.c
@@ -1,4 +1,5 @@
 #include <stdio.h>
+#include <stdlib.h>
 #include "smiol.h"
 
 /*******************************************************************************
@@ -8,11 +9,41 @@
 int main(int argc, char **argv)
 {
 	int ierr;
+	size_t n_compute_elements = 1;
+	size_t n_io_elements = 1;
+	uint64_t *compute_elements;
+	uint64_t *io_elements;
+	struct SMIOL_decomp *decomp = NULL;
 
 	if ((ierr = SMIOL_init()) != SMIOL_SUCCESS) {
 		printf("ERROR: SMIOL_init: %s ", SMIOL_error_string(ierr));
 		return 1;
 	} 
+
+	// Create elements
+	compute_elements = malloc(sizeof(uint64_t) * n_compute_elements);
+	io_elements = malloc(sizeof(uint64_t) * n_io_elements);
+
+	decomp = SMIOL_create_decomp(n_compute_elements, n_io_elements,
+				compute_elements, io_elements);
+	if (decomp == NULL) {
+		printf("ERROR: SMIOL_create_decomp - Decomp was not allocated\n");
+		return 1;
+	}
+
+	// Free local copy
+	free(compute_elements);
+	free(io_elements);
+
+	if ((ierr = SMIOL_free_decomp(&decomp)) != SMIOL_SUCCESS) {
+		printf("ERROR: SMIOL_free_decomp: %s ", SMIOL_error_string(ierr));
+		return 1;
+	}
+
+	if (decomp != NULL) {
+		printf("ERROR: SMIOL_free_decomp - Decomp not 'NULL' after free\n");
+		return 1;
+	}
 
 	if ((ierr = SMIOL_finalize()) != SMIOL_SUCCESS) {
 		printf("ERROR: SMIOL_finalize: %s ", SMIOL_error_string(ierr));

--- a/smiol_runner.c
+++ b/smiol_runner.c
@@ -15,6 +15,11 @@ int main(int argc, char **argv)
 	uint64_t *io_elements;
 	struct SMIOL_decomp *decomp = NULL;
 
+	if (argc == 2) {
+		n_compute_elements = (size_t) atoi(argv[1]);
+		n_io_elements = (size_t) atoi(argv[1]);
+	}
+
 	if ((ierr = SMIOL_init()) != SMIOL_SUCCESS) {
 		printf("ERROR: SMIOL_init: %s ", SMIOL_error_string(ierr));
 		return 1;

--- a/src/smiol.c
+++ b/src/smiol.c
@@ -306,5 +306,14 @@ struct SMIOL_decomp *SMIOL_create_decomp(size_t n_compute_elements,
  ********************************************************************************/
 int SMIOL_free_decomp(struct SMIOL_decomp **d)
 {
+	if ((*d) == NULL) {
+		return SMIOL_SUCCESS;
+	}
+
+	free((*d)->compute_elements);
+	free((*d)->io_elements);
+	free((*d));
+	*d = NULL;
+
 	return SMIOL_SUCCESS;
 }

--- a/src/smiol.c
+++ b/src/smiol.c
@@ -1,4 +1,6 @@
 #include <stddef.h>
+#include <stdlib.h>
+#include <stdio.h>
 #include "smiol.h"
 
 
@@ -256,9 +258,40 @@ int SMIOL_set_option(void)
  * Detailed description.
  *
  ********************************************************************************/
-struct SMIOL_decomp *SMIOL_create_decomp(void)
+struct SMIOL_decomp *SMIOL_create_decomp(size_t n_compute_elements,
+		size_t n_io_elements, uint64_t *compute_elements,
+		uint64_t *io_elements)
 {
-	return NULL;
+	struct SMIOL_decomp *d;
+	size_t i;
+
+	d = malloc(sizeof(struct SMIOL_decomp));
+	d->n_compute_elements = n_compute_elements;
+	d->n_io_elements = n_io_elements;
+
+	d->compute_elements = malloc(sizeof(uint64_t) * d->n_compute_elements);
+	if (d->compute_elements == NULL) {
+		fprintf(stderr, "ERROR: Could not malloc space for d->compute_elements\n");
+		return NULL;
+	}
+
+	d->io_elements = malloc(sizeof(uint64_t) * d->n_io_elements);
+	if (d->io_elements == NULL) {
+		fprintf(stderr, "ERROR: Could not malloc space for d->io_elements\n");
+		return NULL;
+	}
+
+	// Copy compute elements
+	for (i = 0; i < d->n_compute_elements; i++) {
+		d->compute_elements[i] = compute_elements[i];
+	}
+
+	// Copy io elements
+	for (i = 0; i < d->n_io_elements; i++) {
+		d->io_elements[i] = io_elements[i];
+	}
+
+	return d;
 }
 
 

--- a/src/smiol.h
+++ b/src/smiol.h
@@ -2,6 +2,8 @@
  * SMIOL -- The Simple MPAS I/O Library
  *******************************************************************************/
 
+#include <stdint.h>
+
 /*
  * Types
  */
@@ -14,7 +16,10 @@ struct SMIOL_file {
 };
 
 struct SMIOL_decomp {
-	int foo;
+	size_t n_compute_elements;
+	size_t n_io_elements;
+	uint64_t *compute_elements;
+	uint64_t *io_elements;
 };
 
 /*

--- a/src/smiol.h
+++ b/src/smiol.h
@@ -70,5 +70,7 @@ int SMIOL_set_option(void);
 /*
  * Decomposition methods
  */
-struct SMIOL_decomp *SMIOL_create_decomp(void);
+struct SMIOL_decomp *SMIOL_create_decomp(size_t n_compute_elements,
+		size_t n_io_elements, uint64_t *compute_elements,
+		uint64_t *io_elements);
 int SMIOL_free_decomp(struct SMIOL_decomp **d);


### PR DESCRIPTION
This PR implements the functions SMIOL_create_decomp and SMIOL_free_decomp as well as add members to the SMIOL_decomp type struct.

SMIOL_create_decomp allocates a SMIOL_decomp type and copies the contents of `compute_elements` and `io_elements` into it. SMIOL_free_decomp will free a decomp type and all of its elements and will prevent a double free if the decomp is NULL.