### PR TITLE
Implementation of SMIOL_file_sync

### DIFF
--- a/smiol_runner.F90
+++ b/smiol_runner.F90
@@ -108,6 +108,11 @@ program smiol_runner
         stop 1
     endif
 
+    if (SMIOLf_file_sync(file) /= SMIOL_SUCCESS) then
+        write(test_log,'(a)') "ERROR: 'SMIOLf_file_sync' was not called successfully"
+        stop 1
+    endif
+
     if (SMIOLf_close_file(file) /= SMIOL_SUCCESS) then
         write(test_log,'(a)') "ERROR: 'SMIOLf_close_file' was not called successfully"
         stop 1
@@ -150,11 +155,6 @@ program smiol_runner
 
     if (SMIOLf_inquire_att() /= SMIOL_SUCCESS) then
         write(test_log,'(a)') "ERROR: 'SMIOLf_inquire_att' was not called successfully"
-        stop 1
-    endif
-
-    if (SMIOLf_file_sync() /= SMIOL_SUCCESS) then
-        write(test_log,'(a)') "ERROR: 'SMIOLf_file_sync' was not called successfully"
         stop 1
     endif
 

--- a/smiol_runner.F90
+++ b/smiol_runner.F90
@@ -72,7 +72,7 @@ program smiol_runner
     endif
 
     !
-    ! Unit tests for SMIOL_file_sync
+    ! Unit tests for SMIOL_sync_file
     !
     ierr = test_file_sync(test_log)
     if (ierr == 0) then
@@ -119,8 +119,8 @@ program smiol_runner
         stop 1
     endif
 
-    if (SMIOLf_file_sync(file) /= SMIOL_SUCCESS) then
-        write(test_log,'(a)') "ERROR: 'SMIOLf_file_sync' was not called successfully"
+    if (SMIOLf_sync_file(file) /= SMIOL_SUCCESS) then
+        write(test_log,'(a)') "ERROR: 'SMIOLf_sync_file' was not called successfully"
         stop 1
     endif
 
@@ -621,12 +621,12 @@ contains
         type (SMIOLf_file), pointer :: file => null()
 
         write(test_log,'(a)') '********************************************************************************'
-        write(test_log,'(a)') '************************* SMIOLf_file_sync tests *******************************'
+        write(test_log,'(a)') '************************* SMIOLf_sync_file tests *******************************'
         write(test_log,'(a)') ''
 
         ierrcount = 0
 
-        ! Create a SMIOL context for testing SMIOL_file_sync
+        ! Create a SMIOL context for testing SMIOL_sync_file
         ierr = SMIOLf_init(MPI_COMM_WORLD, context)
         if (ierr /= SMIOL_SUCCESS .or. .not. associated(context)) then
             write(test_log,'(a)') 'Failed to initalize a SMIOL context'
@@ -642,9 +642,9 @@ contains
             return
         end if
 
-        ! Everything OK (SMIOLf_file_sync)
-        write(test_log,'(a)',advance='no') 'Everything OK (SMIOLf_file_sync) with SMIOL_FILE_CREATE: '
-        ierr = SMIOLf_file_sync(file)
+        ! Everything OK (SMIOLf_sync_file)
+        write(test_log,'(a)',advance='no') 'Everything OK (SMIOLf_sync_file) with SMIOL_FILE_CREATE: '
+        ierr = SMIOLf_sync_file(file)
         if (ierr == SMIOL_SUCCESS .and. associated(file)) then
             write(test_log,'(a)') 'PASS'
         else if (ierr /= SMIOL_SUCCESS .and. associated(file)) then
@@ -674,9 +674,9 @@ contains
             return
         end if
 
-        ! Everything OK (SMIOLf_file_sync)
-        write(test_log,'(a)',advance='no') 'Everything OK (SMIOLf_file_sync) with SMIOL_FILE_WRITE: '
-        ierr = SMIOLf_file_sync(file)
+        ! Everything OK (SMIOLf_sync_file)
+        write(test_log,'(a)',advance='no') 'Everything OK (SMIOLf_sync_file) with SMIOL_FILE_WRITE: '
+        ierr = SMIOLf_sync_file(file)
         if (ierr == SMIOL_SUCCESS .and. associated(file)) then
             write(test_log,'(a)') 'PASS'
         else if (ierr /= SMIOL_SUCCESS .and. associated(file)) then
