### PR TITLE
Write test messages to test log files rather than stderr

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,10 @@
 smiol_runner_c
 smiol_runner_f
 
+#SMIOL test logs
+smiol.????.test
+smiolf.????.test
+
 # All object and library files
 *.o
 *.a

--- a/smiol_runner.F90
+++ b/smiol_runner.F90
@@ -22,13 +22,13 @@ program smiol_runner
 
     call MPI_Init(ierr)
     if (ierr /= MPI_SUCCESS) then
-        write(0,*) 'Error: MPI_Init failed'
+        write(0,'(a)') 'Error: MPI_Init failed'
         stop 1
     end if
 
     call MPI_Comm_rank(MPI_COMM_WORLD, my_proc_id, ierr)
     if (ierr /= MPI_SUCCESS) then
-        write(0,*) 'Error: MPI_Comm_rank failed'
+        write(0,'(a)') 'Error: MPI_Comm_rank failed'
         stop 1
     end if
 
@@ -40,11 +40,11 @@ program smiol_runner
     !
     ierr = test_init_finalize(test_log)
     if (ierr == 0) then
-        write(test_log,*) 'All tests PASSED!'
-        write(test_log,*) ''
+        write(test_log,'(a)') 'All tests PASSED!'
+        write(test_log,'(a)') ''
     else
-        write(test_log,*) ierr, ' tests FAILED!'
-        write(test_log,*) ''
+        write(test_log,'(a)') ierr, ' tests FAILED!'
+        write(test_log,'(a)') ''
     end if
 
     !
@@ -52,11 +52,11 @@ program smiol_runner
     !
     ierr = test_open_close(test_log)
     if (ierr == 0) then
-        write(test_log,*) 'All tests PASSED!'
-        write(test_log,*) ''
+        write(test_log,'(a)') 'All tests PASSED!'
+        write(test_log,'(a)') ''
     else
-        write(test_log,*) ierr, ' tests FAILED!'
-        write(test_log,*) ''
+        write(test_log,'(a)') ierr, ' tests FAILED!'
+        write(test_log,'(a)') ''
     end if
 
     !
@@ -64,21 +64,21 @@ program smiol_runner
     !
     ierr = test_decomp(test_log)
     if (ierr == 0) then
-        write(test_log,*) 'All tests PASSED!'
-        write(test_log,*) ''
+        write(test_log,'(a)') 'All tests PASSED!'
+        write(test_log,'(a)') ''
     else
-        write(test_log,*) ierr, ' tests FAILED!'
-        write(test_log,*) ''
+        write(test_log,'(a)') ierr, ' tests FAILED!'
+        write(test_log,'(a)') ''
     endif
 
 
     if (SMIOLf_init(MPI_COMM_WORLD, context) /= SMIOL_SUCCESS) then
-        write(test_log,*) "ERROR: 'SMIOLf_init' was not called successfully"
+        write(test_log,'(a)') "ERROR: 'SMIOLf_init' was not called successfully"
         stop 1
     endif 
 
     if (.not. associated(context)) then
-        write(test_log,*) 'Error: SMIOLf_init returned an unassociated context'
+        write(test_log,'(a)') 'Error: SMIOLf_init returned an unassociated context'
         stop 1
     end if
 
@@ -86,7 +86,7 @@ program smiol_runner
     allocate(io_elements(n_io_elements))
 
     if (SMIOLf_create_decomp(n_compute_elements, n_io_elements, compute_elements, io_elements, decomp) /= SMIOL_SUCCESS) then
-        write(test_log,*) "Error: SMIOLf_create_decomp was not called successfully"
+        write(test_log,'(a)') "Error: SMIOLf_create_decomp was not called successfully"
         stop 1
     endif
 
@@ -94,72 +94,72 @@ program smiol_runner
     deallocate(io_elements)
 
     if (SMIOLf_free_decomp(decomp) /= SMIOL_SUCCESS) then
-        write(test_log,*) "Error: SMIOLf_free_decomp was not called successfully"
+        write(test_log,'(a)') "Error: SMIOLf_free_decomp was not called successfully"
         stop 1
     endif
 
     if (SMIOLf_inquire() /= SMIOL_SUCCESS) then
-        write(test_log,*) "ERROR: 'SMIOLf_inquire' was not called successfully"
+        write(test_log,'(a)') "ERROR: 'SMIOLf_inquire' was not called successfully"
         stop 1
     endif
 
     if (SMIOLf_open_file(context, "blahf.nc", file) /= SMIOL_SUCCESS) then
-        write(test_log,*) "ERROR: 'SMIOLf_open_file' was not called successfully"
+        write(test_log,'(a)') "ERROR: 'SMIOLf_open_file' was not called successfully"
         stop 1
     endif
 
     if (SMIOLf_close_file(file) /= SMIOL_SUCCESS) then
-        write(test_log,*) "ERROR: 'SMIOLf_close_file' was not called successfully"
+        write(test_log,'(a)') "ERROR: 'SMIOLf_close_file' was not called successfully"
         stop 1
     endif
 
     if (SMIOLf_define_dim() /= SMIOL_SUCCESS) then 
-        write(test_log,*) "ERROR: 'SMIOLf_define_dim' was not called successfully"
+        write(test_log,'(a)') "ERROR: 'SMIOLf_define_dim' was not called successfully"
         stop 1
     endif
 
     if (SMIOLf_inquire_dim() /= SMIOL_SUCCESS) then
-        write(test_log,*) "ERROR: 'SMIOLf_inquire_dim' was not called successfully"
+        write(test_log,'(a)') "ERROR: 'SMIOLf_inquire_dim' was not called successfully"
         stop 1
     endif
 
     if (SMIOLf_define_var() /= SMIOL_SUCCESS) then
-        write(test_log,*) "ERROR: 'SMIOLf_define_var' was not called successfully"
+        write(test_log,'(a)') "ERROR: 'SMIOLf_define_var' was not called successfully"
         stop 1
     endif
 
     if (SMIOLf_inquire_var() /= SMIOL_SUCCESS) then
-        write(test_log,*) "ERROR: 'SMIOLf_inquire_var' was not called successfully"
+        write(test_log,'(a)') "ERROR: 'SMIOLf_inquire_var' was not called successfully"
         stop 1
     endif
 
     if (SMIOLf_put_var() /= SMIOL_SUCCESS) then
-        write(test_log,*) "ERROR: 'SMIOLf_put_var' was not called successfully"
+        write(test_log,'(a)') "ERROR: 'SMIOLf_put_var' was not called successfully"
         stop 1
     endif
 
     if (SMIOLf_get_var() /= SMIOL_SUCCESS) then
-        write(test_log,*) "ERROR: 'SMIOLf_get_var' was not called successfully"
+        write(test_log,'(a)') "ERROR: 'SMIOLf_get_var' was not called successfully"
         stop 1
     endif
 
     if (SMIOLf_define_att() /= SMIOL_SUCCESS) then
-        write(test_log,*) "ERROR: 'SMIOLf_define_att' was not called successfully"
+        write(test_log,'(a)') "ERROR: 'SMIOLf_define_att' was not called successfully"
         stop 1
     endif
 
     if (SMIOLf_inquire_att() /= SMIOL_SUCCESS) then
-        write(test_log,*) "ERROR: 'SMIOLf_inquire_att' was not called successfully"
+        write(test_log,'(a)') "ERROR: 'SMIOLf_inquire_att' was not called successfully"
         stop 1
     endif
 
     if (SMIOLf_file_sync() /= SMIOL_SUCCESS) then
-        write(test_log,*) "ERROR: 'SMIOLf_file_sync' was not called successfully"
+        write(test_log,'(a)') "ERROR: 'SMIOLf_file_sync' was not called successfully"
         stop 1
     endif
 
     if (SMIOLf_set_option() /= SMIOL_SUCCESS) then
-        write(test_log,*) "ERROR: 'SMIOLf_set_option' was not called successfully"
+        write(test_log,'(a)') "ERROR: 'SMIOLf_set_option' was not called successfully"
         stop 1
     endif
 
@@ -176,12 +176,12 @@ program smiol_runner
     write(test_log,'(a)') "SUCCESS"
 
     if (SMIOLf_finalize(context) /= SMIOL_SUCCESS) then
