### PR TITLE
Initial implementation of SMIOL file open/close routines

### DIFF
--- a/smiol_runner.F90
+++ b/smiol_runner.F90
@@ -9,6 +9,7 @@ program smiol_runner
 
     integer :: ierr
     type (SMIOLf_context), pointer :: context => null()
+    type (SMIOLf_file), pointer :: file => null()
 
     call MPI_Init(ierr)
     if (ierr /= MPI_SUCCESS) then
@@ -40,12 +41,12 @@ program smiol_runner
         stop 1
     endif
 
-    if (SMIOLf_open_file() /= SMIOL_SUCCESS) then
+    if (SMIOLf_open_file(context, "blahf.nc", file) /= SMIOL_SUCCESS) then
         write(0,*) "ERROR: 'SMIOLf_open_file' was not called successfully"
         stop 1
     endif
 
-    if (SMIOLf_close_file() /= SMIOL_SUCCESS) then
+    if (SMIOLf_close_file(file) /= SMIOL_SUCCESS) then
         write(0,*) "ERROR: 'SMIOLf_close_file' was not called successfully"
         stop 1
     endif

--- a/smiol_runner.c
+++ b/smiol_runner.c
@@ -7,6 +7,7 @@
  *******************************************************************************/
 
 int test_init_finalize(void);