@@ -706,9 +706,9 @@ contains
             return
         end if
 
-        ! Everything OK (SMIOLf_file_sync)
-        write(test_log,'(a)',advance='no') 'Everything OK (SMIOLf_file_sync) with SMIOL_FILE_READ: '
-        ierr = SMIOLf_file_sync(file)
+        ! Everything OK (SMIOLf_sync_file)
+        write(test_log,'(a)',advance='no') 'Everything OK (SMIOLf_sync_file) with SMIOL_FILE_READ: '
+        ierr = SMIOLf_sync_file(file)
         if (ierr == SMIOL_SUCCESS .and. associated(file)) then
             write(test_log,'(a)') 'PASS'
         else if (ierr /= SMIOL_SUCCESS .and. associated(file)) then
@@ -751,9 +751,9 @@ contains
 #endif
 
         nullify(file)
-        ! SMIOL_file_sync with an unassociated file
-        write(test_log,'(a)',advance='no') 'Testing SMIOLf_file_sync with NULL file handle: '
-        ierr = SMIOLf_file_sync(file)
+        ! SMIOL_sync_file with an unassociated file
+        write(test_log,'(a)',advance='no') 'Testing SMIOLf_sync_file with NULL file handle: '
+        ierr = SMIOLf_sync_file(file)
         if (ierr == SMIOL_INVALID_ARGUMENT .and. .not. associated(file)) then
             write(test_log,'(a)') 'PASS'
         else

--- a/smiol_runner.F90
+++ b/smiol_runner.F90
@@ -71,6 +71,17 @@ program smiol_runner
         write(test_log,'(a)') ''
     endif
 
+    !
+    ! Unit tests for SMIOL_file_sync
+    !
+    ierr = test_file_sync(test_log)
+    if (ierr == 0) then
+        write(test_log,'(a)') 'All tests PASSED!'
+        write(test_log,'(a)') ''
+    else
+        write(test_log,'(i3,a)') ierr, ' tests FAILED!'
+        write(test_log,'(a)') ''
+    endif
 
     if (SMIOLf_init(MPI_COMM_WORLD, context) /= SMIOL_SUCCESS) then
         write(test_log,'(a)') "ERROR: 'SMIOLf_init' was not called successfully"
@@ -598,5 +609,167 @@ contains
 
     end function test_decomp
 