-        write(test_log,*) "ERROR: 'SMIOLf_finalize' was not called successfully"
+        write(test_log,'(a)') "ERROR: 'SMIOLf_finalize' was not called successfully"
         stop 1
     endif
 
     if (associated(context)) then
-        write(test_log,*) 'Error: SMIOLf_finalize returned an associated context'
+        write(test_log,'(a)') 'Error: SMIOLf_finalize returned an associated context'
         stop 1
     end if
 
@@ -189,7 +189,7 @@ program smiol_runner
 
     call MPI_Finalize(ierr)
     if (ierr /= MPI_SUCCESS) then
-        write(0,*) 'Error: MPI_Finalize failed'
+        write(0,'(a)') 'Error: MPI_Finalize failed'
         stop 1
     end if
 

--- a/smiol_runner.F90
+++ b/smiol_runner.F90
@@ -9,6 +9,8 @@ program smiol_runner
     implicit none
 
     integer :: ierr
+    integer :: my_proc_id
+    integer :: test_log = 42
     integer(c_size_t) :: n_compute_elements = 1
     integer(c_size_t) :: n_io_elements = 1
     integer(c_int64_t), dimension(:), pointer :: compute_elements
@@ -16,6 +18,7 @@ program smiol_runner
     type (SMIOLf_decomp), pointer :: decomp => null()
     type (SMIOLf_context), pointer :: context => null()
     type (SMIOLf_file), pointer :: file => null()
+    character(len=16) :: log_fname
 
     call MPI_Init(ierr)
     if (ierr /= MPI_SUCCESS) then
@@ -23,51 +26,59 @@ program smiol_runner
         stop 1
     end if
 
+    call MPI_Comm_rank(MPI_COMM_WORLD, my_proc_id, ierr)
+    if (ierr /= MPI_SUCCESS) then
+        write(0,*) 'Error: MPI_Comm_rank failed'
+        stop 1
+    end if
+
+    write(log_fname, '(a,I4.4,a)') "smiolf.", my_proc_id, ".test"
+    open(unit=test_log, file=log_fname, status='replace')
 
     !
     ! Unit tests for SMIOL_init and SMIOL_finalize
     !
-    ierr = test_init_finalize()
+    ierr = test_init_finalize(test_log)
     if (ierr == 0) then
-        write(0,*) 'All tests PASSED!'
-        write(0,*) ''
+        write(test_log,*) 'All tests PASSED!'
+        write(test_log,*) ''
     else
-        write(0,*) ierr, ' tests FAILED!'
-        write(0,*) ''
+        write(test_log,*) ierr, ' tests FAILED!'
+        write(test_log,*) ''
     end if
 
     !
     ! Unit tests for SMIOL_open_file and SMIOL_close_file
     !
-    ierr = test_open_close()
+    ierr = test_open_close(test_log)
     if (ierr == 0) then
-        write(0,*) 'All tests PASSED!'
-        write(0,*) ''
+        write(test_log,*) 'All tests PASSED!'
+        write(test_log,*) ''
     else
-        write(0,*) ierr, ' tests FAILED!'
-        write(0,*) ''
+        write(test_log,*) ierr, ' tests FAILED!'
+        write(test_log,*) ''
     end if
 
     !
     ! Unit tests for SMIOL_create_decomp and SMIOL_free_decomp
     !
-    ierr = test_decomp()
+    ierr = test_decomp(test_log)
     if (ierr == 0) then
-        write(0,*) 'All tests PASSED!'
-        write(0,*) ''
+        write(test_log,*) 'All tests PASSED!'
+        write(test_log,*) ''
     else
-        write(0,*) ierr, ' tests FAILED!'
-        write(0,*) ''
+        write(test_log,*) ierr, ' tests FAILED!'
+        write(test_log,*) ''
     endif
 
 
     if (SMIOLf_init(MPI_COMM_WORLD, context) /= SMIOL_SUCCESS) then
-        write(0,*) "ERROR: 'SMIOLf_init' was not called successfully"
+        write(test_log,*) "ERROR: 'SMIOLf_init' was not called successfully"
         stop 1
     endif 
 
     if (.not. associated(context)) then
-        write(0,*) 'Error: SMIOLf_init returned an unassociated context'
+        write(test_log,*) 'Error: SMIOLf_init returned an unassociated context'
         stop 1
     end if
 
@@ -75,7 +86,7 @@ program smiol_runner
     allocate(io_elements(n_io_elements))
 
     if (SMIOLf_create_decomp(n_compute_elements, n_io_elements, compute_elements, io_elements, decomp) /= SMIOL_SUCCESS) then
-        write(0,*) "Error: SMIOLf_create_decomp was not called successfully"
+        write(test_log,*) "Error: SMIOLf_create_decomp was not called successfully"
         stop 1
     endif
 
@@ -83,96 +94,98 @@ program smiol_runner
     deallocate(io_elements)
 
     if (SMIOLf_free_decomp(decomp) /= SMIOL_SUCCESS) then
-        write(0,*) "Error: SMIOLf_free_decomp was not called successfully"
+        write(test_log,*) "Error: SMIOLf_free_decomp was not called successfully"
         stop 1
     endif
 
     if (SMIOLf_inquire() /= SMIOL_SUCCESS) then
-        write(0,*) "ERROR: 'SMIOLf_inquire' was not called successfully"
+        write(test_log,*) "ERROR: 'SMIOLf_inquire' was not called successfully"
         stop 1
     endif
 
     if (SMIOLf_open_file(context, "blahf.nc", file) /= SMIOL_SUCCESS) then
-        write(0,*) "ERROR: 'SMIOLf_open_file' was not called successfully"
+        write(test_log,*) "ERROR: 'SMIOLf_open_file' was not called successfully"
         stop 1
     endif
 
     if (SMIOLf_close_file(file) /= SMIOL_SUCCESS) then
-        write(0,*) "ERROR: 'SMIOLf_close_file' was not called successfully"
+        write(test_log,*) "ERROR: 'SMIOLf_close_file' was not called successfully"
         stop 1
     endif
 
     if (SMIOLf_define_dim() /= SMIOL_SUCCESS) then 
-        write(0,*) "ERROR: 'SMIOLf_define_dim' was not called successfully"
+        write(test_log,*) "ERROR: 'SMIOLf_define_dim' was not called successfully"
         stop 1
     endif
 
     if (SMIOLf_inquire_dim() /= SMIOL_SUCCESS) then
-        write(0,*) "ERROR: 'SMIOLf_inquire_dim' was not called successfully"
+        write(test_log,*) "ERROR: 'SMIOLf_inquire_dim' was not called successfully"
         stop 1
     endif
 
     if (SMIOLf_define_var() /= SMIOL_SUCCESS) then
-        write(0,*) "ERROR: 'SMIOLf_define_var' was not called successfully"
+        write(test_log,*) "ERROR: 'SMIOLf_define_var' was not called successfully"
         stop 1
     endif
 
     if (SMIOLf_inquire_var() /= SMIOL_SUCCESS) then
-        write(0,*) "ERROR: 'SMIOLf_inquire_var' was not called successfully"
+        write(test_log,*) "ERROR: 'SMIOLf_inquire_var' was not called successfully"
         stop 1
     endif
 
     if (SMIOLf_put_var() /= SMIOL_SUCCESS) then
-        write(0,*) "ERROR: 'SMIOLf_put_var' was not called successfully"
+        write(test_log,*) "ERROR: 'SMIOLf_put_var' was not called successfully"
         stop 1
     endif
 
     if (SMIOLf_get_var() /= SMIOL_SUCCESS) then
-        write(0,*) "ERROR: 'SMIOLf_get_var' was not called successfully"
+        write(test_log,*) "ERROR: 'SMIOLf_get_var' was not called successfully"
         stop 1
     endif
 
     if (SMIOLf_define_att() /= SMIOL_SUCCESS) then
-        write(0,*) "ERROR: 'SMIOLf_define_att' was not called successfully"
+        write(test_log,*) "ERROR: 'SMIOLf_define_att' was not called successfully"
         stop 1
     endif
 
     if (SMIOLf_inquire_att() /= SMIOL_SUCCESS) then
-        write(0,*) "ERROR: 'SMIOLf_inquire_att' was not called successfully"
+        write(test_log,*) "ERROR: 'SMIOLf_inquire_att' was not called successfully"
         stop 1
     endif
 
     if (SMIOLf_file_sync() /= SMIOL_SUCCESS) then
