### PR TITLE
Fix format for number of error message

### DIFF
--- a/smiol_runner.F90
+++ b/smiol_runner.F90
@@ -32,7 +32,7 @@ program smiol_runner
         stop 1
     end if
 
-    write(log_fname, '(a,I4.4,a)') "smiolf.", my_proc_id, ".test"
+    write(log_fname, '(a,i4.4,a)') "smiolf.", my_proc_id, ".test"
     open(unit=test_log, file=log_fname, status='replace')
 
     !
@@ -43,7 +43,7 @@ program smiol_runner
         write(test_log,'(a)') 'All tests PASSED!'
         write(test_log,'(a)') ''
     else
-        write(test_log,'(a)') ierr, ' tests FAILED!'
+        write(test_log,'(i3,a)') ierr, ' tests FAILED!'
         write(test_log,'(a)') ''
     end if
 
@@ -55,7 +55,7 @@ program smiol_runner
         write(test_log,'(a)') 'All tests PASSED!'
         write(test_log,'(a)') ''
     else
-        write(test_log,'(a)') ierr, ' tests FAILED!'
+        write(test_log,'(i3,a)') ierr, ' tests FAILED!'
         write(test_log,'(a)') ''
     end if
 
@@ -67,7 +67,7 @@ program smiol_runner
         write(test_log,'(a)') 'All tests PASSED!'
         write(test_log,'(a)') ''
     else
-        write(test_log,'(a)') ierr, ' tests FAILED!'
+        write(test_log,'(i3,a)') ierr, ' tests FAILED!'
         write(test_log,'(a)') ''
     endif
 


### PR DESCRIPTION
The format to print the number of error messages of a unit test function did
not include a format specification for the 'ierr' integer value. Thus, if any
errors occured, `ierr` would not be printed as an ASCII string.