+
+    function test_file_sync(test_log) result(ierrcount)
+
+        implicit none
+
+        integer, intent(in) :: test_log
+        integer :: ierr
+        integer :: ierrcount
+        type (SMIOLf_context), pointer :: context => null()
+        type (SMIOLf_file), pointer :: file => null()
+
+        write(test_log,'(a)') '********************************************************************************'
+        write(test_log,'(a)') '************************* SMIOLf_file_sync tests *******************************'
+        write(test_log,'(a)') ''
+
+        ierrcount = 0
+
+        ! Create a SMIOL context for testing SMIOL_file_sync
+        ierr = SMIOLf_init(MPI_COMM_WORLD, context)
+        if (ierr /= SMIOL_SUCCESS .or. .not. associated(context)) then
+            write(test_log,'(a)') 'Failed to initalize a SMIOL context'
+            ierrcount = -1
+            return
+        end if
+
+        ! Test sync file on a file that was created with SMIOL_FILE_CREATE
+        ierr = SMIOLf_open_file(context, 'smiolf_sync_file.nc', SMIOL_FILE_CREATE, file)
+        if (ierr /= SMIOL_SUCCESS .or. .not. associated(file)) then
+            write(test_log,'(a)') "Failed to open the file 'smiolf_sync_file.nc' with SMIOL_FILE_CREATE"
+            ierrcount = -1
+            return
+        end if
+
+        ! Everything OK (SMIOLf_file_sync)
+        write(test_log,'(a)',advance='no') 'Everything OK (SMIOLf_file_sync) with SMIOL_FILE_CREATE: '
+        ierr = SMIOLf_file_sync(file)
+        if (ierr == SMIOL_SUCCESS .and. associated(file)) then
+            write(test_log,'(a)') 'PASS'
+        else if (ierr /= SMIOL_SUCCESS .and. associated(file)) then
+            write(test_log,'(a)') 'FAIL - File was associated but SMIOL_SUCCESS was not returned'
+            ierrcount = ierrcount + 1
+        else if (ierr == SMIOL_SUCCESS .and. .not. associated(file)) then
+            write(test_log,'(a)') 'FAIL - SMIOL_SUCCESS was returned but file was not associated'
+            ierrcount = ierrcount + 1
+        else if (ierr == SMIOL_LIBRARY_ERROR) then
+            write(test_log,'(a)') 'FAIL - ('//trim(SMIOLf_lib_error_string(context))//')'
+            ierrcount = ierrcount + 1
+        end if
+
+        ! Close file
+        ierr = SMIOLf_close_file(file)
+        if (ierr /= SMIOL_SUCCESS .or. associated(file)) then
+            write(test_log, '(a)') "Failed to close `smiolf_sync_file.nc'"
+            ierrcount = -1
+            return
+        endif
+
+        ! Test sync file on a file that was created with SMIOL_FILE_WRITE
+        ierr = SMIOLf_open_file(context, 'smiolf_sync_file.nc', SMIOL_FILE_WRITE, file)
+        if (ierr /= SMIOL_SUCCESS .or. .not. associated(file)) then
+            write(test_log,'(a)') "Failed to open the file 'smiolf_sync_file.nc' with SMIOL_FILE_WRITE"
+            ierrcount = -1
+            return
+        end if
+
+        ! Everything OK (SMIOLf_file_sync)
+        write(test_log,'(a)',advance='no') 'Everything OK (SMIOLf_file_sync) with SMIOL_FILE_WRITE: '
+        ierr = SMIOLf_file_sync(file)
+        if (ierr == SMIOL_SUCCESS .and. associated(file)) then
+            write(test_log,'(a)') 'PASS'
+        else if (ierr /= SMIOL_SUCCESS .and. associated(file)) then
+            write(test_log,'(a)') 'FAIL - File was associated but SMIOL_SUCCESS was not returned'
+            ierrcount = ierrcount + 1
+        else if (ierr == SMIOL_SUCCESS .and. .not. associated(file)) then
+            write(test_log,'(a)') 'FAIL - SMIOL_SUCCESS was returned but file was not associated'
+            ierrcount = ierrcount + 1
+        else if (ierr == SMIOL_LIBRARY_ERROR) then
+            write(test_log,'(a)') 'FAIL - ('//trim(SMIOLf_lib_error_string(context))//')'
+            ierrcount = ierrcount + 1
+        end if
+
+        ! Close file
+        ierr = SMIOLf_close_file(file)
+        if (ierr /= SMIOL_SUCCESS .or. associated(file)) then
+            write(test_log, '(a)') "Failed to close `smiolf_sync_file.nc'"
+            ierrcount = -1
+            return
+        endif
+
+        ! Test sync file on a file that was created with SMIOL_FILE_READ
+        ierr = SMIOLf_open_file(context, 'smiolf_sync_file.nc', SMIOL_FILE_READ, file)
+        if (ierr /= SMIOL_SUCCESS .or. .not. associated(file)) then
+            write(test_log,'(a)') "Failed to open the file 'smiolf_sync_file.nc' with SMIOL_FILE_READ"
+            ierrcount = -1
+            return
+        end if
+
+        ! Everything OK (SMIOLf_file_sync)
+        write(test_log,'(a)',advance='no') 'Everything OK (SMIOLf_file_sync) with SMIOL_FILE_READ: '
+        ierr = SMIOLf_file_sync(file)
+        if (ierr == SMIOL_SUCCESS .and. associated(file)) then
+            write(test_log,'(a)') 'PASS'
+        else if (ierr /= SMIOL_SUCCESS .and. associated(file)) then
+            write(test_log,'(a)') 'FAIL - File was associated but SMIOL_SUCCESS was not returned'
+            ierrcount = ierrcount + 1
+        else if (ierr == SMIOL_SUCCESS .and. .not. associated(file)) then
+            write(test_log,'(a)') 'FAIL - SMIOL_SUCCESS was returned but file was not associated'
+            ierrcount = ierrcount + 1
+        else if (ierr == SMIOL_LIBRARY_ERROR) then
+            write(test_log,'(a)') 'FAIL - ('//trim(SMIOLf_lib_error_string(context))//')'
+            ierrcount = ierrcount + 1
+        end if
+
+        ! Close file
+        ierr = SMIOLf_close_file(file)
+        if (ierr /= SMIOL_SUCCESS .or. associated(file)) then
+            write(test_log, '(a)') "Failed to close `smiolf_sync_file.nc'"
+            ierrcount = -1
+            return
+        endif
+
+#if 0
+! This test will work for most compilers, but it wont work for the PGI and (most likely)
+! the Flang compiler. It fails at file % contect = c_loc(context).
+#ifdef SMIOL_PNETCDF
+        ! Try to sync a file that was never opened
+        write(test_log,'(a)',advance='no') 'Try to sync a file that was never opened: '
+        allocate(file)
+        file % context = c_loc(context)
+        file % state = -42 ! Erroneous, currently unused file state
+        ierr = SMIOLf_file_sync(file)
+        if (ierr == SMIOL_LIBRARY_ERROR .or. .not. associated(file)) then
+            write(test_log, '(a)') 'PASS ('//trim(SMIOLf_lib_error_string(context))//')'
+        else
+            write(test_log, '(a)') 'FAIL - Expected error code of SMIOL_LIBRARY_ERROR not returned or file was NULL'
+            ierrcount = ierrcount + 1
+        end if
+        deallocate(file)
+#endif
+#endif
+
+        nullify(file)
+        ! SMIOL_file_sync with an unassociated file
+        write(test_log,'(a)',advance='no') 'Testing SMIOLf_file_sync with NULL file handle: '
+        ierr = SMIOLf_file_sync(file)
+        if (ierr == SMIOL_INVALID_ARGUMENT .and. .not. associated(file)) then
+            write(test_log,'(a)') 'PASS'
+        else
+            write(0,*) ierr
+            write(test_log, '(a)') 'FAIL - Expected error code of SMIOL_INVALID_ARGUMENT not returned or file was associated'
+        endif
+
+        ! Free the SMIOL context
+        ierr = SMIOLf_finalize(context)
+        if (ierr /= SMIOL_SUCCESS .or. associated(context)) then
+            ierrcount = -1
+            return
+        end if
+
+        write(test_log,'(a)') ''
+
+    end function test_file_sync
 
 end program smiol_runner

