### PR TITLE
Add -fbacktrace flag for the GNU Fortran compiler

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ gnu:
 	 "CFLAGS = -g -Wall -pedantic" \
 	 "CPPINCLUDES = " \
 	 "FC = gfortran"\
-	 "FFLAGS = -g -Wall -fcheck=all -pedantic -std=f2003" \
+	 "FFLAGS = -g -Wall -fcheck=all -pedantic -std=f2003 -fbacktrace" \
 	 "FCINCLUDES = " \
 	 "CC_PARALLEL = mpicc" \
 	 "FC_PARALLEL = mpif90" )


### PR DESCRIPTION
Note that `-fbacktrace` is not a valid option for the GNU C compiler,
so this option has been added only for the GNU Fortran compiler.