### PR TITLE
Implementation of Fortran create and free decomp

### DIFF
--- a/smiol_runner.F90
+++ b/smiol_runner.F90
@@ -2,12 +2,18 @@
 
 program smiol_runner
 
+    use iso_c_binding, only : c_size_t, c_int64_t
     use SMIOLf
     use mpi
 
     implicit none
 
     integer :: ierr
+    integer(c_size_t) :: n_compute_elements = 1
+    integer(c_size_t) :: n_io_elements = 1
+    integer(c_int64_t), dimension(:), pointer :: compute_elements
+    integer(c_int64_t), dimension(:), pointer :: io_elements
+    type (SMIOLf_decomp), pointer :: decomp => null()
     type (SMIOLf_context), pointer :: context => null()
 
     call MPI_Init(ierr)
@@ -34,6 +40,17 @@ program smiol_runner
         write(0,*) 'Error: SMIOLf_init returned an unassociated context'
         stop 1
     end if
+
+    allocate(compute_elements(n_compute_elements))
+    allocate(io_elements(n_io_elements))
+
+    if (SMIOLf_create_decomp(n_compute_elements, n_io_elements, compute_elements, io_elements, decomp) /= SMIOL_SUCCESS) then
+        write(0,*) "Error: SMIOLf_create_decomp was not called succesfully"
+        stop 1
+    endif
+
+    deallocate(compute_elements)
+    deallocate(io_elements)
 
     if (SMIOLf_inquire() /= SMIOL_SUCCESS) then
         write(0,*) "ERROR: 'SMIOLf_inquire' was not called successfully"

--- a/smiol_runner.F90
+++ b/smiol_runner.F90
@@ -52,6 +52,11 @@ program smiol_runner
     deallocate(compute_elements)
     deallocate(io_elements)
 
+    if (SMIOLf_free_decomp(decomp) /= SMIOL_SUCCESS) then
+        write(0,*) "Error: SMIOLf_free_decomp was not called succesfully"
+        stop 1
+    endif
+
     if (SMIOLf_inquire() /= SMIOL_SUCCESS) then
         write(0,*) "ERROR: 'SMIOLf_inquire' was not called successfully"
         stop 1

--- a/smiol_runner.c
+++ b/smiol_runner.c
@@ -13,8 +13,8 @@ int main(int argc, char **argv)
 	int ierr;
 	size_t n_compute_elements = 1;
 	size_t n_io_elements = 1;
-	uint64_t *compute_elements;
-	uint64_t *io_elements;
+	int64_t *compute_elements;
+	int64_t *io_elements;
 	struct SMIOL_decomp *decomp = NULL;
 	struct SMIOL_context *context = NULL;
 
@@ -50,8 +50,8 @@ int main(int argc, char **argv)
 	}
 
 	// Create elements
-	compute_elements = malloc(sizeof(uint64_t) * n_compute_elements);
-	io_elements = malloc(sizeof(uint64_t) * n_io_elements);
+	compute_elements = malloc(sizeof(int64_t) * n_compute_elements);
+	io_elements = malloc(sizeof(int64_t) * n_io_elements);
 
 	decomp = SMIOL_create_decomp(n_compute_elements, n_io_elements,
 				compute_elements, io_elements);