--- a/smiol_runner.c
+++ b/smiol_runner.c
@@ -128,6 +128,12 @@ int main(int argc, char **argv)
 		return 1;
 	}
 
+	if ((ierr = SMIOL_file_sync(file)) != SMIOL_SUCCESS) {
+		fprintf(test_log, "ERROR: SMIOL_file_sync: %s ",
+			SMIOL_error_string(ierr));
+		return 1;
+	}
+
 	if ((ierr = SMIOL_close_file(&file)) != SMIOL_SUCCESS) {
 		fprintf(test_log, "ERROR: SMIOL_close_file: %s ",
 			SMIOL_error_string(ierr));
@@ -176,12 +182,6 @@ int main(int argc, char **argv)
 		return 1;
 	}
 	
-	if ((ierr = SMIOL_file_sync()) != SMIOL_SUCCESS) {
-		fprintf(test_log, "ERROR: SMIOL_file_sync: %s ",
-			SMIOL_error_string(ierr));
-		return 1;
-	}
-
 	if ((ierr = SMIOL_set_option()) != SMIOL_SUCCESS) {
 		fprintf(test_log, "ERROR: SMIOL_set_option: %s ",
 			SMIOL_error_string(ierr));

--- a/smiol_runner.c
+++ b/smiol_runner.c
@@ -137,8 +137,8 @@ int main(int argc, char **argv)
 		return 1;
 	}
 
