### PR TITLE
Remove unnecessary Makefile variables (LDFLAGS and FCINCLUDES)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,6 @@ llvm:
 	 "CFLAGS = -g -Weverything" \
 	 "FC = flang" \
 	 "FFLAGS = -g -Mbounds -Mchkptr -Mstandard" \
-	 "FCINCLUDES = " \
 	 "CC_PARALLEL = mpicc" \
 	 "FC_PARALLEL = mpifort" )
 
@@ -18,7 +17,6 @@ gnu:
 	 "CFLAGS = -g -Wall -pedantic" \
 	 "FC = gfortran"\
 	 "FFLAGS = -g -Wall -fcheck=all -pedantic -std=f2003 -fbacktrace" \
-	 "FCINCLUDES = " \
 	 "CC_PARALLEL = mpicc" \
 	 "FC_PARALLEL = mpif90" )
 
@@ -28,7 +26,6 @@ intel:
 	 "CFLAGS = -g -Wall -traceback" \
 	 "FC = ifort " \
 	 "FFLAGS = -g -warn all -check all -traceback" \
-	 "FCINCLUDES = " \
 	 "CC_PARALLEL = mpicc" \
 	 "FC_PARALLEL = mpif90" )
 
@@ -38,7 +35,6 @@ pgi:
 	 "CFLAGS = -g -traceback" \
 	 "FC = pgfortran" \
 	 "FFLAGS = -g -Mbounds -Mchkptr -traceback" \
-	 "FCINCLUDES = " \
 	 "CC_PARALLEL = mpicc" \
 	 "FC_PARALLEL = mpif90" )
 
@@ -48,7 +44,6 @@ xl:
 	 "CFLAGS = -g" \
 	 "FC = xlf2003_r" \
 	 "FFLAGS = -g -C" \
-	 "FCINCLUDES = " \
 	 "CC_PARALLEL = mpicc" \
 	 "FC_PARALLEL = mpifort" )
 
@@ -58,7 +53,6 @@ nag:
 	 "CFLAGS = -g -Wall -pedantic" \
 	 "FC = nagfor" \
 	 "FFLAGS = -f2003 -g -C=all" \
-	 "FCINCLUDES = " \
 	 "CC_PARALLEL = mpicc" \
 	 "FC_PARALLEL = mpifort" )
 

--- a/Makefile
+++ b/Makefile
@@ -75,8 +75,8 @@ endif
 smiol:
 
 	$(MAKE) -C ./src CC=$(CC_PARALLEL) FC=$(FC_PARALLEL) CPPINCLUDES="$(CPPINCLUDES)"
-	$(CC_PARALLEL) -I./src/ $(CPPINCLUDES) $(CFLAGS) -L./ $(LDFLAGS) -o smiol_runner_c smiol_runner.c -lsmiol $(LIBS)
-	$(FC_PARALLEL) -I./src/ $(CPPINCLUDES) $(FFLAGS) -L./ $(LDFLAGS) -o smiol_runner_f smiol_runner.F90 -lsmiolf -lsmiol $(LIBS)
+	$(CC_PARALLEL) -I./src/ $(CPPINCLUDES) $(CFLAGS) -L./ -o smiol_runner_c smiol_runner.c -lsmiol $(LIBS)
+	$(FC_PARALLEL) -I./src/ $(CPPINCLUDES) $(FFLAGS) -L./ -o smiol_runner_f smiol_runner.F90 -lsmiolf -lsmiol $(LIBS)
 
 
 test:

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 default:
-	@echo "Please provide a compiler name (llvm, gnu, intel, pgi, xi, nag, cray)"
+	@echo "Please provide a compiler name (llvm, gnu, intel, pgi, xl, nag, cray)"
 	exit 1
 
 llvm:

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,8 +1,8 @@
 all: smiol
 
 smiol:
-	$(CC) $(CPPINCLUDES) $(CFLAGS) $(LDFLAGS) -c smiol.c
-	$(FC) $(CPPINCLUDES) $(FFLAGS) $(LDFLAGS) -c smiolf.F90
+	$(CC) $(CPPINCLUDES) $(CFLAGS) -c smiol.c
+	$(FC) $(CPPINCLUDES) $(FFLAGS) -c smiolf.F90
 	ar cr ../libsmiol.a smiol.o
 	ar cr ../libsmiolf.a smiolf.o
 


### PR DESCRIPTION
This merge removes two unnecessary variables from the Makefiles: LDFLAGS and FCINCLUDES.

Also, the reference to the 'xi' compilers in the top-level Makefile has been changed to 'xl'.