-        write(0,*) "ERROR: 'SMIOLf_file_sync' was not called successfully"
+        write(test_log,*) "ERROR: 'SMIOLf_file_sync' was not called successfully"
         stop 1
     endif
 
     if (SMIOLf_set_option() /= SMIOL_SUCCESS) then
-        write(0,*) "ERROR: 'SMIOLf_set_option' was not called successfully"
+        write(test_log,*) "ERROR: 'SMIOLf_set_option' was not called successfully"
         stop 1
     endif
 
-    write(0,'(a)') "Testing SMIOLf_error_string success: ", trim(SMIOLf_error_string(SMIOL_SUCCESS))
-    write(0,'(a)') "Testing SMIOLf_error_string unkown error: ", trim(SMIOLf_error_string(1))
-    write(0,'(a)') "Testing SMIOLf_error_string malloc returned a null pointer: ", &
+    write(test_log,'(a)') "Testing SMIOLf_error_string success: ", trim(SMIOLf_error_string(SMIOL_SUCCESS))
+    write(test_log,'(a)') "Testing SMIOLf_error_string unkown error: ", trim(SMIOLf_error_string(1))
+    write(test_log,'(a)') "Testing SMIOLf_error_string malloc returned a null pointer: ", &
                trim(SMIOLf_error_string(SMIOL_MALLOC_FAILURE))
-    write(0,'(a)') "Testing SMIOL_error_string test invalid subroutine argument: ", &
+    write(test_log,'(a)') "Testing SMIOL_error_string test invalid subroutine argument: ", &
                trim(SMIOLf_error_string(SMIOL_INVALID_ARGUMENT))
-    write(0,'(a)') "Testing SMIOL_error_string test internal MPI call failed: ", &
+    write(test_log,'(a)') "Testing SMIOL_error_string test internal MPI call failed: ", &
                trim(SMIOLf_error_string(SMIOL_MPI_ERROR))
-    write(0,'(a)') "Testing SMIOL_error_string test Fortran wrapper detected an inconsistency in C return values: ", &
+    write(test_log,'(a)') "Testing SMIOL_error_string test Fortran wrapper detected an inconsistency in C return values: ", &
                trim(SMIOLf_error_string(SMIOL_FORTRAN_ERROR))
-    write(0,'(a)') "SUCCESS"
+    write(test_log,'(a)') "SUCCESS"
 
     if (SMIOLf_finalize(context) /= SMIOL_SUCCESS) then
-        write(0,*) "ERROR: 'SMIOLf_finalize' was not called successfully"
+        write(test_log,*) "ERROR: 'SMIOLf_finalize' was not called successfully"
         stop 1
     endif
 
     if (associated(context)) then
-        write(0,*) 'Error: SMIOLf_finalize returned an associated context'
+        write(test_log,*) 'Error: SMIOLf_finalize returned an associated context'
         stop 1
     end if
+
+    close(test_log)
 
     call MPI_Finalize(ierr)
     if (ierr /= MPI_SUCCESS) then
@@ -186,96 +199,98 @@ program smiol_runner
 contains
 
 
-    function test_init_finalize() result(ierrcount)
+    function test_init_finalize(test_log) result(ierrcount)
 
         implicit none
 
+        integer, intent(in) :: test_log
         integer :: ierrcount
         type (SMIOLf_context), pointer :: context
         type (SMIOLf_context), pointer :: context_temp
 
-        write(0,'(a)') '********************************************************************************'
-        write(0,'(a)') '************ SMIOLf_init / SMIOLf_finalize unit tests **************************'
-        write(0,'(a)') ''
+        write(test_log,'(a)') '********************************************************************************'
+        write(test_log,'(a)') '************ SMIOLf_init / SMIOLf_finalize unit tests **************************'
+        write(test_log,'(a)') ''
 
         ierrcount = 0
 
         ! Invalid MPI communicator, and with an associated context that should be nullified
-        write(0,'(a)',advance='no') 'Invalid MPI communicator (SMIOLf_init): '
+        write(test_log,'(a)',advance='no') 'Invalid MPI communicator (SMIOLf_init): '
         allocate(context_temp)
         context => context_temp
         ierr = SMIOLf_init(MPI_COMM_NULL, context)
         deallocate(context_temp)
         if (ierr == SMIOL_SUCCESS) then
-            write(0,'(a)') 'FAIL - SMIOL_SUCCESS was returned, when an error was expected'
+            write(test_log,'(a)') 'FAIL - SMIOL_SUCCESS was returned, when an error was expected'
             ierrcount = ierrcount + 1
         else if (associated(context)) then
-            write(0,'(a)') 'FAIL - an error code was returned, but context was not nullified'
+            write(test_log,'(a)') 'FAIL - an error code was returned, but context was not nullified'
             ierrcount = ierrcount + 1
         else
-            write(0,'(a)') 'PASS'
+            write(test_log,'(a)') 'PASS'
         end if
 
         ! Handle unassociated context in SMIOL_finalize
-        write(0,'(a)',advance='no') 'Handle unassociated context (SMIOLf_finalize): '
+        write(test_log,'(a)',advance='no') 'Handle unassociated context (SMIOLf_finalize): '
         nullify(context)
         ierr = SMIOLf_finalize(context)
         if (ierr == SMIOL_SUCCESS .and. .not. associated(context)) then
-            write(0,'(a)') 'PASS'
+            write(test_log,'(a)') 'PASS'
         else if (associated(context)) then
-            write(0,'(a)') 'FAIL - context is associated'
+            write(test_log,'(a)') 'FAIL - context is associated'
             ierrcount = ierrcount + 1
         else
-            write(0,'(a)') 'FAIL - context is unassociated as expected, but SMIOL_SUCCESS was not returned'
+            write(test_log,'(a)') 'FAIL - context is unassociated as expected, but SMIOL_SUCCESS was not returned'
             ierrcount = ierrcount + 1
         end if
 
         ! Everything OK for SMIOLf_init
-        write(0,'(a)',advance='no') 'Everything OK (SMIOLf_init): '
+        write(test_log,'(a)',advance='no') 'Everything OK (SMIOLf_init): '
         nullify(context)
         ierr = SMIOLf_init(MPI_COMM_WORLD, context)
         if (ierr == SMIOL_SUCCESS .and. associated(context)) then
-            write(0,'(a)') 'PASS'
+            write(test_log,'(a)') 'PASS'
         else if (ierr == SMIOL_SUCCESS .and. .not. associated(context)) then    ! May not be possible at present...
-            write(0,'(a)') 'FAIL - context is not associated, although SMIOL_SUCCESS was returned'
+            write(test_log,'(a)') 'FAIL - context is not associated, although SMIOL_SUCCESS was returned'
             ierrcount = ierrcount + 1
         else if (ierr /= SMIOL_SUCCESS .and. associated(context)) then
-            write(0,'(a)') 'FAIL - context is associated as expected, but SMIOL_SUCCESS was not returned'
+            write(test_log,'(a)') 'FAIL - context is associated as expected, but SMIOL_SUCCESS was not returned'
             ierrcount = ierrcount + 1
         else
-            write(0,'(a)') 'FAIL - context is not associated, and SMIOL_SUCCESS was not returned'
+            write(test_log,'(a)') 'FAIL - context is not associated, and SMIOL_SUCCESS was not returned'
             ierrcount = ierrcount + 1
         end if
 
         ! Everything OK for SMIOLf_finalize
-        write(0,'(a)',advance='no') 'Everything OK (SMIOLf_finalize): '
+        write(test_log,'(a)',advance='no') 'Everything OK (SMIOLf_finalize): '
         ierr = SMIOLf_finalize(context)
         if (ierr == SMIOL_SUCCESS .and. .not. associated(context)) then
-            write(0,'(a)') 'PASS'
+            write(test_log,'(a)') 'PASS'
         else if (associated(context)) then
-            write(0,'(a)') 'FAIL - context is associated'
+            write(test_log,'(a)') 'FAIL - context is associated'
             ierrcount = ierrcount + 1
         else
-            write(0,'(a)') 'FAIL - context is not associated as expected, but SMIOL_SUCCESS was not returned'
+            write(test_log,'(a)') 'FAIL - context is not associated as expected, but SMIOL_SUCCESS was not returned'
             ierrcount = ierrcount + 1
         end if
 
