### PR TITLE
Implement SMIOL_define_dim and SMIOL_inquire_dim

### DIFF
--- a/smiol_runner.F90
+++ b/smiol_runner.F90
@@ -631,9 +631,10 @@ contains
 #if 0
         type (SMIOLf_file), pointer :: null_file
 #endif
+        integer(kind=SMIOL_offset_kind) :: dimsize
 
         write(test_log,'(a)') '********************************************************************************'
-        write(test_log,'(a)') '************ SMIOL_define_dim unit tests ***************************************'
+        write(test_log,'(a)') '************ SMIOL_define_dim / SMIOL_inquire_dim unit tests *******************'
         write(test_log,'(a)') ''
 
         ierrcount = 0
@@ -695,6 +696,64 @@ contains
         ierr = SMIOLf_define_dim(file, 'nElements', 99999999999_SMIOL_offset_kind)
         if (ierr == SMIOL_SUCCESS) then
             write(test_log,'(a)') 'PASS'
+        else
+            write(test_log,'(a)') 'FAIL - SMIOL_SUCCESS was not returned'
+            ierrcount = ierrcount + 1
+        end if
+
+        ! Handle undefined dimension
+        write(test_log,'(a)',advance='no') 'Handle undefined dimension (SMIOLf_inquire_dim): '
+        ierr = SMIOLf_inquire_dim(file, 'foobar', dimsize)
+        if (ierr /= SMIOL_SUCCESS) then
+            write(test_log,'(a)') 'PASS'
+        else
+            write(test_log,'(a)') 'FAIL - SMIOL_SUCCESS was returned, when an error was expected'
+            ierrcount = ierrcount + 1
+        end if
+
+        ! Everything OK for SMIOL_inquire_dim, unlimited dimension
+        write(test_log,'(a)',advance='no') 'Everything OK - unlimited dimension (SMIOLf_inquire_dim): '
+        dimsize = 0_SMIOL_offset_kind
+        ierr = SMIOLf_inquire_dim(file, 'Time', dimsize)
+        if (ierr == SMIOL_SUCCESS) then
+            if (dimsize == 1_SMIOL_offset_kind) then
+                write(test_log,'(a)') 'PASS'
+            else
+                write(test_log,'(a)') 'FAIL - SMIOL_SUCCESS was returned, but the dimension size is wrong'
+                ierrcount = ierrcount + 1
+            end if
+        else
+            write(test_log,'(a)') 'FAIL - SMIOL_SUCCESS was not returned'
+            ierrcount = ierrcount + 1
+        end if
+
+        ! Everything OK for SMIOL_inquire_dim, small non-record dimension
+        write(test_log,'(a)',advance='no') 'Everything OK - small non-record dimension (SMIOLf_inquire_dim): '
+        dimsize = 0_SMIOL_offset_kind
+        ierr = SMIOLf_inquire_dim(file, 'nCells', dimsize)
+        if (ierr == SMIOL_SUCCESS) then
+            if (dimsize == 1_SMIOL_offset_kind) then
+                write(test_log,'(a)') 'PASS'
+            else
+                write(test_log,'(a)') 'FAIL - SMIOL_SUCCESS was returned, but the dimension size is wrong'
+                ierrcount = ierrcount + 1
+            end if
+        else
+            write(test_log,'(a)') 'FAIL - SMIOL_SUCCESS was not returned'
+            ierrcount = ierrcount + 1
+        end if
+
+        ! Everything OK for SMIOL_inquire_dim, large non-record dimension
+        write(test_log,'(a)',advance='no') 'Everything OK - large non-record dimension (SMIOLf_inquire_dim): '
+        dimsize = 0_SMIOL_offset_kind
+        ierr = SMIOLf_inquire_dim(file, 'nElements', dimsize)
+        if (ierr == SMIOL_SUCCESS) then
+            if (dimsize == 1_SMIOL_offset_kind) then
+                write(test_log,'(a)') 'PASS'
+            else
+                write(test_log,'(a)') 'FAIL - SMIOL_SUCCESS was returned, but the dimension size is wrong'
+                ierrcount = ierrcount + 1
+            end if
         else
             write(test_log,'(a)') 'FAIL - SMIOL_SUCCESS was not returned'
             ierrcount = ierrcount + 1

--- a/smiol_runner.F90
+++ b/smiol_runner.F90
@@ -19,6 +19,7 @@ program smiol_runner
     type (SMIOLf_context), pointer :: context => null()
     type (SMIOLf_file), pointer :: file => null()
     character(len=16) :: log_fname
+    integer(kind=SMIOL_offset_kind) :: dimsize
 
     call MPI_Init(ierr)
     if (ierr /= MPI_SUCCESS) then
@@ -132,13 +133,14 @@ program smiol_runner
         stop 1
     endif
 
-    if (SMIOLf_close_file(file) /= SMIOL_SUCCESS) then
-        write(test_log,'(a)') "ERROR: 'SMIOLf_close_file' was not called successfully"
+    if (SMIOLf_inquire_dim(file, 'nCells', dimsize) /= SMIOL_SUCCESS) then
+        write(test_log,'(a)') "ERROR: 'SMIOLf_inquire_dim' was not called successfully"
         stop 1
     endif
+    write(test_log,'(a,i6)') 'Size of nCells dimension is ', dimsize
 
-    if (SMIOLf_inquire_dim() /= SMIOL_SUCCESS) then
-        write(test_log,'(a)') "ERROR: 'SMIOLf_inquire_dim' was not called successfully"
+    if (SMIOLf_close_file(file) /= SMIOL_SUCCESS) then
+        write(test_log,'(a)') "ERROR: 'SMIOLf_close_file' was not called successfully"
         stop 1
     endif
 

