### PR TITLE
Update decomp interfaces in preperation for decomp implementation

### DIFF
--- a/smiol_runner.F90
+++ b/smiol_runner.F90
@@ -2,7 +2,7 @@
 
 program smiol_runner
 
-    use iso_c_binding, only : c_size_t, c_int64_t
+    use iso_c_binding, only : c_size_t
     use SMIOLf
     use mpi
 
@@ -11,10 +11,10 @@ program smiol_runner
     integer :: ierr
     integer :: my_proc_id
     integer :: test_log = 42
-    integer(c_size_t) :: n_compute_elements = 1
-    integer(c_size_t) :: n_io_elements = 1
-    integer(c_int64_t), dimension(:), pointer :: compute_elements
-    integer(c_int64_t), dimension(:), pointer :: io_elements
+    integer(kind=c_size_t) :: n_compute_elements = 1
+    integer(kind=c_size_t) :: n_io_elements = 1
+    integer(kind=SMIOL_offset_kind), dimension(:), pointer :: compute_elements
+    integer(kind=SMIOL_offset_kind), dimension(:), pointer :: io_elements
     type (SMIOLf_decomp), pointer :: decomp => null()
     type (SMIOLf_context), pointer :: context => null()
     type (SMIOLf_file), pointer :: file => null()
@@ -111,7 +111,8 @@ program smiol_runner
     allocate(compute_elements(n_compute_elements))
     allocate(io_elements(n_io_elements))
 
-    if (SMIOLf_create_decomp(n_compute_elements, n_io_elements, compute_elements, io_elements, decomp) /= SMIOL_SUCCESS) then
+    if (SMIOLf_create_decomp(context, n_compute_elements, compute_elements, &
+                             n_io_elements, io_elements, decomp) /= SMIOL_SUCCESS) then
         write(test_log,'(a)') "Error: SMIOLf_create_decomp was not called successfully"
         stop 1
     endif
@@ -501,16 +502,17 @@ contains
 
     function test_decomp(test_log) result(ierrcount)
 
-        use iso_c_binding, only : c_size_t, c_int64_t
+        use iso_c_binding, only : c_size_t
 
         implicit none
 
         integer, intent(in) :: test_log
         integer :: ierrcount
-        integer(c_size_t) :: n_compute_elements
-        integer(c_size_t) :: n_io_elements
-        integer(c_int64_t), dimension(:), pointer :: compute_elements
-        integer(c_int64_t), dimension(:), pointer :: io_elements
+        integer(kind=c_size_t) :: n_compute_elements
+        integer(kind=c_size_t) :: n_io_elements
+        integer(kind=SMIOL_offset_kind), dimension(:), pointer :: compute_elements
+        integer(kind=SMIOL_offset_kind), dimension(:), pointer :: io_elements
+        type (SMIOLf_context), pointer :: context
         type (SMIOLf_decomp), pointer :: decomp => null()
 
         write(test_log,'(a)') '********************************************************************************'
@@ -519,13 +521,21 @@ contains
 
         ierrcount = 0
 
+        ! Create a SMIOL context for testing decomp routines
+        nullify(context)
+        ierr = SMIOLf_init(MPI_COMM_WORLD, context)
+        if (ierr /= SMIOL_SUCCESS .or. .not. associated(context)) then
+            ierrcount = -1
+            return
+        end if
+
         ! Test with 0 elements
         write(test_log,'(a)',advance='no') 'Everything OK for SMIOLf_create_decomp with 0 elements: '
         n_compute_elements = 0
         n_io_elements = 0
         allocate(compute_elements(n_compute_elements))
         allocate(io_elements(n_io_elements))
-        ierr = SMIOLf_create_decomp(n_compute_elements, n_io_elements, compute_elements, io_elements, decomp)
+        ierr = SMIOLf_create_decomp(context, n_compute_elements, compute_elements, n_io_elements, io_elements, decomp)
         if (ierr == SMIOL_SUCCESS .and. associated(decomp)) then
             write(test_log,'(a)') "PASS"
         else if (ierr /= SMIOL_SUCCESS .and. .not. associated(decomp)) then
