### PR TITLE
Initial implementation of SMIOL_init and SMIOL_finalize

### DIFF
--- a/smiol_runner.c
+++ b/smiol_runner.c
@@ -61,11 +61,6 @@ int main(int argc, char **argv)
 		return 1;
 	}
 
-	if ((ierr = SMIOL_finalize()) != SMIOL_SUCCESS) {
-		printf("ERROR: SMIOL_finalize: %s ", SMIOL_error_string(ierr));
-		return 1;
-	}
-
 	if ((ierr = SMIOL_inquire()) != SMIOL_SUCCESS) {
 		printf("ERROR: SMIOL_inquire: %s ", SMIOL_error_string(ierr));
 		return 1;
@@ -130,6 +125,16 @@ int main(int argc, char **argv)
 	printf("SMIOL_error_string test 'Success!': %s\n", SMIOL_error_string(SMIOL_SUCCESS));
 	printf("SMIOL_error_string test 'malloc returned a null pointer': %s\n",
 		SMIOL_error_string(SMIOL_MALLOC_FAILURE));
+
+	if ((ierr = SMIOL_finalize(&context)) != SMIOL_SUCCESS) {
+		printf("ERROR: SMIOL_finalize: %s ", SMIOL_error_string(ierr));
+		return 1;
+	}
+
+	if (context != NULL) {
+		fprintf(stderr, "SMIOL_finalize returned a non-NULL context\n");
+		return 1;
+	}
 	printf("Called all SMIOL functions successfully!\n");
 
 	if (MPI_Finalize() != MPI_SUCCESS) {

--- a/smiol_runner.c
+++ b/smiol_runner.c
@@ -14,6 +14,7 @@ int main(int argc, char **argv)
 	uint64_t *compute_elements;
 	uint64_t *io_elements;
 	struct SMIOL_decomp *decomp = NULL;
+	struct SMIOL_context *context = NULL;
 
 	if (argc == 2) {
 		n_compute_elements = (size_t) atoi(argv[1]);
@@ -25,10 +26,15 @@ int main(int argc, char **argv)
 		return 1;
 	}
 
-	if ((ierr = SMIOL_init()) != SMIOL_SUCCESS) {
+	if ((ierr = SMIOL_init(MPI_COMM_WORLD, &context)) != SMIOL_SUCCESS) {
 		printf("ERROR: SMIOL_init: %s ", SMIOL_error_string(ierr));
 		return 1;
 	} 
+
+	if (context == NULL) {
+		fprintf(stderr, "SMIOL_init returned a NULL context\n");
+		return 1;
+	}
 
 	// Create elements
 	compute_elements = malloc(sizeof(uint64_t) * n_compute_elements);

--- a/src/smiol.c
+++ b/src/smiol.c
@@ -75,11 +75,24 @@ int SMIOL_init(MPI_Comm comm, struct SMIOL_context **context)
  *
  * Finalize a SMIOL context.
  *
- * Detailed description.
+ * Finalizes a SMIOL context and frees all memory in the SMIOL_context instance.
+ * After this routine is called, no other SMIOL routines that make reference to
+ * the finalized context should be called.
  *
  ********************************************************************************/
-int SMIOL_finalize(void)
+int SMIOL_finalize(struct SMIOL_context **context)
 {
+	/*
+	 * If the pointer to the context pointer is NULL, assume we have nothing
+	 * to do and declare success
+	 */
+	if (context == NULL) {
+		return SMIOL_SUCCESS;
+	}
+
+	free((*context));
+	(*context) = NULL;
+
 	return SMIOL_SUCCESS;
 }
 

--- a/src/smiol.c
+++ b/src/smiol.c
@@ -10,11 +10,61 @@
  *
  * Initialize a SMIOL context.
  *
- * Detailed description.
+ * Initializes a SMIOL context, within which decompositions may be defined and
+ * files may be read and written. At present, the only input argument is an MPI
+ * communicator.
+ *
+ * Upon successful return the context argument points to a valid SMIOL context;
+ * otherwise, it is NULL and an error code other than MPI_SUCCESS is returned.
+ *
+ * Note: It is assumed that MPI_Init has been called prior to this routine, so
+ *       that any use of the provided MPI communicator will be valid.
  *
  ********************************************************************************/
-int SMIOL_init(void)
+int SMIOL_init(MPI_Comm comm, struct SMIOL_context **context)
 {
+	/*
+	 * Before dereferencing context below, ensure that the pointer
+	 * the context pointer is not NULL
+	 */
+	if (context == NULL) {
+		return -999;    /* Should we define an error code for this? */
+	}
+
+	/*
+	 * We cannot check for every possible invalid argument for comm, but
+	 * at least we can verify that the communicator is not MPI_COMM_NULL
+	 */
+	if (comm == MPI_COMM_NULL) {
+		/* Nullifying (*context) here may result in a memory leak, but this
+		 * seems better than disobeying the stated behavior of returning
+		 * a NULL context upon failure
+		 */
+		(*context) = NULL;
+
+		return -999;    /* Should we define an error code for this? */
+	}
+
+	*context = (struct SMIOL_context *)malloc(sizeof(struct SMIOL_context));
+	if ((*context) == NULL) {
+		return SMIOL_MALLOC_FAILURE;
+	}
+
+	/* TODO: should we MPI_Comm_dup ? */
+	(*context)->fcomm = MPI_Comm_c2f(comm);
+
+	if (MPI_Comm_size(comm, &((*context)->comm_size)) != MPI_SUCCESS) {
+		free((*context));
+		(*context) = NULL;
+		return -998;    /* Should we define an error code for this? */
+	}
+
+	if (MPI_Comm_rank(comm, &((*context)->comm_rank)) != MPI_SUCCESS) {
+		free((*context));
+		(*context) = NULL;
+		return -998;    /* Should we define an error code for this? */
+	}
+
 	return SMIOL_SUCCESS;
 }
 

--- a/src/smiol.c
+++ b/src/smiol.c
@@ -6,6 +6,23 @@
 
 /********************************************************************************
  *
+ * SMIOL_fortran_init
+ *
+ * Initialize a SMIOL context from Fortran.
+ *
+ * This function is a simply a wrapper for the SMOIL_init routine that is intended
+ * to be called from Fortran. Accordingly, the first argument is of type MPI_Fint
+ * (a Fortran integer) rather than MPI_Comm.
+ *
+ ********************************************************************************/
+int SMIOL_fortran_init(MPI_Fint comm, struct SMIOL_context **context)
+{
+	return SMIOL_init(MPI_Comm_f2c(comm), context);
+}
+
+
+/********************************************************************************
+ *
  * SMIOL_init
  *
  * Initialize a SMIOL context.

--- a/src/smiol.h
+++ b/src/smiol.h
@@ -33,6 +33,7 @@ struct SMIOL_decomp {
 /*
  * Library methods
  */
+int SMIOL_fortran_init(MPI_Fint comm, struct SMIOL_context **context);
 int SMIOL_init(MPI_Comm comm, struct SMIOL_context **context);
 int SMIOL_finalize(struct SMIOL_context **context);
 int SMIOL_inquire(void);

--- a/src/smiol.h
+++ b/src/smiol.h
@@ -9,7 +9,9 @@
  * Types
  */
 struct SMIOL_context {
-	int foo;
+	MPI_Fint fcomm; /* Fortran handle to MPI communicator */
+	int comm_size;  /* Size of MPI communicator */
+	int comm_rank;  /* Rank within MPI communicator */
 };
 
 struct SMIOL_file {
@@ -31,7 +33,7 @@ struct SMIOL_decomp {
 /*
  * Library methods
  */
-int SMIOL_init(void);
+int SMIOL_init(MPI_Comm comm, struct SMIOL_context **context);
 int SMIOL_finalize(void);
 int SMIOL_inquire(void);
 

--- a/src/smiol.h
+++ b/src/smiol.h
@@ -34,7 +34,7 @@ struct SMIOL_decomp {
  * Library methods
  */
 int SMIOL_init(MPI_Comm comm, struct SMIOL_context **context);
-int SMIOL_finalize(void);
+int SMIOL_finalize(struct SMIOL_context **context);
 int SMIOL_inquire(void);
 
 /*


### PR DESCRIPTION
This merge provides the initial implementations of `SMIOL_init` and `SMIOL_finalize` for both
C and Fortran. It also provides a set of unit tests for these routines.