### PR TITLE
Don't track the smiol_runner_c and smiol_runner_f test programs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+#SMIOL test programs
+smiol_runner_c
+smiol_runner_f
+
 # All object and library files
 *.o
 *.a


### PR DESCRIPTION
The smiol_runner_c and smiol_runner_f files are now listed in
the .gitignore file so that they won't be tracked by git.