@@ -558,7 +568,7 @@ contains
         n_io_elements = 1
         allocate(compute_elements(n_compute_elements))
         allocate(io_elements(n_io_elements))
-        ierr = SMIOLf_create_decomp(n_compute_elements, n_io_elements, compute_elements, io_elements, decomp)
+        ierr = SMIOLf_create_decomp(context, n_compute_elements, compute_elements, n_io_elements, io_elements, decomp)
         if (ierr == SMIOL_SUCCESS .and. associated(decomp)) then
             write(test_log,'(a)') "PASS"
         else if (ierr /= SMIOL_SUCCESS .and. .not. associated(decomp)) then
@@ -591,7 +601,7 @@ contains
         n_io_elements = 10000000
         allocate(compute_elements(n_compute_elements))
         allocate(io_elements(n_io_elements))
-        ierr = SMIOLf_create_decomp(n_compute_elements, n_io_elements, compute_elements, io_elements, decomp)
+        ierr = SMIOLf_create_decomp(context, n_compute_elements, compute_elements, n_io_elements, io_elements, decomp)
         if (ierr == SMIOL_SUCCESS .and. associated(decomp)) then
             write(test_log,'(a)') "PASS"
         else if (ierr /= SMIOL_SUCCESS .and. .not. associated(decomp)) then
@@ -630,6 +640,13 @@ contains
             write(test_log,'(a)') "FAIL - ierr returned SMIOL_SUCCESS, but the decomp became associated..."
             ierrcount = ierrcount + 1
         endif
+
+        ! Free the SMIOL context
+        ierr = SMIOLf_finalize(context)
+        if (ierr /= SMIOL_SUCCESS .or. associated(context)) then
+            ierrcount = -1
+            return
+        end if
 
         write(test_log,'(a)') ''
 

--- a/smiol_runner.F90
+++ b/smiol_runner.F90
@@ -538,11 +538,8 @@ contains
         ierr = SMIOLf_create_decomp(context, n_compute_elements, compute_elements, n_io_elements, io_elements, decomp)
         if (ierr == SMIOL_SUCCESS .and. associated(decomp)) then
             write(test_log,'(a)') "PASS"
-        else if (ierr /= SMIOL_SUCCESS .and. .not. associated(decomp)) then
-            write(test_log,'(a)') "FAIL - SMIOLf_create_decomp returned an error and decomp was not associated"
-            ierrcount = ierrcount + 1
-        else if (ierr == SMIOL_SUCCESS .and. .not. associated(decomp)) then
-            write(test_log,'(a)') "FAIL - ierr returned success but decomp was NOT associated when it should have been"
+        else
+            write(test_log, '(a)') "FAIL - Either SMIOL_SUCCESS was not returned or decomp was not associated"
             ierrcount = ierrcount + 1
         endif
 
@@ -571,11 +568,8 @@ contains
         ierr = SMIOLf_create_decomp(context, n_compute_elements, compute_elements, n_io_elements, io_elements, decomp)
         if (ierr == SMIOL_SUCCESS .and. associated(decomp)) then
             write(test_log,'(a)') "PASS"
-        else if (ierr /= SMIOL_SUCCESS .and. .not. associated(decomp)) then
-            write(test_log,'(a)') "FAIL - SMIOLf_create_decomp returned an error and decomp was not associated"
-            ierrcount = ierrcount + 1
-        else if (ierr == SMIOL_SUCCESS .and. .not. associated(decomp)) then
-            write(test_log,'(a)') "FAIL - ierr returned success but decomp was NOT associated when it should have been"
+        else
+            write(test_log, '(a)') "FAIL - Either SMIOL_SUCCESS was not returned or decomp was not associated"
             ierrcount = ierrcount + 1
         endif
 
@@ -604,11 +598,8 @@ contains
         ierr = SMIOLf_create_decomp(context, n_compute_elements, compute_elements, n_io_elements, io_elements, decomp)
         if (ierr == SMIOL_SUCCESS .and. associated(decomp)) then
             write(test_log,'(a)') "PASS"