-        write(0,'(a)') ''
+        write(test_log,'(a)') ''
 
     end function test_init_finalize
 
 
-    function test_open_close() result(ierrcount)
+    function test_open_close(test_log) result(ierrcount)
 
         implicit none
 
+        integer, intent(in) :: test_log
         integer :: ierrcount
         type (SMIOLf_context), pointer :: context
         type (SMIOLf_file), pointer :: file
 
-        write(0,'(a)') '********************************************************************************'
-        write(0,'(a)') '************ SMIOL_open_file / SMIOL_close_file unit tests *********************'
-        write(0,'(a)') ''
+        write(test_log,'(a)') '********************************************************************************'
+        write(test_log,'(a)') '************ SMIOL_open_file / SMIOL_close_file unit tests *********************'
+        write(test_log,'(a)') ''
 
         ierrcount = 0
 
@@ -289,23 +304,23 @@ contains
         end if
 
         ! Everything OK (SMIOLf_open_file)
-        write(0,'(a)',advance='no') 'Everything OK (SMIOLf_open_file): '
+        write(test_log,'(a)',advance='no') 'Everything OK (SMIOLf_open_file): '
         nullify(file)
         ierr = SMIOLf_open_file(context, 'test_fortran.nc', file)
         if (ierr == SMIOL_SUCCESS .and. associated(file)) then
-            write(0,'(a)') 'PASS'
+            write(test_log,'(a)') 'PASS'
         else
-            write(0,'(a)') 'FAIL - file handle is not associated or SMIOL_SUCCESS was not returned'
+            write(test_log,'(a)') 'FAIL - file handle is not associated or SMIOL_SUCCESS was not returned'
             ierrcount = ierrcount + 1
         end if
 
         ! Everything OK (SMIOLf_close_file)
-        write(0,'(a)',advance='no') 'Everything OK (SMIOLf_close_file): '
+        write(test_log,'(a)',advance='no') 'Everything OK (SMIOLf_close_file): '
         ierr = SMIOLf_close_file(file)
         if (ierr == SMIOL_SUCCESS .and. .not. associated(file)) then
-            write(0,'(a)') 'PASS'
+            write(test_log,'(a)') 'PASS'
         else
-            write(0,'(a)') 'FAIL - file handle is associated or SMIOL_SUCCESS was not returned'
+            write(test_log,'(a)') 'FAIL - file handle is associated or SMIOL_SUCCESS was not returned'
             ierrcount = ierrcount + 1
         end if
 
@@ -316,17 +331,18 @@ contains
             return
         end if
 
-        write(0,'(a)') ''
+        write(test_log,'(a)') ''
 
     end function test_open_close
 
 
-    function test_decomp() result(ierrcount)
+    function test_decomp(test_log) result(ierrcount)
 
         use iso_c_binding, only : c_size_t, c_int64_t
 
         implicit none
 
+        integer, intent(in) :: test_log
         integer :: ierrcount
         integer(c_size_t) :: n_compute_elements
         integer(c_size_t) :: n_io_elements
@@ -334,26 +350,26 @@ contains
         integer(c_int64_t), dimension(:), pointer :: io_elements
         type (SMIOLf_decomp), pointer :: decomp => null()
 
-        write(0,'(a)') '********************************************************************************'
-        write(0,'(a)') '************ SMIOLf_create_decomp / SMIOLf_free_decomp tests *******************'
-        write(0,'(a)') ''
+        write(test_log,'(a)') '********************************************************************************'
+        write(test_log,'(a)') '************ SMIOLf_create_decomp / SMIOLf_free_decomp tests *******************'
+        write(test_log,'(a)') ''
 
         ierrcount = 0
 
         ! Test with 0 elements
-        write(0,'(a)',advance='no') 'Everything OK for SMIOLf_create_decomp with 0 elements: '
+        write(test_log,'(a)',advance='no') 'Everything OK for SMIOLf_create_decomp with 0 elements: '
         n_compute_elements = 0
         n_io_elements = 0
         allocate(compute_elements(n_compute_elements))
         allocate(io_elements(n_io_elements))
         ierr = SMIOLf_create_decomp(n_compute_elements, n_io_elements, compute_elements, io_elements, decomp)
         if (ierr == SMIOL_SUCCESS .and. associated(decomp)) then
-            write(0,'(a)') "PASS"
+            write(test_log,'(a)') "PASS"
         else if (ierr /= SMIOL_SUCCESS .and. .not. associated(decomp)) then
-            write(0,'(a)') "FAIL - SMIOLf_create_decomp returned an error and decomp was not associated"
+            write(test_log,'(a)') "FAIL - SMIOLf_create_decomp returned an error and decomp was not associated"
             ierrcount = ierrcount + 1
         else if (ierr == SMIOL_SUCCESS .and. .not. associated(decomp)) then
-            write(0,'(a)') "FAIL - ierr returned success but decomp was NOT associated when it should have been"
+            write(test_log,'(a)') "FAIL - ierr returned success but decomp was NOT associated when it should have been"
             ierrcount = ierrcount + 1
         endif
 
@@ -361,32 +377,32 @@ contains
         deallocate(io_elements)
 
         ! Free Decomp
-        write(0,'(a)',advance='no') 'Everything OK for SMIOLf_free_decomp with 0 elements: '
+        write(test_log,'(a)',advance='no') 'Everything OK for SMIOLf_free_decomp with 0 elements: '
         ierr = SMIOLf_free_decomp(decomp)
         if (ierr == SMIOL_SUCCESS .and. .not. associated(decomp)) then
-            write(0,'(a)') "PASS"
+            write(test_log,'(a)') "PASS"
         else if (ierr /= SMIOL_SUCCESS .and. associated(decomp)) then
-            write(0,'(a)') "FAIL - ierr did not return SMIOL_SUCCESS, and decomp was still associated"
+            write(test_log,'(a)') "FAIL - ierr did not return SMIOL_SUCCESS, and decomp was still associated"
             ierrcount = ierrcount + 1
         else if (ierr == SMIOL_SUCCESS .and. associated(decomp)) then
-            write(0,'(a)') "FAIL - ierr returned SMIOL_SUCCESS but the decomp was associated"
+            write(test_log,'(a)') "FAIL - ierr returned SMIOL_SUCCESS but the decomp was associated"
             ierrcount = ierrcount + 1
         endif
 
         ! Small number of Compute and IO Elements
-        write(0,'(a)',advance='no') 'Everything OK for SMIOLf_create_decomp 1 element: '
+        write(test_log,'(a)',advance='no') 'Everything OK for SMIOLf_create_decomp 1 element: '
         n_compute_elements = 1
         n_io_elements = 1
         allocate(compute_elements(n_compute_elements))
         allocate(io_elements(n_io_elements))
         ierr = SMIOLf_create_decomp(n_compute_elements, n_io_elements, compute_elements, io_elements, decomp)
         if (ierr == SMIOL_SUCCESS .and. associated(decomp)) then
-            write(0,'(a)') "PASS"
+            write(test_log,'(a)') "PASS"
         else if (ierr /= SMIOL_SUCCESS .and. .not. associated(decomp)) then
-            write(0,'(a)') "FAIL - SMIOLf_create_decomp returned an error and decomp was not associated"
+            write(test_log,'(a)') "FAIL - SMIOLf_create_decomp returned an error and decomp was not associated"
             ierrcount = ierrcount + 1
         else if (ierr == SMIOL_SUCCESS .and. .not. associated(decomp)) then
-            write(0,'(a)') "FAIL - ierr returned success but decomp was NOT associated when it should have been"
+            write(test_log,'(a)') "FAIL - ierr returned success but decomp was NOT associated when it should have been"
             ierrcount = ierrcount + 1
         endif
 
@@ -394,32 +410,32 @@ contains
         deallocate(io_elements)
 
         ! Free Decomp
-        write(0,'(a)',advance='no') 'Everything OK for SMIOLf_free_decomp with 1 element: '
+        write(test_log,'(a)',advance='no') 'Everything OK for SMIOLf_free_decomp with 1 element: '
         ierr = SMIOLf_free_decomp(decomp)
         if (ierr == SMIOL_SUCCESS .and. .not. associated(decomp)) then