--- a/src/smiol.c
+++ b/src/smiol.c
@@ -347,8 +347,8 @@ int SMIOL_set_option(void)
  *
  ********************************************************************************/
 struct SMIOL_decomp *SMIOL_create_decomp(size_t n_compute_elements,
-		size_t n_io_elements, uint64_t *compute_elements,
-		uint64_t *io_elements)
+		size_t n_io_elements, int64_t *compute_elements,
+		int64_t *io_elements)
 {
 	struct SMIOL_decomp *d;
 	size_t i;
@@ -357,13 +357,13 @@ struct SMIOL_decomp *SMIOL_create_decomp(size_t n_compute_elements,
 	d->n_compute_elements = n_compute_elements;
 	d->n_io_elements = n_io_elements;
 
-	d->compute_elements = malloc(sizeof(uint64_t) * d->n_compute_elements);
+	d->compute_elements = malloc(sizeof(int64_t) * d->n_compute_elements);
 	if (d->compute_elements == NULL) {
 		fprintf(stderr, "ERROR: Could not malloc space for d->compute_elements\n");
 		return NULL;
 	}
 
-	d->io_elements = malloc(sizeof(uint64_t) * d->n_io_elements);
+	d->io_elements = malloc(sizeof(int64_t) * d->n_io_elements);
 	if (d->io_elements == NULL) {
 		fprintf(stderr, "ERROR: Could not malloc space for d->io_elements\n");
 		return NULL;

--- a/src/smiol.h
+++ b/src/smiol.h
@@ -21,8 +21,8 @@ struct SMIOL_file {
 struct SMIOL_decomp {
 	size_t n_compute_elements;
 	size_t n_io_elements;
-	uint64_t *compute_elements;
-	uint64_t *io_elements;
+	int64_t *compute_elements;
+	int64_t *io_elements;
 };
 
 /*
@@ -75,6 +75,6 @@ int SMIOL_set_option(void);
  * Decomposition methods
  */
 struct SMIOL_decomp *SMIOL_create_decomp(size_t n_compute_elements,
-		size_t n_io_elements, uint64_t *compute_elements,
-		uint64_t *io_elements);
+		size_t n_io_elements, int64_t *compute_elements,
+		int64_t *io_elements);
 int SMIOL_free_decomp(struct SMIOL_decomp **d);

--- a/src/smiolf.F90
+++ b/src/smiolf.F90
@@ -518,11 +518,41 @@ contains
     !>  Detailed description of what this routine does.
     !
     !-----------------------------------------------------------------------
-    integer function SMIOLf_free_decomp() result(ierr)
+    integer function SMIOLf_free_decomp(decomp) result(ierr)
+
+        use iso_c_binding, only : c_ptr, c_loc, c_associated, c_null_ptr
 
         implicit none
 
-        ierr = 0
+        type(SMIOLF_decomp), pointer, intent(inout) :: decomp
+        type(c_ptr) :: c_decomp = c_null_ptr
+
+        interface
+            function SMIOL_free_decomp(decomp) result(ierr) bind(C, name='SMIOL_free_decomp')
+                use iso_c_binding, only : c_ptr, c_int
+                type(c_ptr) :: decomp
+                integer(kind=c_int) :: ierr
+            end function
+        end interface
+
+        ierr = SMIOL_SUCCESS
+
+        if (associated(decomp)) then
+            c_decomp = c_loc(decomp)
+        endif
+        ierr = SMIOL_free_decomp(c_decomp)
+
+        if (ierr == SMIOL_SUCCESS) then
+            if (c_associated(c_decomp)) then
+                ierr = SMIOL_FORTRAN_ERROR
+            else
+                nullify(decomp)
+            end if
+        else
+            if (.not. c_associated(c_decomp)) then
+                nullify(decomp)
+            end if
+        end if
 
     end function SMIOLf_free_decomp
 

--- a/src/smiolf.F90
+++ b/src/smiolf.F90
@@ -5,7 +5,7 @@
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 module SMIOLf
 
-    use iso_c_binding, only : c_int
+    use iso_c_binding, only : c_int, c_size_t, c_ptr
 
     private
 
@@ -43,7 +43,10 @@ module SMIOLf
     end type SMIOLf_file
 
     type, bind(C) :: SMIOLf_decomp
-        integer(c_int) :: i
+        integer(c_size_t) :: n_compute_elements
+        integer(c_size_t) :: n_io_elements
+        type(c_ptr) :: compute_elements
+        type(c_ptr) :: io_elements
     end type SMIOLf_decomp
 
 


### PR DESCRIPTION
These commits implements the Fortran side of the create and free decomp routines and defines  `SMIOLf_decomp` type which is interoperable with the C Struct SMIOL_decomp type. It also implements unit tests in smiol_runner.F90.