### PR TITLE
Implement file open modes for SMIOL_open_file

### DIFF
--- a/smiol_runner.F90
+++ b/smiol_runner.F90
@@ -103,7 +103,7 @@ program smiol_runner
         stop 1
     endif
 
-    if (SMIOLf_open_file(context, "blahf.nc", file) /= SMIOL_SUCCESS) then
+    if (SMIOLf_open_file(context, "blahf.nc", SMIOL_FILE_CREATE, file) /= SMIOL_SUCCESS) then
         write(test_log,'(a)') "ERROR: 'SMIOLf_open_file' was not called successfully"
         stop 1
     endif
@@ -313,7 +313,7 @@ contains
         ! Try to create a file for which we should not have sufficient permissions
         write(test_log,'(a)',advance='no') 'Try to create a file with insufficient permissions: '
         nullify(file)
-        ierr = SMIOLf_open_file(context, '/smiol_test.nc', file)
+        ierr = SMIOLf_open_file(context, '/smiol_test.nc', SMIOL_FILE_CREATE, file)
         if (ierr == SMIOL_LIBRARY_ERROR) then
             write(test_log,'(a)') 'PASS ('//trim(SMIOLf_lib_error_string(context))//')'
         else
@@ -346,7 +346,7 @@ contains
         ! Everything OK (SMIOLf_open_file)
         write(test_log,'(a)',advance='no') 'Everything OK (SMIOLf_open_file): '
         nullify(file)
-        ierr = SMIOLf_open_file(context, 'test_fortran.nc', file)
+        ierr = SMIOLf_open_file(context, 'test_fortran.nc', SMIOL_FILE_CREATE, file)
         if (ierr == SMIOL_SUCCESS .and. associated(file)) then
             write(test_log,'(a)') 'PASS'
         else

--- a/smiol_runner.c
+++ b/smiol_runner.c
@@ -122,7 +122,7 @@ int main(int argc, char **argv)
 		return 1;
 	}
 
-	if ((ierr = SMIOL_open_file(context, "blah.nc", &file)) != SMIOL_SUCCESS) {
+	if ((ierr = SMIOL_open_file(context, "blah.nc", SMIOL_FILE_CREATE, &file)) != SMIOL_SUCCESS) {
 		fprintf(test_log, "ERROR: SMIOL_open_file: %s ",
 			SMIOL_error_string(ierr));
 		return 1;
@@ -364,7 +364,7 @@ int test_open_close(FILE *test_log)
 	/* Try to create a file for which we should not have sufficient permissions */
 	fprintf(test_log, "Try to create a file with insufficient permissions: ");
 	file = NULL;
-	ierr = SMIOL_open_file(context, "/smiol_test.nc", &file);
+	ierr = SMIOL_open_file(context, "/smiol_test.nc", SMIOL_FILE_CREATE, &file);
 	if (ierr == SMIOL_LIBRARY_ERROR) {
 		fprintf(test_log, "PASS (%s)\n", SMIOL_lib_error_string(context));
 	}
@@ -391,7 +391,7 @@ int test_open_close(FILE *test_log)
 	/* Everything OK (SMIOL_open_file) */
 	fprintf(test_log, "Everything OK (SMIOL_open_file): ");
 	file = NULL;
-	ierr = SMIOL_open_file(context, "test.nc", &file);
+	ierr = SMIOL_open_file(context, "test.nc", SMIOL_FILE_CREATE, &file);
 	if (ierr == SMIOL_SUCCESS && file != NULL) {
 		fprintf(test_log, "PASS\n");
 	}

--- a/src/smiol.h
+++ b/src/smiol.h
@@ -47,7 +47,7 @@ int SMIOL_inquire(void);
 /*
  * File methods
  */
-int SMIOL_open_file(struct SMIOL_context *context, const char *filename, struct SMIOL_file **file);
+int SMIOL_open_file(struct SMIOL_context *context, const char *filename, int mode, struct SMIOL_file **file);
 int SMIOL_close_file(struct SMIOL_file **file);
 
 /*

--- a/src/smiol_codes.inc
+++ b/src/smiol_codes.inc
@@ -5,5 +5,9 @@
 #define SMIOL_FORTRAN_ERROR     (-4)
 #define SMIOL_LIBRARY_ERROR     (-5)
 
+#define SMIOL_FILE_CREATE       (1)
+#define SMIOL_FILE_READ         (2)
+#define SMIOL_FILE_WRITE        (4)
+
 #define SMIOL_LIBRARY_UNKNOWN (1000)
 #define SMIOL_LIBRARY_PNETCDF (1001)

--- a/src/smiolf.F90
+++ b/src/smiolf.F90
@@ -200,15 +200,15 @@ contains
     !
     !> \brief Opens a file within a SMIOL context
     !> \details
-    !>  Creates or opens the file specified by filename within the provided SMIOL
-    !>  context.
+    !>  Depending on the specified file mode, creates or opens the file specified
+    !>  by filename within the provided SMIOL context.
     !>
     !>  Upon successful completion, SMIOL_SUCCESS is returned, and the file handle argument
     !>  will point to a valid file handle. Otherwise, the file handle is not associated
     !>  and an error code other than SMIOL_SUCCESS is returned.
     !
     !-----------------------------------------------------------------------
-    integer function SMIOLf_open_file(context, filename, file) result(ierr)
+    integer function SMIOLf_open_file(context, filename, mode, file) result(ierr)
 
         use iso_c_binding, only : c_loc, c_ptr, c_null_ptr, c_char, c_null_char, c_associated, c_f_pointer
 
@@ -216,20 +216,23 @@ contains
 
         type (SMIOLf_context), pointer :: context
         character(len=*), intent(in) :: filename
+        integer, intent(in) :: mode
         type (SMIOLf_file), pointer :: file
 
         type (c_ptr) :: c_context = c_null_ptr
         type (c_ptr) :: c_file = c_null_ptr
+        integer(kind=c_int) :: c_mode
         character(kind=c_char), dimension(:), pointer :: c_filename => null()
 
         integer :: i
 
         ! C interface definitions
         interface
-            function SMIOL_open_file(context, filename, file) result(ierr) bind(C, name='SMIOL_open_file')
+            function SMIOL_open_file(context, filename, mode, file) result(ierr) bind(C, name='SMIOL_open_file')
                 use iso_c_binding, only : c_char, c_ptr, c_int
                 type (c_ptr), value :: context
                 character(kind=c_char), dimension(*) :: filename
+                integer(kind=c_int), value :: mode
                 type (c_ptr) :: file
                 integer(kind=c_int) :: ierr
             end function
@@ -248,7 +251,9 @@ contains
         end do
         c_filename(i) = c_null_char
 
-        ierr = SMIOL_open_file(c_context, c_filename, c_file)
+        c_mode = mode
+
+        ierr = SMIOL_open_file(c_context, c_filename, c_mode, c_file)
 
         deallocate(c_filename)
 


### PR DESCRIPTION
This merge implements the ability to specify file modes (create, write, or read)
in the call to SMIOL_open_file.

The smiol_codes.inc file now defines SMIOL_FILE_CREATE, SMIOL_FILE_READ,
and SMIOL_FILE_WRITE, and the SMIOL_open_file routine now takes as
an argument one of these modes (or possibly a bit-wise OR of modes).

The SMIOL_open_file routine will attempt to create a file if the mode is
SMIOL_FILE_CREATE, and it will attempt to open an existing file if the mode
is SMIOL_FILE_WRITE or SMIOL_FILE_READ.