-        else if (ierr /= SMIOL_SUCCESS .and. .not. associated(decomp)) then
-            write(test_log,'(a)') "FAIL - SMIOLf_create_decomp returned an error and decomp was not associated"
-            ierrcount = ierrcount + 1
-        else if (ierr == SMIOL_SUCCESS .and. .not. associated(decomp)) then
-            write(test_log,'(a)') "FAIL - ierr returned success but decomp was NOT associated when it should have been"
+        else
+            write(test_log, '(a)') "FAIL - Either SMIOL_SUCCESS was not returned or decomp was not associated"
             ierrcount = ierrcount + 1
         endif
 

--- a/smiol_runner.c
+++ b/smiol_runner.c
@@ -120,9 +120,9 @@ int main(int argc, char **argv)
 	compute_elements = malloc(sizeof(SMIOL_Offset) * n_compute_elements);
 	io_elements = malloc(sizeof(SMIOL_Offset) * n_io_elements);
 
-	decomp = SMIOL_create_decomp(context, n_compute_elements, compute_elements, n_io_elements, io_elements);
-	if (decomp == NULL) {
-		printf("ERROR: SMIOL_create_decomp - Decomp was not allocated\n");
+	ierr = SMIOL_create_decomp(context, n_compute_elements, compute_elements, n_io_elements, io_elements, &decomp);
+	if (ierr != SMIOL_SUCCESS) {
+		printf("ERROR: SMIOL_create_decomp - SMIOL_SUCCESS was not returned\n");
 		return 1;
 	}
 
@@ -573,15 +573,17 @@ int test_decomp(FILE *test_log)
 		return -1;
 	}
 