-	if ((ierr = SMIOL_file_sync(file)) != SMIOL_SUCCESS) {
-		fprintf(test_log, "ERROR: SMIOL_file_sync: %s ",
+	if ((ierr = SMIOL_sync_file(file)) != SMIOL_SUCCESS) {
+		fprintf(test_log, "ERROR: SMIOL_sync_file: %s ",
 			SMIOL_error_string(ierr));
 		return 1;
 	}
@@ -697,7 +697,7 @@ int test_file_sync(FILE *test_log)
 	struct SMIOL_file *file = NULL;
 
 	fprintf(test_log, "********************************************************************************\n");
-	fprintf(test_log, "************************ SMIOL_file_sync unit tests ****************************\n");
+	fprintf(test_log, "************************ SMIOL_sync_file unit tests ****************************\n");
 	fprintf(test_log, "\n");
 
 	errcount = 0;
@@ -717,9 +717,9 @@ int test_file_sync(FILE *test_log)
 		return -1;
 	}
 
-	/* Testing SMIOL_file_sync on a file opened with SMIOL_FILE_CREATE*/
-	fprintf(test_log, "Everything OK (SMIOL_file_sync) with SMIOL_FILE_CREATE: ");
-	ierr = SMIOL_file_sync(file);
+	/* Testing SMIOL_sync_file on a file opened with SMIOL_FILE_CREATE*/
+	fprintf(test_log, "Everything OK (SMIOL_sync_file) with SMIOL_FILE_CREATE: ");
+	ierr = SMIOL_sync_file(file);
 	if (ierr == SMIOL_SUCCESS && file != NULL) {
 		fprintf(test_log, "PASS\n");
 	} else if (ierr != SMIOL_SUCCESS && file != NULL) {
@@ -741,16 +741,16 @@ int test_file_sync(FILE *test_log)
 	}
 
 
-	/* Testing SMIOL_file_sync on a file opened with SMIOL_FILE_WRITE */
+	/* Testing SMIOL_sync_file on a file opened with SMIOL_FILE_WRITE */
 	ierr = SMIOL_open_file(context, "smiol_sync_file.nc", SMIOL_FILE_WRITE, &file);
 	if (ierr != SMIOL_SUCCESS || file == NULL) {
 		fprintf(test_log, "Failed to open `smiol_sync_file.nc in write mode\n");
 		return -1;
 	}
 
-	/* Testing SMIOL_file_sync */
-	fprintf(test_log, "Everything OK (SMIOL_file_sync) with SMIOL_FILE_WRITE: ");
-	ierr = SMIOL_file_sync(file);
+	/* Testing SMIOL_sync_file */
+	fprintf(test_log, "Everything OK (SMIOL_sync_file) with SMIOL_FILE_WRITE: ");
+	ierr = SMIOL_sync_file(file);
 	if (ierr == SMIOL_SUCCESS && file != NULL) {
 		fprintf(test_log, "PASS\n");
 	} else if (ierr != SMIOL_SUCCESS && file != NULL) {
@@ -771,16 +771,16 @@ int test_file_sync(FILE *test_log)
 		return -1;
 	}
 
-	/* Testing SMIOL_file_sync on a file opened with SMIOL_FILE_READ*/
+	/* Testing SMIOL_sync_file on a file opened with SMIOL_FILE_READ*/
 	ierr = SMIOL_open_file(context, "smiol_sync_file.nc", SMIOL_FILE_READ, &file);
 	if (ierr != SMIOL_SUCCESS || file == NULL) {
 		fprintf(test_log, "Failed to open `smiol_sync_file.nc with SMIOL_FILE_READ\n");
 		return -1;
 	}
 
-	/* Testing SMIOL_file_sync */
-	fprintf(test_log, "Everything OK (SMIOL_file_sync) with SMIOL_FILE_READ: ");
-	ierr = SMIOL_file_sync(file);
+	/* Testing SMIOL_sync_file */
+	fprintf(test_log, "Everything OK (SMIOL_sync_file) with SMIOL_FILE_READ: ");
+	ierr = SMIOL_sync_file(file);
 	if (ierr == SMIOL_SUCCESS && file != NULL) {
 		fprintf(test_log, "PASS\n");
 	} else if (ierr != SMIOL_SUCCESS && file != NULL) {
@@ -808,7 +808,7 @@ int test_file_sync(FILE *test_log)
 	file = (struct SMIOL_file *)malloc(sizeof(struct SMIOL_file));
 	file->context = context;
 	file->state = -42;	// Erroneous, currently unused, state
-	ierr = SMIOL_file_sync(file);
+	ierr = SMIOL_sync_file(file);
 	if (ierr == SMIOL_LIBRARY_ERROR && file != NULL) {
 		fprintf(test_log, "PASS (%s)\n",
 			SMIOL_lib_error_string(context));
@@ -819,10 +819,10 @@ int test_file_sync(FILE *test_log)
 	free(file);
 #endif
 
-	/* Testing SMIOL_file_sync with a NULL file pointer*/
+	/* Testing SMIOL_sync_file with a NULL file pointer*/
 	file = NULL;
-	fprintf(test_log, "Testing SMIOL_file_sync with a NULL file pointer: ");
-	ierr = SMIOL_file_sync(file);
+	fprintf(test_log, "Testing SMIOL_sync_file with a NULL file pointer: ");
+	ierr = SMIOL_sync_file(file);
 	if (ierr == SMIOL_INVALID_ARGUMENT && file == NULL) {
 		fprintf(test_log, "PASS\n");
 	} else {

--- a/src/smiol.c
+++ b/src/smiol.c
@@ -429,17 +429,43 @@ int SMIOL_inquire_att(void)
  *
  * Forces all in-memory data to be flushed to disk.
  *
- * Detailed description.
+ * Upon success, all in-memory data for the file associatd with the file
+ * handle will be flushed to the file system and SMIOL_SUCCESS will be
+ * returned; otherwise, an error code is returned.
  *
  ********************************************************************************/
 int SMIOL_file_sync(struct SMIOL_file *file)
 {
+#ifdef SMIOL_PNETCDF
+	int ierr;
+#endif
+
 	/*
 	 * Check that file is valid
 	 */
 	if (file == NULL) {
 		return SMIOL_INVALID_ARGUMENT;
 	}
+
+#ifdef SMIOL_PNETCDF
+	/*
+	 * If the file is in define mode then switch it into data mode
+	 */
+	if (file->state == PNETCDF_DEFINE_MODE) {
+		if ((ierr = ncmpi_enddef(file->ncidp)) != NC_NOERR) {
+			file->context->lib_type = SMIOL_LIBRARY_PNETCDF;
+			file->context->lib_ierr = ierr;
+			return SMIOL_LIBRARY_ERROR;
+		}
+		file->state = PNETCDF_DATA_MODE;
+	}
+
+	if ((ierr = ncmpi_sync(file->ncidp)) != NC_NOERR) {
+		file->context->lib_type = SMIOL_LIBRARY_PNETCDF;
+		file->context->lib_ierr = ierr;
+		return SMIOL_LIBRARY_ERROR;
+	}
+#endif
 
 	return SMIOL_SUCCESS;
 }

--- a/src/smiol.c
+++ b/src/smiol.c
@@ -432,7 +432,7 @@ int SMIOL_inquire_att(void)
  * Detailed description.
  *
  ********************************************************************************/
-int SMIOL_file_sync(void)
+int SMIOL_file_sync(struct SMIOL_file *file)
 {
 	return SMIOL_SUCCESS;
 }

--- a/src/smiol.c
+++ b/src/smiol.c
@@ -5,6 +5,8 @@
 
 #ifdef SMIOL_PNETCDF
 #include "pnetcdf.h"
+#define PNETCDF_DEFINE_MODE 0
+#define PNETCDF_DATA_MODE 1
 #endif
 
 
@@ -215,6 +217,8 @@ int SMIOL_open_file(struct SMIOL_context *context, const char *filename, int mod
 			context->lib_type = SMIOL_LIBRARY_PNETCDF;
 			context->lib_ierr = ierr;
 			return SMIOL_LIBRARY_ERROR;
+		} else {
+			(*file)->state = PNETCDF_DEFINE_MODE;
 		}
 #endif
 	}
@@ -227,6 +231,8 @@ int SMIOL_open_file(struct SMIOL_context *context, const char *filename, int mod
 			context->lib_type = SMIOL_LIBRARY_PNETCDF;
 			context->lib_ierr = ierr;
 			return SMIOL_LIBRARY_ERROR;
+		} else {
+			(*file)->state = PNETCDF_DATA_MODE;
 		}
 #endif
 	}
@@ -239,6 +245,8 @@ int SMIOL_open_file(struct SMIOL_context *context, const char *filename, int mod
 			context->lib_type = SMIOL_LIBRARY_PNETCDF;
 			context->lib_ierr = ierr;
 			return SMIOL_LIBRARY_ERROR;
+		} else {
+			(*file)->state = PNETCDF_DATA_MODE;
 		}
 #endif
 	}

--- a/src/smiol.c
+++ b/src/smiol.c
@@ -434,6 +434,13 @@ int SMIOL_inquire_att(void)
  ********************************************************************************/
 int SMIOL_file_sync(struct SMIOL_file *file)
 {
+	/*
+	 * Check that file is valid
+	 */
+	if (file == NULL) {
+		return SMIOL_INVALID_ARGUMENT;
+	}
+
 	return SMIOL_SUCCESS;
 }
 

--- a/src/smiol.c
+++ b/src/smiol.c
@@ -425,7 +425,7 @@ int SMIOL_inquire_att(void)
 
 /********************************************************************************
  *
- * SMIOL_file_sync
+ * SMIOL_sync_file
  *
  * Forces all in-memory data to be flushed to disk.
  *
@@ -434,7 +434,7 @@ int SMIOL_inquire_att(void)
  * returned; otherwise, an error code is returned.
  *
  ********************************************************************************/
-int SMIOL_file_sync(struct SMIOL_file *file)
+int SMIOL_sync_file(struct SMIOL_file *file)
 {
 #ifdef SMIOL_PNETCDF
 	int ierr;

--- a/src/smiol.h
+++ b/src/smiol.h
@@ -74,7 +74,7 @@ int SMIOL_inquire_att(void);
 /*
  * Control methods
  */
-int SMIOL_file_sync(void);
+int SMIOL_file_sync(struct SMIOL_file *file);
 const char *SMIOL_error_string(int errno);
 const char *SMIOL_lib_error_string(struct SMIOL_context *context);
 int SMIOL_set_option(void);

--- a/src/smiol.h
+++ b/src/smiol.h
@@ -20,6 +20,7 @@ struct SMIOL_context {
 struct SMIOL_file {
 	struct SMIOL_context *context; /* Context for this file */
 #ifdef SMIOL_PNETCDF
+	int state; /* parallel-netCDF file state (i.e. Define or data mode) */
 	int ncidp; /* parallel-netCDF file handle */
 #endif
 };

--- a/src/smiol.h
+++ b/src/smiol.h
@@ -74,7 +74,7 @@ int SMIOL_inquire_att(void);
 /*
  * Control methods
  */
-int SMIOL_file_sync(struct SMIOL_file *file);
+int SMIOL_sync_file(struct SMIOL_file *file);
 const char *SMIOL_error_string(int errno);
 const char *SMIOL_lib_error_string(struct SMIOL_context *context);
 int SMIOL_set_option(void);

--- a/src/smiolf.F90
+++ b/src/smiolf.F90
@@ -484,15 +484,35 @@ contains
     !
     !> \brief Forces all in-memory data to be flushed to disk
     !> \details
-    !>  Detailed description of what this routine does.
+    !> Upon success, all in-memory data for the file associatd with the file
+    !> handle will be flushed to the file system and SMIOL_SUCCESS will be
+    !> returned; otherwise, an error code is returned.
     !
     !-----------------------------------------------------------------------
     integer function SMIOLf_file_sync(file) result(ierr)
 
-        implicit none
-        type (SMIOLf_file), pointer :: file
+        use iso_c_binding, only : c_ptr, c_loc, c_null_ptr
 
-        ierr = SMIOL_SUCCESS
+        implicit none
+
+        type (SMIOLf_file), pointer :: file
+        type (c_ptr) :: c_file
+
+        interface
+            function SMIOL_file_sync(file) result(ierr) bind(C, name='SMIOL_file_sync')
+                use iso_c_binding, only : c_ptr, c_int
+                type(c_ptr), value :: file
+                integer(kind=c_int) :: ierr
+            end function
+        end interface
+
+        c_file = c_null_ptr
+
+        if (associated(file)) then
+            c_file = c_loc(file)
+        end if
+
+        ierr = SMIOL_file_sync(c_file)
 
     end function SMIOLf_file_sync
 

--- a/src/smiolf.F90
+++ b/src/smiolf.F90
@@ -46,6 +46,7 @@ module SMIOLf
     type, bind(C) :: SMIOLf_file
         type (c_ptr) :: context      ! Pointer to (struct SMIOL_context); the context within which the file was opened
 #ifdef SMIOL_PNETCDF
+        integer(c_int) :: state      ! parallel-netCDF file state (i.e. Define or data mode)
         integer(c_int) :: ncidp      ! parallel-netCDF file handle
 #endif
     end type SMIOLf_file

--- a/src/smiolf.F90
+++ b/src/smiolf.F90
@@ -26,7 +26,7 @@ module SMIOLf
               SMIOLf_get_var, &
               SMIOLf_define_att, &
               SMIOLf_inquire_att, &
-              SMIOLf_file_sync, &
+              SMIOLf_sync_file, &
               SMIOLf_error_string, &
               SMIOLf_lib_error_string, &
               SMIOLf_set_option, &
@@ -480,7 +480,7 @@ contains
     !
 
     !-----------------------------------------------------------------------
-    !  routine SMIOLf_file_sync
+    !  routine SMIOLf_sync_file
     !
     !> \brief Forces all in-memory data to be flushed to disk
     !> \details
@@ -489,7 +489,7 @@ contains
     !> returned; otherwise, an error code is returned.
     !
     !-----------------------------------------------------------------------
-    integer function SMIOLf_file_sync(file) result(ierr)
+    integer function SMIOLf_sync_file(file) result(ierr)
 
         use iso_c_binding, only : c_ptr, c_loc, c_null_ptr
 
@@ -499,7 +499,7 @@ contains
         type (c_ptr) :: c_file
 
         interface
-            function SMIOL_file_sync(file) result(ierr) bind(C, name='SMIOL_file_sync')
+            function SMIOL_sync_file(file) result(ierr) bind(C, name='SMIOL_sync_file')
                 use iso_c_binding, only : c_ptr, c_int
                 type(c_ptr), value :: file
                 integer(kind=c_int) :: ierr
@@ -512,9 +512,9 @@ contains
             c_file = c_loc(file)
         end if
 
-        ierr = SMIOL_file_sync(c_file)
+        ierr = SMIOL_sync_file(c_file)
 
-    end function SMIOLf_file_sync
+    end function SMIOLf_sync_file
 
 
     !-----------------------------------------------------------------------

--- a/src/smiolf.F90
+++ b/src/smiolf.F90
@@ -487,11 +487,12 @@ contains
     !>  Detailed description of what this routine does.
     !
     !-----------------------------------------------------------------------
-    integer function SMIOLf_file_sync() result(ierr)
+    integer function SMIOLf_file_sync(file) result(ierr)
 
         implicit none
+        type (SMIOLf_file), pointer :: file
 
-        ierr = 0
+        ierr = SMIOL_SUCCESS
 
     end function SMIOLf_file_sync
 


### PR DESCRIPTION
These commits implement SMIOL_file_sync and SMIOLf_file_sync. This function can be used to flush system cache to the file system. Currently, this function is only implemented with support for parallel-netCDF and will call `ncmpi_sync` if SMIOL is compiled with PnetCDF. If SMIOL is not compiled with parallel-netCDF, then this function preforms no operation and returns SMIOL_SUCCESS. 

If SMIOL is updated with additional I/O libraries or different methods for I/O, this function can be altered to hold other library specific synchronization/flushing methods.