-            write(0,'(a)') "PASS"
+            write(test_log,'(a)') "PASS"
         else if (ierr /= SMIOL_SUCCESS .and. associated(decomp)) then
-            write(0,'(a)') "FAIL - ierr did not return SMIOL_SUCCESS, and decomp was still associated"
+            write(test_log,'(a)') "FAIL - ierr did not return SMIOL_SUCCESS, and decomp was still associated"
             ierrcount = ierrcount + 1
         else if (ierr == SMIOL_SUCCESS .and. associated(decomp)) then
-            write(0,'(a)') "FAIL - ierr returned SMIOL_SUCCESS but the decomp was associated"
+            write(test_log,'(a)') "FAIL - ierr returned SMIOL_SUCCESS but the decomp was associated"
             ierrcount = ierrcount + 1
         endif
 
         ! Large number of Compute and IO Elements
-        write(0,'(a)',advance='no') 'Everything OK for SMIOLf_create_decomp large number of elements: '
+        write(test_log,'(a)',advance='no') 'Everything OK for SMIOLf_create_decomp large number of elements: '
         n_compute_elements = 10000000
         n_io_elements = 10000000
         allocate(compute_elements(n_compute_elements))
         allocate(io_elements(n_io_elements))
         ierr = SMIOLf_create_decomp(n_compute_elements, n_io_elements, compute_elements, io_elements, decomp)
         if (ierr == SMIOL_SUCCESS .and. associated(decomp)) then
-            write(0,'(a)') "PASS"
+            write(test_log,'(a)') "PASS"
         else if (ierr /= SMIOL_SUCCESS .and. .not. associated(decomp)) then
-            write(0,'(a)') "FAIL - SMIOLf_create_decomp returned an error and decomp was not associated"
+            write(test_log,'(a)') "FAIL - SMIOLf_create_decomp returned an error and decomp was not associated"
             ierrcount = ierrcount + 1
         else if (ierr == SMIOL_SUCCESS .and. .not. associated(decomp)) then
-            write(0,'(a)') "FAIL - ierr returned success but decomp was NOT associated when it should have been"
+            write(test_log,'(a)') "FAIL - ierr returned success but decomp was NOT associated when it should have been"
             ierrcount = ierrcount + 1
         endif
 
@@ -427,32 +443,32 @@ contains
         deallocate(io_elements)
 
         ! Free Decomp
-        write(0,'(a)',advance='no') 'Everything OK for SMIOLf_free_decomp large number of elements: '
+        write(test_log,'(a)',advance='no') 'Everything OK for SMIOLf_free_decomp large number of elements: '
         ierr = SMIOLf_free_decomp(decomp)
         if (ierr == SMIOL_SUCCESS .and. .not. associated(decomp)) then
-            write(0,'(a)') "PASS"
+            write(test_log,'(a)') "PASS"
         else if (ierr /= SMIOL_SUCCESS .and. associated(decomp)) then
-            write(0,'(a)') "FAIL - ierr did not return SMIOL_SUCCESS, and decomp was still associated"
+            write(test_log,'(a)') "FAIL - ierr did not return SMIOL_SUCCESS, and decomp was still associated"
             ierrcount = ierrcount + 1
         else if (ierr == SMIOL_SUCCESS .and. associated(decomp)) then
-            write(0,'(a)') "FAIL - ierr returned SMIOL_SUCCESS but the decomp was associated"
+            write(test_log,'(a)') "FAIL - ierr returned SMIOL_SUCCESS but the decomp was associated"
             ierrcount = ierrcount + 1
         endif
 
         ! Pass SMIOLf_free_decomp a decomp that has already been freed
-        write(0,'(a)',advance='no') 'Everything OK for SMIOLf_free_decomp on an unassociated decomp: '
+        write(test_log,'(a)',advance='no') 'Everything OK for SMIOLf_free_decomp on an unassociated decomp: '
         ierr = SMIOLf_free_decomp(decomp)
         if (ierr == SMIOL_SUCCESS .and. .not. associated(decomp)) then
-            write(0,'(a)') "PASS"
+            write(test_log,'(a)') "PASS"
         else if (ierr /= SMIOL_SUCCESS .and. associated(decomp)) then
-            write(0,'(a)') "FAIL - ierr did not return SMIOL_SUCCESS, and decomp became associated..."
+            write(test_log,'(a)') "FAIL - ierr did not return SMIOL_SUCCESS, and decomp became associated..."
             ierrcount = ierrcount + 1
         else if (ierr == SMIOL_SUCCESS .and. associated(decomp)) then
-            write(0,'(a)') "FAIL - ierr returned SMIOL_SUCCESS, but the decomp became associated..."
+            write(test_log,'(a)') "FAIL - ierr returned SMIOL_SUCCESS, but the decomp became associated..."
             ierrcount = ierrcount + 1
         endif
 
-        write(0,'(a)') ''
+        write(test_log,'(a)') ''
 
     end function test_decomp
 

--- a/smiol_runner.c
+++ b/smiol_runner.c
@@ -55,7 +55,7 @@ int main(int argc, char **argv)
 
 
 	if ((ierr = SMIOL_init(MPI_COMM_WORLD, &context)) != SMIOL_SUCCESS) {
-		printf("ERROR: SMIOL_init: %s ", SMIOL_error_string(ierr));
+		fprintf(stderr, "ERROR: SMIOL_init: %s ", SMIOL_error_string(ierr));
 		return 1;
 	} 
 
@@ -80,88 +80,103 @@ int main(int argc, char **argv)
 	free(io_elements);
 
 	if ((ierr = SMIOL_free_decomp(&decomp)) != SMIOL_SUCCESS) {
-		printf("ERROR: SMIOL_free_decomp: %s ", SMIOL_error_string(ierr));
+		fprintf(stderr, "ERROR: SMIOL_free_decomp: %s ",
+			SMIOL_error_string(ierr));
 		return 1;
 	}
 
 	if (decomp != NULL) {
-		printf("ERROR: SMIOL_free_decomp - Decomp not 'NULL' after free\n");
+		fprintf(stderr, "ERROR: SMIOL_free_decomp - Decomp not 'NULL' after free\n");
 		return 1;
 	}
 
 	if ((ierr = SMIOL_inquire()) != SMIOL_SUCCESS) {
-		printf("ERROR: SMIOL_inquire: %s ", SMIOL_error_string(ierr));
+		fprintf(stderr, "ERROR: SMIOL_inquire: %s ",
+			SMIOL_error_string(ierr));
 		return 1;
 	}
 
 	if ((ierr = SMIOL_open_file(context, "blah.nc", &file)) != SMIOL_SUCCESS) {
-		printf("ERROR: SMIOL_open_file: %s ", SMIOL_error_string(ierr));
+		fprintf(stderr, "ERROR: SMIOL_open_file: %s ",
+			SMIOL_error_string(ierr));
 		return 1;
 	}
 
 	if ((ierr = SMIOL_close_file(&file)) != SMIOL_SUCCESS) {
-		printf("ERROR: SMIOL_close_file: %s ", SMIOL_error_string(ierr));
+		fprintf(stderr, "ERROR: SMIOL_close_file: %s ",
+			SMIOL_error_string(ierr));
 		return 1;
 	}
 
 	if ((ierr = SMIOL_define_dim()) != SMIOL_SUCCESS) {
-		printf("ERROR: SMIOL_define_dim: %s ", SMIOL_error_string(ierr));
+		fprintf(stderr, "ERROR: SMIOL_define_dim: %s ",
+			SMIOL_error_string(ierr));
 		return 1;
 	}
 
 	if ((ierr = SMIOL_inquire_dim()) != SMIOL_SUCCESS) {
-		printf("ERROR: SMIOL_inquire_dim: %s ", SMIOL_error_string(ierr));
+		fprintf(stderr, "ERROR: SMIOL_inquire_dim: %s ",
+			SMIOL_error_string(ierr));
 		return 1;
 	}
 
 	if ((ierr = SMIOL_define_var()) != SMIOL_SUCCESS) {
-		printf("ERROR: SMIOL_define_var: %s ", SMIOL_error_string(ierr));
+		fprintf(stderr, "ERROR: SMIOL_define_var: %s ",
+			SMIOL_error_string(ierr));
 		return 1;
 	}
 
 	if ((ierr = SMIOL_put_var()) != SMIOL_SUCCESS) {
-		printf("ERROR: SMIOL_put_var: %s ", SMIOL_error_string(ierr));
+		fprintf(stderr, "ERROR: SMIOL_put_var: %s ",
+			SMIOL_error_string(ierr));
 		return 1;
 	}
 
 	if ((ierr = SMIOL_get_var()) != SMIOL_SUCCESS) {
-		printf("ERROR: SMIOL_get_var: %s ", SMIOL_error_string(ierr));
+		fprintf(stderr, "ERROR: SMIOL_get_var: %s ",
+			SMIOL_error_string(ierr));
 		return 1;
 	}
 		
 	if ((ierr = SMIOL_define_att()) != SMIOL_SUCCESS) {
-		printf("ERROR: SMIOL_define_att: %s ", SMIOL_error_string(ierr));
+		fprintf(stderr, "ERROR: SMIOL_define_att: %s ",
+			SMIOL_error_string(ierr));
 		return 1;
 	}
 
 	if ((ierr = SMIOL_inquire_att()) != SMIOL_SUCCESS) {
-		printf("ERROR: SMIOL_inquire_att: %s ", SMIOL_error_string(ierr));
+		fprintf(stderr, "ERROR: SMIOL_inquire_att: %s ",
+			SMIOL_error_string(ierr));
 		return 1;
 	}
 	
 	if ((ierr = SMIOL_file_sync()) != SMIOL_SUCCESS) {
-		printf("ERROR: SMIOL_file_sync: %s ", SMIOL_error_string(ierr));
+		fprintf(stderr, "ERROR: SMIOL_file_sync: %s ",
+			SMIOL_error_string(ierr));
 		return 1;
 	}
 
 	if ((ierr = SMIOL_set_option()) != SMIOL_SUCCESS) {
-		printf("ERROR: SMIOL_set_option: %s ", SMIOL_error_string(ierr));
+		fprintf(stderr, "ERROR: SMIOL_set_option: %s ",
+			SMIOL_error_string(ierr));
 		return 1;
 	}
 
