### PR TITLE
Re-add definition of 'Time' in runner programs

### DIFF
--- a/smiol_runner.F90
+++ b/smiol_runner.F90
@@ -134,6 +134,11 @@ program smiol_runner
         stop 1
     endif
 
+    if (SMIOLf_define_dim(file, 'Time', -1_SMIOL_offset_kind) /= SMIOL_SUCCESS) then
+        write(test_log,'(a)') "ERROR: 'SMIOLf_define_dim' was not called successfully"
+        stop 1
+    endif
+
     if (SMIOLf_sync_file(file) /= SMIOL_SUCCESS) then
         write(test_log,'(a)') "ERROR: 'SMIOLf_sync_file' was not called successfully"
         stop 1

--- a/smiol_runner.c
+++ b/smiol_runner.c
@@ -154,6 +154,11 @@ int main(int argc, char **argv)
 		return 1;
 	}
 
+	if ((ierr = SMIOL_define_dim(file, "Time", -1)) != SMIOL_SUCCESS) {
+		fprintf(test_log, "ERROR: SMIOL_define_dim: %s ", SMIOL_error_string(ierr));
+		return 1;
+	}
+
 	if ((ierr = SMIOL_sync_file(file)) != SMIOL_SUCCESS) {
 		fprintf(test_log, "ERROR: SMIOL_sync_file: %s ",
 			SMIOL_error_string(ierr));


### PR DESCRIPTION
The merge in commit e7aeb4c accidentally removed the definition of the 'Time'
dimension in the SMIOL runner program's main function. This commit re-adds the
definition into both runner programs.