--- a/smiol_runner.F90
+++ b/smiol_runner.F90
@@ -790,6 +790,84 @@ contains
             return
         end if
 
+        ! Re-open the SMIOL file
+        nullify(file)
+        ierr = SMIOLf_open_file(context, 'test_dims_fortran.nc', SMIOL_FILE_READ, file)
+        if (ierr /= SMIOL_SUCCESS .or. .not. associated(file)) then
+            write(test_log,'(a)') 'Failed to open existing SMIOL file...'
+            ierrcount = -1
+            return
+        end if
+
+        ! Existing file for SMIOL_inquire_dim, unlimited dimension
+        write(test_log,'(a)',advance='no') 'Existing file - unlimited dimension (SMIOLf_inquire_dim): '
+        dimsize = 0_SMIOL_offset_kind
+        ierr = SMIOLf_inquire_dim(file, 'Time', dimsize)
+        if (ierr == SMIOL_SUCCESS) then
+            if (dimsize == 0_SMIOL_offset_kind) then
+                write(test_log,'(a)') 'PASS'
+            else
+                write(test_log,'(a,a,i11,a,i11)') 'FAIL - SMIOL_SUCCESS was returned, but the dimension size is wrong', &
+                               ' (got ', dimsize, ', expected ', 0_SMIOL_offset_kind, ')'
+                ierrcount = ierrcount + 1
+            end if
+        else
+            write(test_log,'(a)') 'FAIL - SMIOL_SUCCESS was not returned'
+            ierrcount = ierrcount + 1
+        end if
+
+        ! Existing file for SMIOL_inquire_dim, small non-record dimension
+        write(test_log,'(a)',advance='no') 'Existing file - small non-record dimension (SMIOLf_inquire_dim): '
+        dimsize = 0_SMIOL_offset_kind
+#ifdef SMIOL_PNETCDF
+        expected_dimsize = 40962_SMIOL_offset_kind
+#else
+        expected_dimsize = 0_SMIOL_offset_kind
+#endif
+        ierr = SMIOLf_inquire_dim(file, 'nCells', dimsize)
+        if (ierr == SMIOL_SUCCESS) then
+            if (dimsize == expected_dimsize) then
+                write(test_log,'(a)') 'PASS'
+            else
+                write(test_log,'(a,a,i11,a,i11)') 'FAIL - SMIOL_SUCCESS was returned, but the dimension size is wrong', &
+                               ' (got ', dimsize, ', expected ', expected_dimsize, ')'
+                ierrcount = ierrcount + 1
+            end if
+        else
+            write(test_log,'(a)') 'FAIL - SMIOL_SUCCESS was not returned'
+            ierrcount = ierrcount + 1
+        end if
+
+        ! Existing file for SMIOL_inquire_dim, large non-record dimension
+        write(test_log,'(a)',advance='no') 'Existing file - large non-record dimension (SMIOLf_inquire_dim): '
+        dimsize = 0_SMIOL_offset_kind
+#ifdef SMIOL_PNETCDF
+        expected_dimsize = 99999999999_SMIOL_offset_kind
+#else
+        expected_dimsize = 0_SMIOL_offset_kind
+#endif
+        ierr = SMIOLf_inquire_dim(file, 'nElements', dimsize)
+        if (ierr == SMIOL_SUCCESS) then
+            if (dimsize == expected_dimsize) then
+                write(test_log,'(a)') 'PASS'
+            else
+                write(test_log,'(a,a,i11,a,i11)') 'FAIL - SMIOL_SUCCESS was returned, but the dimension size is wrong', &
+                               ' (got ', dimsize, ', expected ', expected_dimsize, ')'
+                ierrcount = ierrcount + 1
+            end if
+        else
+            write(test_log,'(a)') 'FAIL - SMIOL_SUCCESS was not returned'
+            ierrcount = ierrcount + 1
+        end if
+
+        ! Close the SMIOL file
+        ierr = SMIOLf_close_file(file)
+        if (ierr /= SMIOL_SUCCESS .or. associated(file)) then
+            write(test_log,'(a)') 'Failed to close SMIOL file...'
+            ierrcount = -1
+            return
+        end if
+
         ! Free the SMIOL context
         ierr = SMIOLf_finalize(context)
         if (ierr /= SMIOL_SUCCESS .or. associated(context)) then

--- a/smiol_runner.F90
+++ b/smiol_runner.F90
@@ -108,13 +108,18 @@ program smiol_runner
         stop 1
     endif
 
-    if (SMIOLf_close_file(file) /= SMIOL_SUCCESS) then
-        write(test_log,'(a)') "ERROR: 'SMIOLf_close_file' was not called successfully"
+    if (SMIOLf_define_dim(file, 'Time', -1_SMIOL_offset_kind) /= SMIOL_SUCCESS) then
+        write(test_log,'(a)') "ERROR: 'SMIOLf_define_dim' was not called successfully"
         stop 1
     endif
 
-    if (SMIOLf_define_dim() /= SMIOL_SUCCESS) then 
+    if (SMIOLf_define_dim(file, 'nCells', 40962_SMIOL_offset_kind) /= SMIOL_SUCCESS) then
         write(test_log,'(a)') "ERROR: 'SMIOLf_define_dim' was not called successfully"
+        stop 1
+    endif
+
+    if (SMIOLf_close_file(file) /= SMIOL_SUCCESS) then
+        write(test_log,'(a)') "ERROR: 'SMIOLf_close_file' was not called successfully"
         stop 1
     endif
 