-	printf("SMIOL_error_string test 'Unknown error': %s\n", SMIOL_error_string(-1));
-	printf("SMIOL_error_string test 'Success!': %s\n", SMIOL_error_string(SMIOL_SUCCESS));
-	printf("SMIOL_error_string test 'malloc returned a null pointer': %s\n",
+	fprintf(stderr, "SMIOL_error_string test 'Unknown error': %s\n",
+						SMIOL_error_string(-1));
+	fprintf(stderr, "SMIOL_error_string test 'Success!': %s\n",
+						SMIOL_error_string(SMIOL_SUCCESS));
+	fprintf(stderr, "SMIOL_error_string test 'malloc returned a null pointer': %s\n",
 		SMIOL_error_string(SMIOL_MALLOC_FAILURE));
-	printf("SMIOL_error_string test 'invalid subroutine argument': %s\n",
+	fprintf(stderr, "SMIOL_error_string test 'invalid subroutine argument': %s\n",
 		SMIOL_error_string(SMIOL_INVALID_ARGUMENT));
-	printf("SMIOL_error_string test 'internal MPI call failed': %s\n",
+	fprintf(stderr, "SMIOL_error_string test 'internal MPI call failed': %s\n",
 		SMIOL_error_string(SMIOL_MPI_ERROR));
-	printf("SMIOL_error_string test 'Fortran wrapper detected an inconsistency in C return values': %s\n",
+	fprintf(stderr, "SMIOL_error_string test 'Fortran wrapper detected an inconsistency in C return values': %s\n",
 		SMIOL_error_string(SMIOL_FORTRAN_ERROR));
 
 	if ((ierr = SMIOL_finalize(&context)) != SMIOL_SUCCESS) {
-		printf("ERROR: SMIOL_finalize: %s ", SMIOL_error_string(ierr));
+		fprintf(stderr, "ERROR: SMIOL_finalize: %s ", SMIOL_error_string(ierr));
 		return 1;
 	}
 
@@ -170,7 +185,7 @@ int main(int argc, char **argv)
 		return 1;
 	}
 
-	printf("Called all SMIOL functions successfully!\n");
+	fprintf(stderr, "Called all SMIOL functions successfully!\n");
 
 	if (MPI_Finalize() != MPI_SUCCESS) {
 		fprintf(stderr, "Error: MPI_Finalize failed.\n");

--- a/smiol_runner.c
+++ b/smiol_runner.c
@@ -6,12 +6,13 @@
  * SMIOL C Runner - Take SMIOL out for a run!
  *******************************************************************************/
 
-int test_init_finalize(void);
-int test_open_close(void);
+int test_init_finalize(FILE *test_log);
+int test_open_close(FILE *test_log);
 
 int main(int argc, char **argv)
 {
 	int ierr;
+	int my_proc_id;
 	size_t n_compute_elements = 1;
 	size_t n_io_elements = 1;
 	int64_t *compute_elements;
@@ -19,6 +20,8 @@ int main(int argc, char **argv)
 	struct SMIOL_decomp *decomp = NULL;
 	struct SMIOL_context *context = NULL;
 	struct SMIOL_file *file = NULL;
+	char log_fname[17];
+	FILE *test_log = NULL;
 
 	if (argc == 2) {
 		n_compute_elements = (size_t) atoi(argv[1]);
@@ -30,37 +33,48 @@ int main(int argc, char **argv)
 		return 1;
 	}
 
+	if (MPI_Comm_rank(MPI_COMM_WORLD, &my_proc_id) != MPI_SUCCESS) {
+		fprintf(stderr, "Error: MPI_Comm_rank failed.\n");
+	}
+
+	sprintf(log_fname, "smiol.%04d.test", my_proc_id);
+	test_log = fopen(log_fname, "w");
+	if (test_log == NULL) {
+		fprintf(stderr, "Error: Could not open test log file\n");
+		return 1;
+	}
+
 	/*
 	 * Unit tests for SMIOL_init and SMIOL_finalize
 	 */
-	ierr = test_init_finalize();
+	ierr = test_init_finalize(test_log);
 	if (ierr == 0) {
-		fprintf(stderr, "All tests PASSED!\n\n");
+		fprintf(test_log, "All tests PASSED!\n\n");
 	}
 	else {
-		fprintf(stderr, "%i tests FAILED!\n\n", ierr);
+		fprintf(test_log, "%i tests FAILED!\n\n", ierr);
 	}
 
 
 	/*
 	 * Unit tests for SMIOL_open_file and SMIOL_close_file
 	 */
-	ierr = test_open_close();
+	ierr = test_open_close(test_log);
 	if (ierr == 0) {
-		fprintf(stderr, "All tests PASSED!\n\n");
+		fprintf(test_log, "All tests PASSED!\n\n");
 	}
 	else {
-		fprintf(stderr, "%i tests FAILED!\n\n", ierr);
+		fprintf(test_log, "%i tests FAILED!\n\n", ierr);
 	}
 
 
 	if ((ierr = SMIOL_init(MPI_COMM_WORLD, &context)) != SMIOL_SUCCESS) {
-		fprintf(stderr, "ERROR: SMIOL_init: %s ", SMIOL_error_string(ierr));
+		fprintf(test_log, "ERROR: SMIOL_init: %s ", SMIOL_error_string(ierr));
 		return 1;
 	} 
 
 	if (context == NULL) {
-		fprintf(stderr, "SMIOL_init returned a NULL context\n");
+		fprintf(test_log, "SMIOL_init returned a NULL context\n");
 		return 1;
 	}
 
@@ -80,108 +94,113 @@ int main(int argc, char **argv)
 	free(io_elements);
 
 	if ((ierr = SMIOL_free_decomp(&decomp)) != SMIOL_SUCCESS) {
-		fprintf(stderr, "ERROR: SMIOL_free_decomp: %s ",
+		fprintf(test_log, "ERROR: SMIOL_free_decomp: %s ",
 			SMIOL_error_string(ierr));
 		return 1;
 	}
 
 	if (decomp != NULL) {
-		fprintf(stderr, "ERROR: SMIOL_free_decomp - Decomp not 'NULL' after free\n");
+		fprintf(test_log, "ERROR: SMIOL_free_decomp - Decomp not 'NULL' after free\n");
 		return 1;
 	}
 
 	if ((ierr = SMIOL_inquire()) != SMIOL_SUCCESS) {
-		fprintf(stderr, "ERROR: SMIOL_inquire: %s ",
+		fprintf(test_log, "ERROR: SMIOL_inquire: %s ",
 			SMIOL_error_string(ierr));
 		return 1;
 	}
 
 	if ((ierr = SMIOL_open_file(context, "blah.nc", &file)) != SMIOL_SUCCESS) {
-		fprintf(stderr, "ERROR: SMIOL_open_file: %s ",
+		fprintf(test_log, "ERROR: SMIOL_open_file: %s ",
 			SMIOL_error_string(ierr));
 		return 1;
 	}
 
 	if ((ierr = SMIOL_close_file(&file)) != SMIOL_SUCCESS) {
-		fprintf(stderr, "ERROR: SMIOL_close_file: %s ",
+		fprintf(test_log, "ERROR: SMIOL_close_file: %s ",
 			SMIOL_error_string(ierr));
 		return 1;
 	}
 
 	if ((ierr = SMIOL_define_dim()) != SMIOL_SUCCESS) {
-		fprintf(stderr, "ERROR: SMIOL_define_dim: %s ",
+		fprintf(test_log, "ERROR: SMIOL_define_dim: %s ",
 			SMIOL_error_string(ierr));
 		return 1;
 	}
 
 	if ((ierr = SMIOL_inquire_dim()) != SMIOL_SUCCESS) {
-		fprintf(stderr, "ERROR: SMIOL_inquire_dim: %s ",
+		fprintf(test_log, "ERROR: SMIOL_inquire_dim: %s ",
 			SMIOL_error_string(ierr));
 		return 1;
 	}
 
 	if ((ierr = SMIOL_define_var()) != SMIOL_SUCCESS) {
-		fprintf(stderr, "ERROR: SMIOL_define_var: %s ",
+		fprintf(test_log, "ERROR: SMIOL_define_var: %s ",
 			SMIOL_error_string(ierr));
 		return 1;
 	}
 
 	if ((ierr = SMIOL_put_var()) != SMIOL_SUCCESS) {
-		fprintf(stderr, "ERROR: SMIOL_put_var: %s ",
+		fprintf(test_log, "ERROR: SMIOL_put_var: %s ",
 			SMIOL_error_string(ierr));
 		return 1;
 	}
 
 	if ((ierr = SMIOL_get_var()) != SMIOL_SUCCESS) {
-		fprintf(stderr, "ERROR: SMIOL_get_var: %s ",
+		fprintf(test_log, "ERROR: SMIOL_get_var: %s ",
 			SMIOL_error_string(ierr));
 		return 1;
 	}
 		
 	if ((ierr = SMIOL_define_att()) != SMIOL_SUCCESS) {
-		fprintf(stderr, "ERROR: SMIOL_define_att: %s ",
+		fprintf(test_log, "ERROR: SMIOL_define_att: %s ",
 			SMIOL_error_string(ierr));
 		return 1;
 	}
 
 	if ((ierr = SMIOL_inquire_att()) != SMIOL_SUCCESS) {
-		fprintf(stderr, "ERROR: SMIOL_inquire_att: %s ",
+		fprintf(test_log, "ERROR: SMIOL_inquire_att: %s ",
 			SMIOL_error_string(ierr));
 		return 1;
 	}
 	
 	if ((ierr = SMIOL_file_sync()) != SMIOL_SUCCESS) {
-		fprintf(stderr, "ERROR: SMIOL_file_sync: %s ",
+		fprintf(test_log, "ERROR: SMIOL_file_sync: %s ",
 			SMIOL_error_string(ierr));
 		return 1;
 	}
 
 	if ((ierr = SMIOL_set_option()) != SMIOL_SUCCESS) {
-		fprintf(stderr, "ERROR: SMIOL_set_option: %s ",
+		fprintf(test_log, "ERROR: SMIOL_set_option: %s ",
 			SMIOL_error_string(ierr));
 		return 1;
 	}
 
-	fprintf(stderr, "SMIOL_error_string test 'Unknown error': %s\n",
+	fprintf(test_log, "SMIOL_error_string test 'Unknown error': %s\n",
 						SMIOL_error_string(-1));
-	fprintf(stderr, "SMIOL_error_string test 'Success!': %s\n",
+	fprintf(test_log, "SMIOL_error_string test 'Success!': %s\n",
 						SMIOL_error_string(SMIOL_SUCCESS));
-	fprintf(stderr, "SMIOL_error_string test 'malloc returned a null pointer': %s\n",
+	fprintf(test_log, "SMIOL_error_string test 'malloc returned a null pointer': %s\n",
 		SMIOL_error_string(SMIOL_MALLOC_FAILURE));
-	fprintf(stderr, "SMIOL_error_string test 'invalid subroutine argument': %s\n",
+	fprintf(test_log, "SMIOL_error_string test 'invalid subroutine argument': %s\n",
 		SMIOL_error_string(SMIOL_INVALID_ARGUMENT));
-	fprintf(stderr, "SMIOL_error_string test 'internal MPI call failed': %s\n",
+	fprintf(test_log, "SMIOL_error_string test 'internal MPI call failed': %s\n",
 		SMIOL_error_string(SMIOL_MPI_ERROR));
-	fprintf(stderr, "SMIOL_error_string test 'Fortran wrapper detected an inconsistency in C return values': %s\n",
+	fprintf(test_log, "SMIOL_error_string test 'Fortran wrapper detected an inconsistency in C return values': %s\n",
 		SMIOL_error_string(SMIOL_FORTRAN_ERROR));
 
 	if ((ierr = SMIOL_finalize(&context)) != SMIOL_SUCCESS) {
-		fprintf(stderr, "ERROR: SMIOL_finalize: %s ", SMIOL_error_string(ierr));
+		fprintf(test_log, "ERROR: SMIOL_finalize: %s ", SMIOL_error_string(ierr));
 		return 1;
 	}
 
 	if (context != NULL) {
-		fprintf(stderr, "SMIOL_finalize returned a non-NULL context\n");
+		fprintf(test_log, "SMIOL_finalize returned a non-NULL context\n");
+		return 1;
+	}
+
+	if (fclose(test_log) != 0) {
+		fprintf(stderr, "Error: Could not close test_log\n");
 		return 1;
 	}
 
@@ -195,169 +214,169 @@ int main(int argc, char **argv)
 	return 0;
 }
 
-int test_init_finalize(void)
+int test_init_finalize(FILE *test_log)
 {
 	int ierr;
 	int errcount;
 	struct SMIOL_context *context;
 
-	fprintf(stderr, "********************************************************************************\n");
-	fprintf(stderr, "************ SMIOL_init / SMIOL_finalize unit tests ****************************\n");
-	fprintf(stderr, "\n");
+	fprintf(test_log, "********************************************************************************\n");
+	fprintf(test_log, "************ SMIOL_init / SMIOL_finalize unit tests ****************************\n");
+	fprintf(test_log, "\n");
 
 	errcount = 0;
 
 	/* Null context pointer */
-	fprintf(stderr, "Null pointer to context pointer (SMIOL_init): ");
+	fprintf(test_log, "Null pointer to context pointer (SMIOL_init): ");
 	ierr = SMIOL_init(MPI_COMM_WORLD, NULL);
 	if (ierr == SMIOL_SUCCESS) {
-		fprintf(stderr, "FAIL - SMIOL_SUCCESS was returned, when an error was expected\n");
+		fprintf(test_log, "FAIL - SMIOL_SUCCESS was returned, when an error was expected\n");
 		errcount++;
 	}
 	else {
-		fprintf(stderr, "PASS\n");
+		fprintf(test_log, "PASS\n");
 	}
 
 	/* Invalid MPI communicator, and with a non-NULL context that should be NULL on return */
-	fprintf(stderr, "Invalid MPI communicator (SMIOL_init): ");
+	fprintf(test_log, "Invalid MPI communicator (SMIOL_init): ");
 	context = (struct SMIOL_context *)NULL + 42;   /* Any non-NULL value should be fine... */
 	ierr = SMIOL_init(MPI_COMM_NULL, &context);
 	if (ierr == SMIOL_SUCCESS) {
-		fprintf(stderr, "FAIL - SMIOL_SUCCESS was returned, when an error was expected\n");
+		fprintf(test_log, "FAIL - SMIOL_SUCCESS was returned, when an error was expected\n");
 		errcount++;
 	}
 	else if (context != NULL) {
-		fprintf(stderr, "FAIL - an error code was returned, but context was not NULL\n");
+		fprintf(test_log, "FAIL - an error code was returned, but context was not NULL\n");
 		errcount++;
 	}
 	else {
-		fprintf(stderr, "PASS\n");
+		fprintf(test_log, "PASS\n");
 	}
 
 	/* Handle NULL context in SMIOL_finalize */
-	fprintf(stderr, "Handle NULL context (SMIOL_finalize): ");
+	fprintf(test_log, "Handle NULL context (SMIOL_finalize): ");
 	context = NULL;
 	ierr = SMIOL_finalize(&context);
 	if (ierr == SMIOL_SUCCESS && context == NULL) {
-		fprintf(stderr, "PASS\n");
+		fprintf(test_log, "PASS\n");
 	}
 	else if (context != NULL) {
-		fprintf(stderr, "FAIL - context is not NULL\n");
+		fprintf(test_log, "FAIL - context is not NULL\n");
 		errcount++;
 	}
 	else {
-		fprintf(stderr, "FAIL - context is NULL as expected, but SMIOL_SUCCESS was not returned\n");
+		fprintf(test_log, "FAIL - context is NULL as expected, but SMIOL_SUCCESS was not returned\n");
 		errcount++;
 	}
 
 	/* Handle NULL pointer to context pointer in SMIOL_finalize */
-	fprintf(stderr, "Handle NULL pointer to context pointer (SMIOL_finalize): ");
+	fprintf(test_log, "Handle NULL pointer to context pointer (SMIOL_finalize): ");
 	ierr = SMIOL_finalize(NULL);
 	if (ierr == SMIOL_SUCCESS) {
-		fprintf(stderr, "PASS\n");
+		fprintf(test_log, "PASS\n");
 	}
 	else {
-		fprintf(stderr, "FAIL - SMIOL_SUCCESS was not returned\n");
+		fprintf(test_log, "FAIL - SMIOL_SUCCESS was not returned\n");
 		errcount++;
 	}
 
 	/* Everything OK for SMIOL_init */
-	fprintf(stderr, "Everything OK (SMIOL_init): ");
+	fprintf(test_log, "Everything OK (SMIOL_init): ");
 	context = NULL;
 	ierr = SMIOL_init(MPI_COMM_WORLD, &context);
 	if (ierr == SMIOL_SUCCESS && context != NULL) {
-		fprintf(stderr, "PASS\n");
+		fprintf(test_log, "PASS\n");
 	}
 	else if (ierr == SMIOL_SUCCESS && context == NULL) {
-		fprintf(stderr, "FAIL - context is NULL, although SMIOL_SUCCESS was returned\n");
+		fprintf(test_log, "FAIL - context is NULL, although SMIOL_SUCCESS was returned\n");
 		errcount++;
 	}
 	else if (ierr != SMIOL_SUCCESS && context != NULL) {
-		fprintf(stderr, "FAIL - context is not NULL as expected, but SMIOL_SUCCESS was not returned\n");
+		fprintf(test_log, "FAIL - context is not NULL as expected, but SMIOL_SUCCESS was not returned\n");
 		errcount++;
 	}
 	else {
-		fprintf(stderr, "FAIL - context is NULL, and SMIOL_SUCCESS was not returned\n");
+		fprintf(test_log, "FAIL - context is NULL, and SMIOL_SUCCESS was not returned\n");
 		errcount++;
 	}
 
 	/* Everything OK for SMIOL_finalize */
-	fprintf(stderr, "Everything OK (SMIOL_finalize): ");
+	fprintf(test_log, "Everything OK (SMIOL_finalize): ");
 	ierr = SMIOL_finalize(&context);
 	if (ierr == SMIOL_SUCCESS && context == NULL) {
-		fprintf(stderr, "PASS\n");
+		fprintf(test_log, "PASS\n");
 	}
 	else if (context != NULL) {
-		fprintf(stderr, "FAIL - context is not NULL\n");
+		fprintf(test_log, "FAIL - context is not NULL\n");
 		errcount++;
 	}
 	else {
-		fprintf(stderr, "FAIL - context is NULL as expected, but SMIOL_SUCCESS was not returned\n");
+		fprintf(test_log, "FAIL - context is NULL as expected, but SMIOL_SUCCESS was not returned\n");
 		errcount++;
 	}
 
-	fflush(stderr);
+	fflush(test_log);
 	ierr = MPI_Barrier(MPI_COMM_WORLD);
 
-	fprintf(stderr, "\n");
+	fprintf(test_log, "\n");
 
 	return errcount;
 }
 
-int test_open_close(void)
+int test_open_close(FILE *test_log)
 {
 	int ierr;
 	int errcount;
 	struct SMIOL_context *context;
 	struct SMIOL_file *file;
 
-	fprintf(stderr, "********************************************************************************\n");
-	fprintf(stderr, "************ SMIOL_open_file / SMIOL_close_file unit tests *********************\n");
-	fprintf(stderr, "\n");
+	fprintf(test_log, "********************************************************************************\n");
+	fprintf(test_log, "************ SMIOL_open_file / SMIOL_close_file unit tests *********************\n");
+	fprintf(test_log, "\n");
 
 	errcount = 0;
 
 	/* Create a SMIOL context for testing file open/close routines */
 	ierr = SMIOL_init(MPI_COMM_WORLD, &context);
 	if (ierr != SMIOL_SUCCESS || context == NULL) {
-		fprintf(stderr, "Failed to create SMIOL context...\n");
+		fprintf(test_log, "Failed to create SMIOL context...\n");
 		return -1;
 	}
 
 	/* Everything OK (SMIOL_open_file) */
-	fprintf(stderr, "Everything OK (SMIOL_open_file): ");
+	fprintf(test_log, "Everything OK (SMIOL_open_file): ");
 	file = NULL;
 	ierr = SMIOL_open_file(context, "test.nc", &file);
 	if (ierr == SMIOL_SUCCESS && file != NULL) {
-		fprintf(stderr, "PASS\n");
+		fprintf(test_log, "PASS\n");
 	}
 	else {
-		fprintf(stderr, "FAIL - context is NULL or SMIOL_SUCCESS was not returned\n");
+		fprintf(test_log, "FAIL - context is NULL or SMIOL_SUCCESS was not returned\n");
 		errcount++;
 	}
 
 	/* Everything OK (SMIOL_close_file) */
-	fprintf(stderr, "Everything OK (SMIOL_close_file): ");
+	fprintf(test_log, "Everything OK (SMIOL_close_file): ");
 	ierr = SMIOL_close_file(&file);
 	if (ierr == SMIOL_SUCCESS && file == NULL) {
-		fprintf(stderr, "PASS\n");
+		fprintf(test_log, "PASS\n");
 	}
 	else {
-		fprintf(stderr, "FAIL - context is not NULL or SMIOL_SUCCESS was not returned\n");
+		fprintf(test_log, "FAIL - context is not NULL or SMIOL_SUCCESS was not returned\n");
 		errcount++;
 	}
 
 	/* Free the SMIOL context */
 	ierr = SMIOL_finalize(&context);
 	if (ierr != SMIOL_SUCCESS || context != NULL) {
-		fprintf(stderr, "Failed to free SMIOL context...\n");
+		fprintf(test_log, "Failed to free SMIOL context...\n");
 		return -1;
 	}
 
-	fflush(stderr);
+	fflush(test_log);
 	ierr = MPI_Barrier(MPI_COMM_WORLD);
 
-	fprintf(stderr, "\n");
+	fprintf(test_log, "\n");
 
 	return errcount;
 }


### PR DESCRIPTION
These commits update the `smiol_runner.c` and `smiol_runner.f90` to write their test messages to files, rather than stderr. This will help to facilitate testing on multiple MPI processes, where collective writes to stderr can be hard to comprehend.

Each MPI task will create a new test log file in the format `smiol.xxxx.test`  and `smiolf.xxxx.test` (where xxxx is the MPI task ID) for the C and Fortran test codes respectively. To find error messages, `grep `can be ran to find error messages.