+int test_open_close(void);
 
 int main(int argc, char **argv)
 {
@@ -39,6 +40,19 @@ int main(int argc, char **argv)
 	else {
 		fprintf(stderr, "%i tests FAILED!\n\n", ierr);
 	}
+
+
+	/*
+	 * Unit tests for SMIOL_open_file and SMIOL_close_file
+	 */
+	ierr = test_open_close();
+	if (ierr == 0) {
+		fprintf(stderr, "All tests PASSED!\n\n");
+	}
+	else {
+		fprintf(stderr, "%i tests FAILED!\n\n", ierr);
+	}
+
 
 	if ((ierr = SMIOL_init(MPI_COMM_WORLD, &context)) != SMIOL_SUCCESS) {
 		printf("ERROR: SMIOL_init: %s ", SMIOL_error_string(ierr));
@@ -265,6 +279,64 @@ int test_init_finalize(void)
 	else {
 		fprintf(stderr, "FAIL - context is NULL as expected, but SMIOL_SUCCESS was not returned\n");
 		errcount++;
+	}
+
+	fflush(stderr);
+	ierr = MPI_Barrier(MPI_COMM_WORLD);
+
+	fprintf(stderr, "\n");
+
+	return errcount;
+}
+
+int test_open_close(void)
+{
+	int ierr;
+	int errcount;
+	struct SMIOL_context *context;
+	struct SMIOL_file *file;
+
+	fprintf(stderr, "********************************************************************************\n");
+	fprintf(stderr, "************ SMIOL_open_file / SMIOL_close_file unit tests *********************\n");
+	fprintf(stderr, "\n");
+
+	errcount = 0;
+
+	/* Create a SMIOL context for testing file open/close routines */
+	ierr = SMIOL_init(MPI_COMM_WORLD, &context);
+	if (ierr != SMIOL_SUCCESS || context == NULL) {
+		fprintf(stderr, "Failed to create SMIOL context...\n");
+		return -1;
+	}
+
+	/* Everything OK (SMIOL_open_file) */
+	fprintf(stderr, "Everything OK (SMIOL_open_file): ");
+	file = NULL;
+	ierr = SMIOL_open_file(context, "test.nc", &file);
+	if (ierr == SMIOL_SUCCESS && file != NULL) {
+		fprintf(stderr, "PASS\n");
+	}
+	else {
+		fprintf(stderr, "FAIL - context is NULL or SMIOL_SUCCESS was not returned\n");
+		errcount++;
+	}
+
+	/* Everything OK (SMIOL_close_file) */
+	fprintf(stderr, "Everything OK (SMIOL_close_file): ");
+	ierr = SMIOL_close_file(&file);
+	if (ierr == SMIOL_SUCCESS && file == NULL) {
+		fprintf(stderr, "PASS\n");
+	}
+	else {
+		fprintf(stderr, "FAIL - context is not NULL or SMIOL_SUCCESS was not returned\n");
+		errcount++;
+	}
+
+	/* Free the SMIOL context */
+	ierr = SMIOL_finalize(&context);
+	if (ierr != SMIOL_SUCCESS || context != NULL) {
+		fprintf(stderr, "Failed to free SMIOL context...\n");
+		return -1;
 	}
 
 	fflush(stderr);

--- a/smiol_runner.c
+++ b/smiol_runner.c
@@ -17,6 +17,7 @@ int main(int argc, char **argv)
 	uint64_t *io_elements;
 	struct SMIOL_decomp *decomp = NULL;
 	struct SMIOL_context *context = NULL;
+	struct SMIOL_file *file = NULL;
 
 	if (argc == 2) {
 		n_compute_elements = (size_t) atoi(argv[1]);
@@ -79,12 +80,12 @@ int main(int argc, char **argv)
 		return 1;
 	}
 
-	if ((ierr = SMIOL_open_file()) != SMIOL_SUCCESS) {
+	if ((ierr = SMIOL_open_file(context, "blah.nc", &file)) != SMIOL_SUCCESS) {
 		printf("ERROR: SMIOL_open_file: %s ", SMIOL_error_string(ierr));
 		return 1;
 	}
 
-	if ((ierr = SMIOL_close_file()) != SMIOL_SUCCESS) {
+	if ((ierr = SMIOL_close_file(&file)) != SMIOL_SUCCESS) {
 		printf("ERROR: SMIOL_close_file: %s ", SMIOL_error_string(ierr));
 		return 1;
 	}

--- a/src/smiol.c
+++ b/src/smiol.c
@@ -3,6 +3,10 @@
 #include <stdio.h>
 #include "smiol.h"
 
+#ifdef SMIOL_PNETCDF
+#include "pnetcdf.h"
+#endif
+
 
 /********************************************************************************
  *
@@ -170,6 +174,15 @@ int SMIOL_open_file(struct SMIOL_context *context, const char *filename, struct 
 	 */
 	(*file)->context = context;
 
+#ifdef SMIOL_PNETCDF
+	if (ncmpi_create(MPI_Comm_f2c(context->fcomm), filename, NC_NOCLOBBER,
+				MPI_INFO_NULL, &((*file)->ncidp)) != NC_NOERR) {
+		free((*file));
+		(*file) = NULL;
+		return -996;
+	}
+#endif
+
 	return SMIOL_SUCCESS;
 }
 
@@ -195,6 +208,14 @@ int SMIOL_close_file(struct SMIOL_file **file)
 	if (file == NULL) {
 		return SMIOL_SUCCESS;
 	}
+
+#ifdef SMIOL_PNETCDF
+	if (ncmpi_close((*file)->ncidp) != NC_NOERR) {
+		free((*file));
+		(*file) = NULL;
+		return -996;
+	}
+#endif
 
 	free((*file));
 	(*file) = NULL;

--- a/src/smiol.c
+++ b/src/smiol.c
@@ -170,8 +170,6 @@ int SMIOL_open_file(struct SMIOL_context *context, const char *filename, struct 
 	 */
 	(*file)->context = context;
 
-fprintf(stderr, "DEBUG: SMIOL_open_file: Would open SMIOL file %s\n", filename);
-
 	return SMIOL_SUCCESS;
 }
 

--- a/src/smiol.c
+++ b/src/smiol.c
@@ -145,6 +145,33 @@ int SMIOL_inquire(void)
  ********************************************************************************/
 int SMIOL_open_file(struct SMIOL_context *context, const char *filename, struct SMIOL_file **file)
 {
+	/*
+	 * Before dereferencing file below, ensure that the pointer
+	 * the file pointer is not NULL
+	 */
+	if (file == NULL) {
+		return -999;    /* Should we define an error code for this? */
+	}
+
+	/*
+	 * Check that context is valid
+	 */
+	if (context == NULL) {
+		return -999;    /* Should we define an error code for this? */
+	}
+
+	*file = (struct SMIOL_file *)malloc(sizeof(struct SMIOL_file));
+	if ((*file) == NULL) {
+		return SMIOL_MALLOC_FAILURE;
+	}
+
+	/*
+	 * Save pointer to context for this file
+	 */
+	(*file)->context = context;
+
+fprintf(stderr, "DEBUG: SMIOL_open_file: Would open SMIOL file %s\n", filename);
+
 	return SMIOL_SUCCESS;
 }
 
@@ -163,6 +190,17 @@ int SMIOL_open_file(struct SMIOL_context *context, const char *filename, struct 
  ********************************************************************************/
 int SMIOL_close_file(struct SMIOL_file **file)
 {
+	/*
+	 * If the pointer to the file pointer is NULL, assume we have nothing
+	 * to do and declare success
+	 */
+	if (file == NULL) {
+		return SMIOL_SUCCESS;
+	}
+
+	free((*file));
+	(*file) = NULL;
+
 	return SMIOL_SUCCESS;
 }
 

--- a/src/smiol.c
+++ b/src/smiol.c
@@ -135,10 +135,15 @@ int SMIOL_inquire(void)
  *
  * Opens a file within a SMIOL context.
  *
- * Detailed description.
+ * Creates or opens the file specified by filename within the provided SMIOL
+ * context.
+ *
+ * Upon successful completion, SMIOL_SUCCESS is returned, and the file handle argument
+ * will point to a valid file handle. Otherwise, the file handle is NULL and an error
+ * code other than SMIOL_SUCCESS is returned.
  *
  ********************************************************************************/
-int SMIOL_open_file(void)
+int SMIOL_open_file(struct SMIOL_context *context, const char *filename, struct SMIOL_file **file)
 {
 	return SMIOL_SUCCESS;
 }
@@ -150,10 +155,13 @@ int SMIOL_open_file(void)
  *
  * Closes a file within a SMIOL context.
  *
- * Detailed description.
+ * Closes the file associated with the provided file handle. Upon successful
+ * completion, SMIOL_SUCCESS is returned, the file will be closed, and all memory
+ * that is uniquely associated with the file handle will be deallocated.
+ * Otherwise, an error code other than SMIOL_SUCCESS will be returned.
  *
  ********************************************************************************/
-int SMIOL_close_file(void)
+int SMIOL_close_file(struct SMIOL_file **file)
 {
 	return SMIOL_SUCCESS;
 }

--- a/src/smiol.h
+++ b/src/smiol.h
@@ -16,6 +16,9 @@ struct SMIOL_context {
 
 struct SMIOL_file {
 	struct SMIOL_context *context; /* Context for this file */
+#ifdef SMIOL_PNETCDF
+	int ncidp; /* parallel-netCDF file handle */
+#endif
 };
 
 struct SMIOL_decomp {

--- a/src/smiol.h
+++ b/src/smiol.h
@@ -15,7 +15,7 @@ struct SMIOL_context {
 };
 
 struct SMIOL_file {
-	int foo;
+	struct SMIOL_context *context; /* Context for this file */
 };
 
 struct SMIOL_decomp {

--- a/src/smiol.h
+++ b/src/smiol.h
@@ -41,8 +41,8 @@ int SMIOL_inquire(void);
 /*
  * File methods
  */
-int SMIOL_open_file(void);
-int SMIOL_close_file(void);
+int SMIOL_open_file(struct SMIOL_context *context, const char *filename, struct SMIOL_file **file);
+int SMIOL_close_file(struct SMIOL_file **file);
 
 /*
  * Dimension methods

--- a/src/smiolf.F90
+++ b/src/smiolf.F90
@@ -189,14 +189,23 @@ contains
     !
     !> \brief Opens a file within a SMIOL context
     !> \details
-    !>  Detailed description of what this routine does.
+    !>  Creates or opens the file specified by filename within the provided SMIOL
+    !>  context.
+    !>
+    !>  Upon successful completion, SMIOL_SUCCESS is returned, and the file handle argument
+    !>  will point to a valid file handle. Otherwise, the file handle is not associated
+    !>  and an error code other than SMIOL_SUCCESS is returned.
     !
     !-----------------------------------------------------------------------
-    integer function SMIOLf_open_file() result(ierr)
+    integer function SMIOLf_open_file(context, filename, file) result(ierr)
 
         implicit none
 
-        ierr = 0
+        type (SMIOLf_context), pointer :: context
+        character(len=*), intent(in) :: filename
+        type (SMIOLf_file), pointer :: file
+
+        ierr = SMIOL_SUCCESS
 
     end function SMIOLf_open_file
 
@@ -206,17 +215,21 @@ contains
     !
     !> \brief Closes a file within a SMIOL context
     !> \details
-    !>  Detailed description of what this routine does.
+    !>  Closes the file associated with the provided file handle. Upon successful
+    !>  completion, SMIOL_SUCCESS is returned, the file will be closed, and all memory
+    !>  that is uniquely associated with the file handle will be deallocated.
+    !>  Otherwise, an error code other than SMIOL_SUCCESS will be returned.
     !
     !-----------------------------------------------------------------------
-    integer function SMIOLf_close_file() result(ierr)
+    integer function SMIOLf_close_file(file) result(ierr)
 
         implicit none
 
-        ierr = 0
+        type (SMIOLf_file), pointer :: file
+
+        ierr = SMIOL_SUCCESS
 
     end function SMIOLf_close_file
-
 
 
     !

--- a/src/smiolf.F90
+++ b/src/smiolf.F90
@@ -5,7 +5,7 @@
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 module SMIOLf
 
-    use iso_c_binding, only : c_int
+    use iso_c_binding, only : c_int, c_ptr
 
     private
 
@@ -39,7 +39,7 @@ module SMIOLf
     end type SMIOLf_context
 
     type, bind(C) :: SMIOLf_file
-        integer(c_int) :: i
+        type (c_ptr) :: context      ! Pointer to (struct SMIOL_context); the context within which the file was opened
     end type SMIOLf_file
 
     type, bind(C) :: SMIOLf_decomp
@@ -199,13 +199,62 @@ contains
     !-----------------------------------------------------------------------
     integer function SMIOLf_open_file(context, filename, file) result(ierr)
 
+        use iso_c_binding, only : c_loc, c_ptr, c_null_ptr, c_char, c_null_char, c_associated, c_f_pointer
+
         implicit none
 
         type (SMIOLf_context), pointer :: context
         character(len=*), intent(in) :: filename
         type (SMIOLf_file), pointer :: file
 
-        ierr = SMIOL_SUCCESS
+        type (c_ptr) :: c_context = c_null_ptr
+        type (c_ptr) :: c_file = c_null_ptr
+        character(kind=c_char), dimension(:), pointer :: c_filename => null()
+
+        integer :: i
+
+        ! C interface definitions
+        interface
+            function SMIOL_open_file(context, filename, file) result(ierr) bind(C, name='SMIOL_open_file')
+                use iso_c_binding, only : c_char, c_ptr, c_int
+                type (c_ptr), value :: context
+                character(kind=c_char), dimension(*) :: filename
+                type (c_ptr) :: file
+                integer(kind=c_int) :: ierr
+            end function
+        end interface
+
+        if (associated(context)) then
+            c_context = c_loc(context)
+        end if
+
+        !
+        ! Convert Fortran string to C character array
+        !
+        allocate(c_filename(len_trim(filename) + 1))
+        do i=1,len_trim(filename)
+            c_filename(i) = filename(i:i)
+        end do
+        c_filename(i) = c_null_char
+
+        ierr = SMIOL_open_file(c_context, c_filename, c_file)
+
+        deallocate(c_filename)
+
+        if (ierr == SMIOL_SUCCESS) then
+            if (.not. c_associated(c_file)) then
+                nullify(file)
+                ierr = -997     ! TODO: define an error code for this. The c_file should not be null...
+            else
+                call c_f_pointer(c_file, file)
+            end if
+        else
+            if (.not. c_associated(c_file)) then
+                nullify(file)
+            else
+                ierr = -997     ! TODO: define an error code for this. The c_file should be null...
+            end if
+        end if
 
     end function SMIOLf_open_file
 
@@ -223,11 +272,40 @@ contains
     !-----------------------------------------------------------------------
     integer function SMIOLf_close_file(file) result(ierr)
 
+        use iso_c_binding, only : c_loc, c_ptr, c_null_ptr, c_associated
+
         implicit none
 
         type (SMIOLf_file), pointer :: file
 
-        ierr = SMIOL_SUCCESS
+        type (c_ptr) :: c_file = c_null_ptr
+
+        ! C interface definitions
+        interface
+            function SMIOL_close_file(file) result(ierr) bind(C, name='SMIOL_close_file')
+                use iso_c_binding, only : c_ptr, c_int
+                type (c_ptr) :: file
+                integer(kind=c_int) :: ierr
+            end function
+        end interface
+
+        if (associated(file)) then
+            c_file = c_loc(file)
+        end if
+
+        ierr = SMIOL_close_file(c_file)
+
+        if (ierr == SMIOL_SUCCESS) then
+            if (c_associated(c_file)) then
+                ierr = -997     ! TODO: define an error code for this. The c_file should be null...
+            else
+                nullify(file)
+            end if
+        else
+            if (.not. c_associated(c_file)) then
+                nullify(file)
+            end if
+        end if
 
     end function SMIOLf_close_file
 

--- a/src/smiolf.F90
+++ b/src/smiolf.F90
@@ -40,6 +40,9 @@ module SMIOLf
 
     type, bind(C) :: SMIOLf_file
         type (c_ptr) :: context      ! Pointer to (struct SMIOL_context); the context within which the file was opened
+#ifdef SMIOL_PNETCDF
+        integer(c_int) :: ncidp      ! parallel-netCDF file handle
+#endif
     end type SMIOLf_file
 
     type, bind(C) :: SMIOLf_decomp


### PR DESCRIPTION
This merge provides initial implementations of the `SMIOL_open_file` and `SMIOL_close_file`
routines using the parallel-netCDF library, and it also provides unit tests for these routines.

As of this merge, the `SMIOL_open_file` routine can only create a new file -- it is not yet
possible to open existing files.