### PR TITLE
Define new error code: SMIOL_MALLOC_FAILURE

### DIFF
--- a/smiol_runner.F90
+++ b/smiol_runner.F90
@@ -83,6 +83,8 @@ program smiol_runner
 
     write(0,*) "Testing SMIOLf_error_string success: ", trim(SMIOLf_error_string(SMIOL_SUCCESS))
     write(0,*) "Testing SMIOLf_error_string unkown error: ", trim(SMIOLf_error_string(1))
+    write(0,*) "Testing SMIOLf_error_string malloc returned a null pointer: ", &
+               trim(SMIOLf_error_string(SMIOL_MALLOC_FAILURE))
     write(0,*) "SUCCESS"
 
     stop 0

--- a/smiol_runner.c
+++ b/smiol_runner.c
@@ -117,6 +117,8 @@ int main(int argc, char **argv)
 
 	printf("SMIOL_error_string test 'Unknown error': %s\n", SMIOL_error_string(-1));
 	printf("SMIOL_error_string test 'Success!': %s\n", SMIOL_error_string(SMIOL_SUCCESS));
+	printf("SMIOL_error_string test 'malloc returned a null pointer': %s\n",
+		SMIOL_error_string(SMIOL_MALLOC_FAILURE));
 	printf("Called all SMIOL functions successfully!\n");
 
 	return 0;

--- a/src/smiol.c
+++ b/src/smiol.c
@@ -228,6 +228,8 @@ const char *SMIOL_error_string(int errno)
 	switch (errno) {
 	case SMIOL_SUCCESS:
 		return "Success!";
+	case SMIOL_MALLOC_FAILURE:
+		return "malloc returned a null pointer";
 	default:
 		return "Unknown error";
 	}

--- a/src/smiol_codes.inc
+++ b/src/smiol_codes.inc
@@ -1,1 +1,2 @@
 #define SMIOL_SUCCESS (0)
+#define SMIOL_MALLOC_FAILURE (-1)


### PR DESCRIPTION
The new SMIOL_MALLOC_FAILURE has an associated error string
"malloc returned a null pointer".

This error code may be returned any time a SMIOL routine is not able to allocate
memory, except if a more specific error code is applicable.