-	/* Create decomp with io_elements and compute_elements == NULL */
-	fprintf(test_log, "Everything OK (SMIOL_create_decomp) with NULL elements: ");
-	n_compute_elements = 0;
-	n_io_elements = 0;
-	decomp = SMIOL_create_decomp(context, n_compute_elements, compute_elements, n_io_elements, io_elements);
-	if (decomp != NULL) {
+	/* Test create decomp with io_elements and compute_elements == NULL and
+	 * n_io_elements and n_compute != 0 */
+	fprintf(test_log, "Testing SMIOL_create_decomp with NULL elements and n_elements != 0: ");
+	n_compute_elements = 1;
+	n_io_elements = 1;
+	ierr = SMIOL_create_decomp(context, n_compute_elements, compute_elements, n_io_elements, io_elements, &decomp);
+	if (ierr == SMIOL_INVALID_ARGUMENT && decomp == NULL) {
 		fprintf(test_log, "PASS\n");
 	} else {
-		fprintf(test_log, "FAIL - decomp was returned as NULL\n");
+		fprintf(test_log, "FAIL - Either SMIOL_INVALID_ARGUMENT was not returned or DECOMP was not NULL\n");
+		errcount++;
 	}
 
 	fprintf(test_log, "Everything OK (SMIOL_free_decomp) with NULL elements: ");
@@ -603,11 +605,11 @@ int test_decomp(FILE *test_log)
 	n_io_elements = 0;
 	compute_elements = malloc(sizeof(SMIOL_Offset) * n_compute_elements);
 	io_elements = malloc(sizeof(SMIOL_Offset) * n_io_elements);
-	decomp = SMIOL_create_decomp(context, n_compute_elements, compute_elements, n_io_elements, io_elements);
-	if (decomp != NULL) {
+	ierr = SMIOL_create_decomp(context, n_compute_elements, compute_elements, n_io_elements, io_elements, &decomp);
+	if (ierr == SMIOL_SUCCESS && decomp != NULL) {
 		fprintf(test_log, "PASS\n");
 	} else {
-		fprintf(test_log, "FAIL - decomp was returned as null\n");
+		fprintf(test_log, "FAIL - SMIOL_SUCCESS was not returned or decomp was NULL\n");
 		errcount++;
 	}
 	free(compute_elements);
@@ -637,11 +639,11 @@ int test_decomp(FILE *test_log)
 	n_io_elements = 1;
 	compute_elements = malloc(sizeof(SMIOL_Offset) * n_compute_elements);
 	io_elements = malloc(sizeof(SMIOL_Offset) * n_io_elements);
-	decomp = SMIOL_create_decomp(context, n_compute_elements, compute_elements, n_io_elements, io_elements);
-	if (decomp != NULL) {
+	ierr = SMIOL_create_decomp(context, n_compute_elements, compute_elements, n_io_elements, io_elements, &decomp);
+	if (ierr == SMIOL_SUCCESS && decomp != NULL) {
 		fprintf(test_log, "PASS\n");
 	} else {
-		fprintf(test_log, "FAIL - decomp was returned as NULL\n");
+		fprintf(test_log, "FAIL - SMIOL_SUCCESS was not returned or decomp was NULL\n");
 		errcount++;
 	}
 	free(compute_elements);
@@ -670,11 +672,11 @@ int test_decomp(FILE *test_log)
 	n_io_elements = 100000000;
 	compute_elements = malloc(sizeof(SMIOL_Offset) * n_compute_elements);
 	io_elements = malloc(sizeof(SMIOL_Offset) * n_io_elements);
-	decomp = SMIOL_create_decomp(context, n_compute_elements, compute_elements, n_io_elements, io_elements);
-	if (decomp != NULL) {
+	ierr = SMIOL_create_decomp(context, n_compute_elements, compute_elements, n_io_elements, io_elements, &decomp);
+	if (ierr == SMIOL_SUCCESS && decomp != NULL) {
 		fprintf(test_log, "PASS\n");
 	} else {
-		fprintf(test_log, "FAIL - decomp was returned as NULL\n");
+		fprintf(test_log, "FAIL - SMIOL_SUCCESS was not returned or decomp was NULL\n");
 		errcount++;
 	}
 	free(compute_elements);

--- a/src/smiol.c
+++ b/src/smiol.c
@@ -683,29 +683,27 @@ struct SMIOL_decomp *SMIOL_create_decomp(struct SMIOL_context *context,
 	size_t i;
 
 	d = malloc(sizeof(struct SMIOL_decomp));
-	d->n_compute_elements = n_compute_elements;
-	d->n_io_elements = n_io_elements;
 
-	d->compute_elements = malloc(sizeof(SMIOL_Offset) * d->n_compute_elements);
-	if (d->compute_elements == NULL) {
-		fprintf(stderr, "ERROR: Could not malloc space for d->compute_elements\n");
+	d->comp_list = malloc(sizeof(SMIOL_Offset) * n_compute_elements);
+	if (d->comp_list == NULL) {
+		fprintf(stderr, "ERROR: Could not malloc space for d->comp_list\n");
 		return NULL;
 	}
 
-	d->io_elements = malloc(sizeof(SMIOL_Offset) * d->n_io_elements);
-	if (d->io_elements == NULL) {
-		fprintf(stderr, "ERROR: Could not malloc space for d->io_elements\n");
+	d->io_list = malloc(sizeof(SMIOL_Offset) * n_io_elements);
+	if (d->io_list == NULL) {
+		fprintf(stderr, "ERROR: Could not malloc space for d->io_list\n");
 		return NULL;
 	}
 
 	// Copy compute elements
-	for (i = 0; i < d->n_compute_elements; i++) {
-		d->compute_elements[i] = compute_elements[i];
+	for (i = 0; i < n_compute_elements; i++) {
+		d->comp_list[i] = compute_elements[i];
 	}
 
 	// Copy io elements
-	for (i = 0; i < d->n_io_elements; i++) {
-		d->io_elements[i] = io_elements[i];
+	for (i = 0; i < n_io_elements; i++) {
+		d->io_list[i] = io_elements[i];
 	}
 
 	return d;
@@ -729,8 +727,8 @@ int SMIOL_free_decomp(struct SMIOL_decomp **d)
 		return SMIOL_SUCCESS;
 	}
 
-	free((*d)->compute_elements);
-	free((*d)->io_elements);
+	free((*d)->comp_list);
+	free((*d)->io_list);
 	free((*d));
 	*d = NULL;
 

--- a/src/smiol.c
+++ b/src/smiol.c
@@ -675,38 +675,57 @@ int SMIOL_set_option(void)
  * success, return a valid SMIOL decomp; otherwise return NULL.
  *
  ********************************************************************************/
-struct SMIOL_decomp *SMIOL_create_decomp(struct SMIOL_context *context,
-                                         size_t n_compute_elements, SMIOL_Offset *compute_elements,
-                                         size_t n_io_elements, SMIOL_Offset *io_elements)
+int SMIOL_create_decomp(struct SMIOL_context *context,
+                        size_t n_compute_elements,
+                        SMIOL_Offset *compute_elements,
+                        size_t n_io_elements,
+                        SMIOL_Offset *io_elements,
+                        struct SMIOL_decomp **decomp)
 {
-	struct SMIOL_decomp *d;
 	size_t i;
 
-	d = malloc(sizeof(struct SMIOL_decomp));
-
-	d->comp_list = malloc(sizeof(SMIOL_Offset) * n_compute_elements);
-	if (d->comp_list == NULL) {
-		fprintf(stderr, "ERROR: Could not malloc space for d->comp_list\n");
-		return NULL;
+	if (context == NULL) {
+		return SMIOL_INVALID_ARGUMENT;
 	}
 
-	d->io_list = malloc(sizeof(SMIOL_Offset) * n_io_elements);
-	if (d->io_list == NULL) {
-		fprintf(stderr, "ERROR: Could not malloc space for d->io_list\n");
-		return NULL;
+	if (compute_elements == NULL && n_compute_elements != 0) {
+		return SMIOL_INVALID_ARGUMENT;
+	}
+
+	if (io_elements == NULL && n_io_elements != 0) {
+		return SMIOL_INVALID_ARGUMENT;
+	}
+
+	*decomp = malloc(sizeof(struct SMIOL_decomp));
+	if ((*decomp) == NULL) {
+		return SMIOL_MALLOC_FAILURE;
+	}
+
+	(*decomp)->comp_list = malloc(sizeof(SMIOL_Offset) * n_compute_elements);
+	if ((*decomp)->comp_list == NULL) {
+		free(*decomp);
+		*decomp = NULL;
+		return SMIOL_MALLOC_FAILURE;
+	}
+
+	(*decomp)->io_list = malloc(sizeof(SMIOL_Offset) * n_io_elements);
+	if ((*decomp)->io_list == NULL) {
+		free(*decomp);
+		*decomp = NULL;
+		return SMIOL_MALLOC_FAILURE;
 	}
 
 	// Copy compute elements
 	for (i = 0; i < n_compute_elements; i++) {
-		d->comp_list[i] = compute_elements[i];
+		(*decomp)->comp_list[i] = compute_elements[i];
 	}
 
 	// Copy io elements
 	for (i = 0; i < n_io_elements; i++) {
-		d->io_list[i] = io_elements[i];
+		(*decomp)->io_list[i] = io_elements[i];
 	}
 
-	return d;
+	return SMIOL_SUCCESS;
 }
 
 

--- a/src/smiol.c
+++ b/src/smiol.c
@@ -740,16 +740,16 @@ int SMIOL_create_decomp(struct SMIOL_context *context,
  * is called, no other SMIOL routines should use the freed SMIOL_decomp.
  *
  ********************************************************************************/
-int SMIOL_free_decomp(struct SMIOL_decomp **d)
+int SMIOL_free_decomp(struct SMIOL_decomp **decomp)
 {
-	if ((*d) == NULL) {
+	if ((*decomp) == NULL) {
 		return SMIOL_SUCCESS;
 	}
 
-	free((*d)->comp_list);
-	free((*d)->io_list);
-	free((*d));
-	*d = NULL;
+	free((*decomp)->comp_list);
+	free((*decomp)->io_list);
+	free((*decomp));
+	*decomp = NULL;
 
 	return SMIOL_SUCCESS;
 }

--- a/src/smiol.c
+++ b/src/smiol.c
@@ -675,9 +675,9 @@ int SMIOL_set_option(void)
  * success, return a valid SMIOL decomp; otherwise return NULL.
  *
  ********************************************************************************/
-struct SMIOL_decomp *SMIOL_create_decomp(size_t n_compute_elements,
-		size_t n_io_elements, int64_t *compute_elements,
-		int64_t *io_elements)
+struct SMIOL_decomp *SMIOL_create_decomp(struct SMIOL_context *context,
+                                         size_t n_compute_elements, SMIOL_Offset *compute_elements,
+                                         size_t n_io_elements, SMIOL_Offset *io_elements)
 {
 	struct SMIOL_decomp *d;
 	size_t i;
@@ -686,13 +686,13 @@ struct SMIOL_decomp *SMIOL_create_decomp(size_t n_compute_elements,
 	d->n_compute_elements = n_compute_elements;
 	d->n_io_elements = n_io_elements;
 
-	d->compute_elements = malloc(sizeof(int64_t) * d->n_compute_elements);
+	d->compute_elements = malloc(sizeof(SMIOL_Offset) * d->n_compute_elements);
 	if (d->compute_elements == NULL) {
 		fprintf(stderr, "ERROR: Could not malloc space for d->compute_elements\n");
 		return NULL;
 	}
 
-	d->io_elements = malloc(sizeof(int64_t) * d->n_io_elements);
+	d->io_elements = malloc(sizeof(SMIOL_Offset) * d->n_io_elements);
 	if (d->io_elements == NULL) {
 		fprintf(stderr, "ERROR: Could not malloc space for d->io_elements\n");
 		return NULL;

--- a/src/smiol.h
+++ b/src/smiol.h
@@ -96,7 +96,8 @@ int SMIOL_set_option(void);
 /*
  * Decomposition methods
  */
-struct SMIOL_decomp *SMIOL_create_decomp(struct SMIOL_context *context,
-                                         size_t n_compute_elements, SMIOL_Offset *compute_elements,
-                                         size_t n_io_elements, SMIOL_Offset *io_elements);
+int SMIOL_create_decomp(struct SMIOL_context *context,
+                        size_t n_compute_elements, SMIOL_Offset *compute_elements,
+                        size_t n_io_elements, SMIOL_Offset *io_elements,
+                        struct SMIOL_decomp **decomp);
 int SMIOL_free_decomp(struct SMIOL_decomp **d);

--- a/src/smiol.h
+++ b/src/smiol.h
@@ -31,10 +31,17 @@ struct SMIOL_file {
 };
 
 struct SMIOL_decomp {
-	size_t n_compute_elements;
-	size_t n_io_elements;
-	SMIOL_Offset *compute_elements;
-	SMIOL_Offset *io_elements;
+	/*
+	 * The lists below are structured as follows:
+	 *   list[0] - the number of neighbors for which a task sends/recvs
+	 *                                                                             |
+	 *   list[n] - neighbor task ID                                                | repeated for
+	 *   list[n+1] - number of elements, m, to send/recv to/from the neighbor      | each neighbor
+	 *   list[n+2 .. n+2+m] - local element IDs to send/recv to/from the neighbor  |
+	 *                                                                             |
+	 */
+	SMIOL_Offset *comp_list;   /* Elements to be sent/received from/on a compute task */
+	SMIOL_Offset *io_list;     /* Elements to be sent/received from/on an I/O task */
 };
 
 

--- a/src/smiol.h
+++ b/src/smiol.h
@@ -33,8 +33,8 @@ struct SMIOL_file {
 struct SMIOL_decomp {
 	size_t n_compute_elements;
 	size_t n_io_elements;
-	int64_t *compute_elements;
-	int64_t *io_elements;
+	SMIOL_Offset *compute_elements;
+	SMIOL_Offset *io_elements;
 };
 
 
@@ -89,7 +89,7 @@ int SMIOL_set_option(void);
 /*
  * Decomposition methods
  */
-struct SMIOL_decomp *SMIOL_create_decomp(size_t n_compute_elements,
-		size_t n_io_elements, int64_t *compute_elements,
-		int64_t *io_elements);
+struct SMIOL_decomp *SMIOL_create_decomp(struct SMIOL_context *context,
+                                         size_t n_compute_elements, SMIOL_Offset *compute_elements,
+                                         size_t n_io_elements, SMIOL_Offset *io_elements);
 int SMIOL_free_decomp(struct SMIOL_decomp **d);

--- a/src/smiol.h
+++ b/src/smiol.h
@@ -100,4 +100,4 @@ int SMIOL_create_decomp(struct SMIOL_context *context,
                         size_t n_compute_elements, SMIOL_Offset *compute_elements,
                         size_t n_io_elements, SMIOL_Offset *io_elements,
                         struct SMIOL_decomp **decomp);
-int SMIOL_free_decomp(struct SMIOL_decomp **d);
+int SMIOL_free_decomp(struct SMIOL_decomp **decomp);

--- a/src/smiolf.F90
+++ b/src/smiolf.F90
@@ -763,19 +763,20 @@ contains
         type (SMIOLf_decomp), pointer, intent(inout) :: decomp
 
         type (c_ptr) :: c_context = c_null_ptr
+        type (c_ptr) :: c_decomp = c_null_ptr
         type (c_ptr) :: c_compute_elements = c_null_ptr
         type (c_ptr) :: c_io_elements = c_null_ptr
-        type (c_ptr) :: c_decomp = c_null_ptr
         
         interface
-            function SMIOL_create_decomp(context, n_compute_elements, compute_elements, n_io_elements, io_elements) &
-                                         result(decomp) bind(C, name='SMIOL_create_decomp')
-                use iso_c_binding, only : c_size_t, c_ptr
+            function SMIOL_create_decomp(context, n_compute_elements, compute_elements, n_io_elements, io_elements, decomp) &
+                                         result(ierr) bind(C, name='SMIOL_create_decomp')
+                use iso_c_binding, only : c_size_t, c_ptr, c_int
                 type (c_ptr), value :: context
                 integer(c_size_t), value :: n_compute_elements
                 type(c_ptr), value :: compute_elements
                 integer(c_size_t), value :: n_io_elements
                 type(c_ptr), value :: io_elements
+                integer(kind=c_int) :: ierr
                 type(c_ptr) :: decomp
             end function
         end interface
@@ -792,7 +793,7 @@ contains
         c_io_elements = c_loc(io_elements)
 
         ! Create SMIOL_decomp type via c SMIOL_create_decomp
-        c_decomp = SMIOL_create_decomp(c_context, n_compute_elements, c_compute_elements, n_io_elements, c_io_elements)
+        ierr = SMIOL_create_decomp(c_context, n_compute_elements, c_compute_elements, n_io_elements, c_io_elements, c_decomp)
 
         ! Error check and translate c_decomp ptr into Fortran SMIOLf_decomp 
         if (.not. c_associated(c_decomp)) then

--- a/src/smiolf.F90
+++ b/src/smiolf.F90
@@ -57,10 +57,17 @@ module SMIOLf
     end type SMIOLf_file
 
     type, bind(C) :: SMIOLf_decomp
-        integer(c_size_t) :: n_compute_elements
-        integer(c_size_t) :: n_io_elements
-        type(c_ptr) :: compute_elements
-        type(c_ptr) :: io_elements
+        !
+        ! The lists below are structured (in C) as follows:
+        !   list[0] - the number of neighbors for which a task sends/recvs
+        !                                                                             |
+        !   list[n] - neighbor task ID                                                | repeated for
+        !   list[n+1] - number of elements, m, to send/recv to/from the neighbor      | each neighbor
+        !   list[n+2 .. n+2+m] - local element IDs to send/recv to/from the neighbor  |
+        !                                                                             |
+        !
+        type(c_ptr) :: comp_list  ! Elements to be sent/received from/on a compute task
+        type(c_ptr) :: io_list    ! Elements to be send/received from/on an I/O task
     end type SMIOLf_decomp
 
 


### PR DESCRIPTION
These commits contain changes that update the interfaces of `SMIOL(f)_create_decomp` (and `SMIOL_free_decomp`) for preparation of the implementation of create decomp implementation.