--- a/smiol_runner.c
+++ b/smiol_runner.c
@@ -705,6 +705,7 @@ int test_dimensions(FILE *test_log)
 	int64_t dimsize;
 	struct SMIOL_context *context;
 	struct SMIOL_file *file;
+	int64_t expected_dimsize;
 
 	fprintf(test_log, "********************************************************************************\n");
 	fprintf(test_log, "************ SMIOL_define_dim / SMIOL_inquire_dim ******************************\n");
@@ -819,24 +820,35 @@ int test_dimensions(FILE *test_log)
 	/* Handle undefined dimension */
 	fprintf(test_log, "Handle undefined dimension (SMIOL_inquire_dim): ");
 	ierr = SMIOL_inquire_dim(file, "foobar", &dimsize);
-	if (ierr != SMIOL_SUCCESS) {
+#ifdef SMIOL_PNETCDF
+	if (ierr == SMIOL_LIBRARY_ERROR) {
+		fprintf(test_log, "PASS (%s)\n", SMIOL_lib_error_string(context));
+	}
+	else {
+		fprintf(test_log, "FAIL - SMIOL_LIBRARY_ERROR was not returned\n");
+		errcount++;
+	}
+#else
+	if (ierr == SMIOL_SUCCESS) {
 		fprintf(test_log, "PASS\n");
 	}
 	else {
-		fprintf(test_log, "FAIL - SMIOL_SUCCESS was returned, when an error was expected\n");
+		fprintf(test_log, "FAIL - SMIOL_SUCCESS was not returned for no-op implementation of SMIOL_inquire_dim\n");
 		errcount++;
 	}
+#endif
 
 	/* Everything OK for SMIOL_inquire_dim, unlimited dimension */
 	fprintf(test_log, "Everything OK - unlimited dimension (SMIOL_inquire_dim): ");
 	dimsize = (int64_t)0;
 	ierr = SMIOL_inquire_dim(file, "Time", &dimsize);
 	if (ierr == SMIOL_SUCCESS) {
-		if (dimsize == 1) {
+		if (dimsize == (int64_t)0) {
 			fprintf(test_log, "PASS\n");
 		}
 		else {
-			fprintf(test_log, "FAIL - SMIOL_SUCCESS was returned, but the dimension size is wrong\n");
+			fprintf(test_log, "FAIL - SMIOL_SUCCESS was returned, but the dimension size is wrong (got %li, expected %li)\n",
+				(long int)dimsize, (long int)0);
 			errcount++;
 		}
 	}
@@ -848,13 +860,19 @@ int test_dimensions(FILE *test_log)
 	/* Everything OK for SMIOL_inquire_dim, small non-record dimension */
 	fprintf(test_log, "Everything OK - small non-record dimension (SMIOL_inquire_dim): ");
 	dimsize = (int64_t)0;
+#ifdef SMIOL_PNETCDF
+	expected_dimsize = (int64_t)40962;
+#else
+	expected_dimsize = (int64_t)0;
+#endif
 	ierr = SMIOL_inquire_dim(file, "nCells", &dimsize);
 	if (ierr == SMIOL_SUCCESS) {
-		if (dimsize == 1) {
+		if (dimsize == expected_dimsize) {
 			fprintf(test_log, "PASS\n");
 		}
 		else {
-			fprintf(test_log, "FAIL - SMIOL_SUCCESS was returned, but the dimension size is wrong\n");
+			fprintf(test_log, "FAIL - SMIOL_SUCCESS was returned, but the dimension size is wrong (got %li, expected %li)\n",
+				(long int)dimsize, (long int)expected_dimsize);
 			errcount++;
 		}
 	}
@@ -866,13 +884,19 @@ int test_dimensions(FILE *test_log)
 	/* Everything OK for SMIOL_inquire_dim, large non-record dimension */
 	fprintf(test_log, "Everything OK - large non-record dimension (SMIOL_inquire_dim): ");
 	dimsize = (int64_t)0;
+#ifdef SMIOL_PNETCDF
+	expected_dimsize = (int64_t)99999999999;
+#else
+	expected_dimsize = (int64_t)0;
+#endif
 	ierr = SMIOL_inquire_dim(file, "nElements", &dimsize);
 	if (ierr == SMIOL_SUCCESS) {
-		if (dimsize == 1) {
+		if (dimsize == expected_dimsize) {
 			fprintf(test_log, "PASS\n");
 		}
 		else {
-			fprintf(test_log, "FAIL - SMIOL_SUCCESS was returned, but the dimension size is wrong\n");
+			fprintf(test_log, "FAIL - SMIOL_SUCCESS was returned, but the dimension size is wrong (got %li, expected %li)\n",
+				(long int)dimsize, (long int)expected_dimsize);
 			errcount++;
 		}
 	}

--- a/smiol_runner.c
+++ b/smiol_runner.c
@@ -702,11 +702,12 @@ int test_dimensions(FILE *test_log)
 {
 	int ierr;
 	int errcount;
+	int64_t dimsize;
 	struct SMIOL_context *context;
 	struct SMIOL_file *file;
 
 	fprintf(test_log, "********************************************************************************\n");
-	fprintf(test_log, "************ SMIOL_define_dim **************************************************\n");
+	fprintf(test_log, "************ SMIOL_define_dim / SMIOL_inquire_dim ******************************\n");
 	fprintf(test_log, "\n");
 
 	errcount = 0;
@@ -776,6 +777,104 @@ int test_dimensions(FILE *test_log)
 	ierr = SMIOL_define_dim(file, "nElements", 99999999999);
 	if (ierr == SMIOL_SUCCESS) {
 		fprintf(test_log, "PASS\n");
+	}
+	else {
+		fprintf(test_log, "FAIL - SMIOL_SUCCESS was not returned\n");
+		errcount++;
+	}
+
+	/* Handle NULL file handle */
+	fprintf(test_log, "Handle NULL file handle (SMIOL_inquire_dim): ");
+	ierr = SMIOL_inquire_dim(NULL, "invalid_dim", &dimsize);
+	if (ierr != SMIOL_SUCCESS) {
+		fprintf(test_log, "PASS\n");
+	}
+	else {
+		fprintf(test_log, "FAIL - SMIOL_SUCCESS was returned, when an error was expected\n");
+		errcount++;
+	}
+
+	/* Handle NULL dimension name */
+	fprintf(test_log, "Handle NULL dimension name (SMIOL_inquire_dim): ");
+	ierr = SMIOL_inquire_dim(file, NULL, &dimsize);
+	if (ierr != SMIOL_SUCCESS) {
+		fprintf(test_log, "PASS\n");
+	}
+	else {
+		fprintf(test_log, "FAIL - SMIOL_SUCCESS was returned, when an error was expected\n");
+		errcount++;
+	}
+
+	/* Handle NULL dimension size */
+	fprintf(test_log, "Handle NULL dimension size (SMIOL_inquire_dim): ");
+	ierr = SMIOL_inquire_dim(file, "nCells", NULL);
+	if (ierr != SMIOL_SUCCESS) {
+		fprintf(test_log, "PASS\n");
+	}
+	else {
+		fprintf(test_log, "FAIL - SMIOL_SUCCESS was returned, when an error was expected\n");
+		errcount++;
+	}
+
+	/* Handle undefined dimension */
+	fprintf(test_log, "Handle undefined dimension (SMIOL_inquire_dim): ");
+	ierr = SMIOL_inquire_dim(file, "foobar", &dimsize);
+	if (ierr != SMIOL_SUCCESS) {
+		fprintf(test_log, "PASS\n");
+	}
+	else {
+		fprintf(test_log, "FAIL - SMIOL_SUCCESS was returned, when an error was expected\n");
+		errcount++;
+	}
+
+	/* Everything OK for SMIOL_inquire_dim, unlimited dimension */
+	fprintf(test_log, "Everything OK - unlimited dimension (SMIOL_inquire_dim): ");
+	dimsize = (int64_t)0;
+	ierr = SMIOL_inquire_dim(file, "Time", &dimsize);
+	if (ierr == SMIOL_SUCCESS) {
+		if (dimsize == 1) {
+			fprintf(test_log, "PASS\n");
+		}
+		else {
+			fprintf(test_log, "FAIL - SMIOL_SUCCESS was returned, but the dimension size is wrong\n");
+			errcount++;
+		}
+	}
+	else {
+		fprintf(test_log, "FAIL - SMIOL_SUCCESS was not returned\n");
+		errcount++;
+	}
+
+	/* Everything OK for SMIOL_inquire_dim, small non-record dimension */
+	fprintf(test_log, "Everything OK - small non-record dimension (SMIOL_inquire_dim): ");
+	dimsize = (int64_t)0;
+	ierr = SMIOL_inquire_dim(file, "nCells", &dimsize);
+	if (ierr == SMIOL_SUCCESS) {
+		if (dimsize == 1) {
+			fprintf(test_log, "PASS\n");
+		}
+		else {
+			fprintf(test_log, "FAIL - SMIOL_SUCCESS was returned, but the dimension size is wrong\n");
+			errcount++;
+		}
+	}
+	else {
+		fprintf(test_log, "FAIL - SMIOL_SUCCESS was not returned\n");
+		errcount++;
+	}
+
+	/* Everything OK for SMIOL_inquire_dim, large non-record dimension */
+	fprintf(test_log, "Everything OK - large non-record dimension (SMIOL_inquire_dim): ");
+	dimsize = (int64_t)0;
+	ierr = SMIOL_inquire_dim(file, "nElements", &dimsize);
+	if (ierr == SMIOL_SUCCESS) {
+		if (dimsize == 1) {
+			fprintf(test_log, "PASS\n");
+		}
+		else {
+			fprintf(test_log, "FAIL - SMIOL_SUCCESS was returned, but the dimension size is wrong\n");
+			errcount++;
+		}
 	}
 	else {
 		fprintf(test_log, "FAIL - SMIOL_SUCCESS was not returned\n");

--- a/smiol_runner.c
+++ b/smiol_runner.c
@@ -15,6 +15,7 @@ int main(int argc, char **argv)
 {
 	int ierr;
 	int my_proc_id;
+	int64_t dimsize;
 	size_t n_compute_elements = 1;
 	size_t n_io_elements = 1;
 	int64_t *compute_elements;
@@ -152,14 +153,14 @@ int main(int argc, char **argv)
 		return 1;
 	}
 
-	if ((ierr = SMIOL_close_file(&file)) != SMIOL_SUCCESS) {
-		fprintf(test_log, "ERROR: SMIOL_close_file: %s ", SMIOL_error_string(ierr));
+	if ((ierr = SMIOL_inquire_dim(file, "nCells", &dimsize)) != SMIOL_SUCCESS) {
+		fprintf(test_log, "ERROR: SMIOL_inquire_dim: %s ", SMIOL_error_string(ierr));
 		return 1;
 	}
+	fprintf(test_log, "Size of nCells dimension is %li\n", (long int)dimsize);
 
-	if ((ierr = SMIOL_inquire_dim()) != SMIOL_SUCCESS) {
-		fprintf(test_log, "ERROR: SMIOL_inquire_dim: %s ",
-			SMIOL_error_string(ierr));
+	if ((ierr = SMIOL_close_file(&file)) != SMIOL_SUCCESS) {
+		fprintf(test_log, "ERROR: SMIOL_close_file: %s ", SMIOL_error_string(ierr));
 		return 1;
 	}
 

--- a/smiol_runner.c
+++ b/smiol_runner.c
@@ -15,7 +15,7 @@ int main(int argc, char **argv)
 {
 	int ierr;
 	int my_proc_id;
-	int64_t dimsize;
+	SMIOL_Offset dimsize;
 	size_t n_compute_elements = 1;
 	size_t n_io_elements = 1;
 	int64_t *compute_elements;
@@ -702,10 +702,10 @@ int test_dimensions(FILE *test_log)
 {
 	int ierr;
 	int errcount;
-	int64_t dimsize;
+	SMIOL_Offset dimsize;
 	struct SMIOL_context *context;
 	struct SMIOL_file *file;
-	int64_t expected_dimsize;
+	SMIOL_Offset expected_dimsize;
 
 	fprintf(test_log, "********************************************************************************\n");
 	fprintf(test_log, "************ SMIOL_define_dim / SMIOL_inquire_dim ******************************\n");
@@ -840,10 +840,10 @@ int test_dimensions(FILE *test_log)
 
 	/* Everything OK for SMIOL_inquire_dim, unlimited dimension */
 	fprintf(test_log, "Everything OK - unlimited dimension (SMIOL_inquire_dim): ");
-	dimsize = (int64_t)0;
+	dimsize = (SMIOL_Offset)0;
 	ierr = SMIOL_inquire_dim(file, "Time", &dimsize);
 	if (ierr == SMIOL_SUCCESS) {
-		if (dimsize == (int64_t)0) {
+		if (dimsize == (SMIOL_Offset)0) {
 			fprintf(test_log, "PASS\n");
 		}
 		else {
@@ -859,11 +859,11 @@ int test_dimensions(FILE *test_log)
 
 	/* Everything OK for SMIOL_inquire_dim, small non-record dimension */
 	fprintf(test_log, "Everything OK - small non-record dimension (SMIOL_inquire_dim): ");
-	dimsize = (int64_t)0;
+	dimsize = (SMIOL_Offset)0;
 #ifdef SMIOL_PNETCDF
-	expected_dimsize = (int64_t)40962;
+	expected_dimsize = (SMIOL_Offset)40962;
 #else
-	expected_dimsize = (int64_t)0;
+	expected_dimsize = (SMIOL_Offset)0;
 #endif
 	ierr = SMIOL_inquire_dim(file, "nCells", &dimsize);
 	if (ierr == SMIOL_SUCCESS) {
@@ -883,11 +883,11 @@ int test_dimensions(FILE *test_log)
 
 	/* Everything OK for SMIOL_inquire_dim, large non-record dimension */
 	fprintf(test_log, "Everything OK - large non-record dimension (SMIOL_inquire_dim): ");
-	dimsize = (int64_t)0;
+	dimsize = (SMIOL_Offset)0;
 #ifdef SMIOL_PNETCDF
-	expected_dimsize = (int64_t)99999999999;
+	expected_dimsize = (SMIOL_Offset)99999999999;
 #else
-	expected_dimsize = (int64_t)0;
+	expected_dimsize = (SMIOL_Offset)0;
 #endif
 	ierr = SMIOL_inquire_dim(file, "nElements", &dimsize);
 	if (ierr == SMIOL_SUCCESS) {

--- a/smiol_runner.c
+++ b/smiol_runner.c
@@ -912,6 +912,88 @@ int test_dimensions(FILE *test_log)
 		return -1;
 	}
 
+	/* Re-open the SMIOL file */
+	file = NULL;
+	ierr = SMIOL_open_file(context, "test_dims.nc", SMIOL_FILE_READ, &file);
+	if (ierr != SMIOL_SUCCESS || file == NULL) {
+		fprintf(test_log, "Failed to open existing SMIOL file...\n");
+		return -1;
+	}
+
+	/* Existing file for SMIOL_inquire_dim, unlimited dimension */
+	fprintf(test_log, "Existing file - unlimited dimension (SMIOL_inquire_dim): ");
+	dimsize = (SMIOL_Offset)0;
+	ierr = SMIOL_inquire_dim(file, "Time", &dimsize);
+	if (ierr == SMIOL_SUCCESS) {
+		if (dimsize == (SMIOL_Offset)0) {
+			fprintf(test_log, "PASS\n");
+		}
+		else {
+			fprintf(test_log, "FAIL - SMIOL_SUCCESS was returned, but the dimension size is wrong (got %li, expected %li)\n",
+				(long int)dimsize, (long int)0);
+			errcount++;
+		}
+	}
+	else {
+		fprintf(test_log, "FAIL - SMIOL_SUCCESS was not returned\n");
+		errcount++;
+	}
+
+	/* Existing file for SMIOL_inquire_dim, small non-record dimension */
+	fprintf(test_log, "Existing file - small non-record dimension (SMIOL_inquire_dim): ");
+	dimsize = (SMIOL_Offset)0;
+#ifdef SMIOL_PNETCDF
+	expected_dimsize = (SMIOL_Offset)40962;
+#else
+	expected_dimsize = (SMIOL_Offset)0;
+#endif
+	ierr = SMIOL_inquire_dim(file, "nCells", &dimsize);
+	if (ierr == SMIOL_SUCCESS) {
+		if (dimsize == expected_dimsize) {
+			fprintf(test_log, "PASS\n");
+		}
+		else {
+			fprintf(test_log, "FAIL - SMIOL_SUCCESS was returned, but the dimension size is wrong (got %li, expected %li)\n",
+				(long int)dimsize, (long int)expected_dimsize);
+			errcount++;
+		}
+	}
+	else {
+		fprintf(test_log, "FAIL - SMIOL_SUCCESS was not returned\n");
+		errcount++;
+	}
+
+	/* Existing file for SMIOL_inquire_dim, large non-record dimension */
+	fprintf(test_log, "Existing file - large non-record dimension (SMIOL_inquire_dim): ");
+	dimsize = (SMIOL_Offset)0;
+#ifdef SMIOL_PNETCDF
+	expected_dimsize = (SMIOL_Offset)99999999999;
+#else
+	expected_dimsize = (SMIOL_Offset)0;
+#endif
+	ierr = SMIOL_inquire_dim(file, "nElements", &dimsize);
+	if (ierr == SMIOL_SUCCESS) {
+		if (dimsize == expected_dimsize) {
+			fprintf(test_log, "PASS\n");
+		}
+		else {
+			fprintf(test_log, "FAIL - SMIOL_SUCCESS was returned, but the dimension size is wrong (got %li, expected %li)\n",
+				(long int)dimsize, (long int)expected_dimsize);
+			errcount++;
+		}
+	}
+	else {
+		fprintf(test_log, "FAIL - SMIOL_SUCCESS was not returned\n");
+		errcount++;
+	}
+
+	/* Close the SMIOL file */
+	ierr = SMIOL_close_file(&file);
+	if (ierr != SMIOL_SUCCESS || file != NULL) {
+		fprintf(test_log, "Failed to close SMIOL file...\n");
+		return -1;
+	}
+
 	/* Free the SMIOL context */
 	ierr = SMIOL_finalize(&context);
 	if (ierr != SMIOL_SUCCESS || context != NULL) {

--- a/smiol_runner.c
+++ b/smiol_runner.c
@@ -128,15 +128,18 @@ int main(int argc, char **argv)
 		return 1;
 	}
 
-	if ((ierr = SMIOL_close_file(&file)) != SMIOL_SUCCESS) {
-		fprintf(test_log, "ERROR: SMIOL_close_file: %s ",
-			SMIOL_error_string(ierr));
+	if ((ierr = SMIOL_define_dim(file, "Time", -1)) != SMIOL_SUCCESS) {
+		fprintf(test_log, "ERROR: SMIOL_define_dim: %s ", SMIOL_error_string(ierr));
 		return 1;
 	}
 
-	if ((ierr = SMIOL_define_dim()) != SMIOL_SUCCESS) {
-		fprintf(test_log, "ERROR: SMIOL_define_dim: %s ",
-			SMIOL_error_string(ierr));
+	if ((ierr = SMIOL_define_dim(file, "nCells", 40962)) != SMIOL_SUCCESS) {
+		fprintf(test_log, "ERROR: SMIOL_define_dim: %s ", SMIOL_error_string(ierr));
+		return 1;
+	}
+
+	if ((ierr = SMIOL_close_file(&file)) != SMIOL_SUCCESS) {
+		fprintf(test_log, "ERROR: SMIOL_close_file: %s ", SMIOL_error_string(ierr));
 		return 1;
 	}
 

--- a/src/smiol.c
+++ b/src/smiol.c
@@ -325,8 +325,6 @@ int SMIOL_define_dim(struct SMIOL_file *file, const char *dimname, int64_t dimsi
 		return SMIOL_INVALID_ARGUMENT;
 	}
 
-	fprintf(stderr, "Defining dimension %s = %li\n", dimname, (long int)dimsize);
-
 	return SMIOL_SUCCESS;
 }
 

--- a/src/smiol.c
+++ b/src/smiol.c
@@ -310,7 +310,7 @@ int SMIOL_close_file(struct SMIOL_file **file)
  * code is returned.
  *
  ********************************************************************************/
-int SMIOL_define_dim(struct SMIOL_file *file, const char *dimname, int64_t dimsize)
+int SMIOL_define_dim(struct SMIOL_file *file, const char *dimname, SMIOL_Offset dimsize)
 {
 #ifdef SMIOL_PNETCDF
 	int dimidp;
@@ -336,14 +336,14 @@ int SMIOL_define_dim(struct SMIOL_file *file, const char *dimname, int64_t dimsi
 	/*
 	 * The parallel-netCDF library does not permit zero-length dimensions
 	 */
-	if (dimsize == 0) {
+	if (dimsize == (SMIOL_Offset)0) {
 		return SMIOL_INVALID_ARGUMENT;
 	}
 
 	/*
 	 * Handle unlimited / record dimension specifications
 	 */
-	if (dimsize < 0) {
+	if (dimsize < (SMIOL_Offset)0) {
 		len = NC_UNLIMITED;
 	}
 	else {
@@ -376,7 +376,7 @@ int SMIOL_define_dim(struct SMIOL_file *file, const char *dimname, int64_t dimsi
  * code is returned.
  *
  ********************************************************************************/
-int SMIOL_inquire_dim(struct SMIOL_file *file, const char *dimname, int64_t *dimsize)
+int SMIOL_inquire_dim(struct SMIOL_file *file, const char *dimname, SMIOL_Offset *dimsize)
 {
 #ifdef SMIOL_PNETCDF
 	int dimidp;
@@ -408,20 +408,20 @@ int SMIOL_inquire_dim(struct SMIOL_file *file, const char *dimname, int64_t *dim
 
 #ifdef SMIOL_PNETCDF
 	if ((ierr = ncmpi_inq_dimid(file->ncidp, dimname, &dimidp)) != NC_NOERR) {
-		(*dimsize) = -1;  /* TODO: should there be a well-defined invalid size? */
+		(*dimsize) = (SMIOL_Offset)(-1);  /* TODO: should there be a well-defined invalid size? */
 		file->context->lib_type = SMIOL_LIBRARY_PNETCDF;
 		file->context->lib_ierr = ierr;
 		return SMIOL_LIBRARY_ERROR;
 	}
 
 	if ((ierr = ncmpi_inq_dimlen(file->ncidp, dimidp, &len)) != NC_NOERR) {
-		(*dimsize) = -1;  /* TODO: should there be a well-defined invalid size? */
+		(*dimsize) = (SMIOL_Offset)(-1);  /* TODO: should there be a well-defined invalid size? */
 		file->context->lib_type = SMIOL_LIBRARY_PNETCDF;
 		file->context->lib_ierr = ierr;
 		return SMIOL_LIBRARY_ERROR;
 	}
 
-	(*dimsize) = (int64_t)len;
+	(*dimsize) = (SMIOL_Offset)len;
 #endif
 
 	return SMIOL_SUCCESS;

--- a/src/smiol.c
+++ b/src/smiol.c
@@ -367,11 +367,40 @@ int SMIOL_define_dim(struct SMIOL_file *file, const char *dimname, int64_t dimsi
  *
  * Inquires about an existing dimension in a file.
  *
- * Detailed description.
+ * Inquires about the size of an existing dimension in a file. For record
+ * dimensions, the current size of the dimension is returned; future writes of
+ * additional records to a file can lead to different return sizes for record
+ * dimensions.
+ *
+ * Upon successful completion, SMIOL_SUCCESS is returned; otherwise, an error
+ * code is returned.
  *
  ********************************************************************************/
-int SMIOL_inquire_dim(void)
+int SMIOL_inquire_dim(struct SMIOL_file *file, const char *dimname, int64_t *dimsize)
 {
+	/*
+	 * Check that file handle is valid
+	 */
+	if (file == NULL) {
+		return SMIOL_INVALID_ARGUMENT;
+	}
+
+	/*
+	 * Check that dimension name is valid
+	 */
+	if (dimname == NULL) {
+		return SMIOL_INVALID_ARGUMENT;
+	}
+
+	/*
+	 * Check that dimension size is not NULL
+	 */
+	if (dimsize == NULL) {
+		return SMIOL_INVALID_ARGUMENT;
+	}
+
+	(*dimsize) = 1;
+
 	return SMIOL_SUCCESS;
 }
 

--- a/src/smiol.c
+++ b/src/smiol.c
@@ -301,11 +301,32 @@ int SMIOL_close_file(struct SMIOL_file **file)
  *
  * Defines a new dimension in a file.
  *
- * Detailed description.
+ * Defines a dimension with the specified name and size in the file associated
+ * with the file handle. If a negative value is provided for the size argument,
+ * the dimension will be defined as an unlimited or record dimension.
+ *
+ * Upon successful completion, SMIOL_SUCCESS is returned; otherwise, an error
+ * code is returned.
  *
  ********************************************************************************/
-int SMIOL_define_dim(void)
+int SMIOL_define_dim(struct SMIOL_file *file, const char *dimname, int64_t dimsize)
 {
+	/*
+	 * Check that file handle is valid
+	 */
+	if (file == NULL) {
+		return SMIOL_INVALID_ARGUMENT;
+	}
+
+	/*
+	 * Check that dimension name is valid
+	 */
+	if (dimname == NULL) {
+		return SMIOL_INVALID_ARGUMENT;
+	}
+
+	fprintf(stderr, "Defining dimension %s = %li\n", dimname, (long int)dimsize);
+
 	return SMIOL_SUCCESS;
 }
 

--- a/src/smiol.h
+++ b/src/smiol.h
@@ -54,7 +54,7 @@ int SMIOL_close_file(struct SMIOL_file **file);
  * Dimension methods
  */
 int SMIOL_define_dim(struct SMIOL_file *file, const char *dimname, int64_t dimsize);
-int SMIOL_inquire_dim(void);
+int SMIOL_inquire_dim(struct SMIOL_file *file, const char *dimname, int64_t *dimsize);
 
 /*
  * Variable methods

--- a/src/smiol.h
+++ b/src/smiol.h
@@ -53,7 +53,7 @@ int SMIOL_close_file(struct SMIOL_file **file);
 /*
  * Dimension methods
  */
-int SMIOL_define_dim(void);
+int SMIOL_define_dim(struct SMIOL_file *file, const char *dimname, int64_t dimsize);
 int SMIOL_inquire_dim(void);
 
 /*

--- a/src/smiol.h
+++ b/src/smiol.h
@@ -5,6 +5,11 @@
 #include <stdint.h>
 #include "mpi.h"
 
+
+/* If SMIOL_Offset is redefined, interoperable Fortran types and interfaces must also be updated */
+typedef int64_t SMIOL_Offset;
+
+
 /*
  * Types
  */
@@ -31,10 +36,12 @@ struct SMIOL_decomp {
 	int64_t *io_elements;
 };
 
+
 /*
  * Return error codes
  */
 #include "smiol_codes.inc"
+
 
 /*
  * Library methods
@@ -53,8 +60,8 @@ int SMIOL_close_file(struct SMIOL_file **file);
 /*
  * Dimension methods
  */
-int SMIOL_define_dim(struct SMIOL_file *file, const char *dimname, int64_t dimsize);
-int SMIOL_inquire_dim(struct SMIOL_file *file, const char *dimname, int64_t *dimsize);
+int SMIOL_define_dim(struct SMIOL_file *file, const char *dimname, SMIOL_Offset dimsize);
+int SMIOL_inquire_dim(struct SMIOL_file *file, const char *dimname, SMIOL_Offset *dimsize);
 
 /*
  * Variable methods

--- a/src/smiolf.F90
+++ b/src/smiolf.F90
@@ -5,13 +5,15 @@
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 module SMIOLf
 
-    use iso_c_binding, only : c_int, c_size_t, c_ptr
+    use iso_c_binding, only : c_int, c_size_t, c_int64_t, c_ptr
 
     private
 
     public :: SMIOLf_context, &
               SMIOLf_decomp, &
               SMIOLf_file
+
+    public :: SMIOL_offset_kind
 
     public :: SMIOLf_init, &
               SMIOLf_finalize, &
@@ -32,6 +34,9 @@ module SMIOLf
               SMIOLf_set_option, &
               SMIOLf_create_decomp, &
               SMIOLf_free_decomp
+
+
+    integer, parameter :: SMIOL_offset_kind = c_int64_t
 
 
     type, bind(C) :: SMIOLf_context
@@ -335,14 +340,56 @@ contains
     !
     !> \brief Defines a new dimension in a file
     !> \details
-    !>  Detailed description of what this routine does.
+    !>  Defines a dimension with the specified name and size in the file associated
+    !>  with the file handle. If a negative value is provided for the size argument,
+    !>  the dimension will be defined as an unlimited or record dimension.
+    !>
+    !>  Upon successful completion, SMIOL_SUCCESS is returned; otherwise, an error
+    !>  code is returned.
     !
     !-----------------------------------------------------------------------
-    integer function SMIOLf_define_dim() result(ierr)
+    integer function SMIOLf_define_dim(file, dimname, dimsize) result(ierr)
+
+        use iso_c_binding, only : c_char, c_null_char, c_loc, c_ptr, c_null_ptr, c_associated
 
         implicit none
 
-        ierr = 0
+        type (SMIOLf_file), target :: file
+        character(len=*), intent(in) :: dimname
+        integer(kind=SMIOL_offset_kind), intent(in) :: dimsize
+
+        type (c_ptr) :: c_file
+        character(kind=c_char), dimension(:), pointer :: c_dimname
+
+        integer :: i
+
+        ! C interface definitions
+        interface
+            function SMIOL_define_dim(file, dimname, dimsize) result(ierr) bind(C, name='SMIOL_define_dim')
+                use iso_c_binding, only : c_ptr, c_char, c_int64_t, c_int
+                type (c_ptr), value :: file
+                character(kind=c_char), dimension(*) :: dimname
+                integer(kind=c_int64_t), value :: dimsize
+                integer(kind=c_int) :: ierr
+            end function
+        end interface
+
+        ! Get C address of file; there is no need to worry about an unassociated file here,
+        ! since the file argument is not a pointer
+        c_file = c_loc(file)
+
+        !
+        ! Convert Fortran string to C character array
+        !
+        allocate(c_dimname(len_trim(dimname) + 1))
+        do i=1,len_trim(dimname)
+            c_dimname(i) = dimname(i:i)
+        end do
+        c_dimname(i) = c_null_char
+
+        ierr = SMIOL_define_dim(c_file, c_dimname, dimsize)
+
+        deallocate(c_dimname)
 
     end function SMIOLf_define_dim
 

--- a/src/smiolf.F90
+++ b/src/smiolf.F90
@@ -36,7 +36,7 @@ module SMIOLf
               SMIOLf_free_decomp
 
 
-    integer, parameter :: SMIOL_offset_kind = c_int64_t
+    integer, parameter :: SMIOL_offset_kind = c_int64_t   ! Must match SMIOL_Offset in smiol.h
 
 
     type, bind(C) :: SMIOLf_context
@@ -366,10 +366,11 @@ contains
         ! C interface definitions
         interface
             function SMIOL_define_dim(file, dimname, dimsize) result(ierr) bind(C, name='SMIOL_define_dim')
-                use iso_c_binding, only : c_ptr, c_char, c_int64_t, c_int
+                use iso_c_binding, only : c_ptr, c_char, c_int
+                import SMIOL_offset_kind
                 type (c_ptr), value :: file
                 character(kind=c_char), dimension(*) :: dimname
-                integer(kind=c_int64_t), value :: dimsize
+                integer(kind=SMIOL_offset_kind), value :: dimsize
                 integer(kind=c_int) :: ierr
             end function
         end interface
@@ -426,10 +427,11 @@ contains
         ! C interface definitions
         interface
             function SMIOL_inquire_dim(file, dimname, dimsize) result(ierr) bind(C, name='SMIOL_inquire_dim')
-                use iso_c_binding, only : c_ptr, c_char, c_int64_t, c_int
+                use iso_c_binding, only : c_ptr, c_char, c_int
+                import SMIOL_offset_kind
                 type (c_ptr), value :: file
                 character(kind=c_char), dimension(*) :: dimname
-                integer(kind=c_int64_t) :: dimsize
+                integer(kind=SMIOL_offset_kind) :: dimsize
                 integer(kind=c_int) :: ierr
             end function
         end interface


### PR DESCRIPTION
This merge provides C and Fortran implementations for the SMIOL routines for defining
and inquiring about dimensions in a file. Unit tests in C an Fortran are also included for
the dimension routines.