### PR TITLE
Add SMIOL utilities for sorting and searching lists of triplets

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1,11 +1,12 @@
 all: smiol
 
 smiol:
+	$(CC) $(CPPINCLUDES) $(CFLAGS) -c smiol_utils.c
 	$(CC) $(CPPINCLUDES) $(CFLAGS) -c smiol.c
 	$(FC) $(CPPINCLUDES) $(FFLAGS) -c smiolf.F90
-	ar cr ../libsmiol.a smiol.o
+	ar cr ../libsmiol.a smiol.o smiol_utils.o
 	ar cr ../libsmiolf.a smiolf.o
 
 clean:
-	$(RM) -f smiol.o ../libsmiol.a
+	$(RM) -f smiol.o smiol_utils.o ../libsmiol.a
 	$(RM) -f smiolf.o smiolf.mod ../libsmiolf.a

--- a/src/smiol_utils.c
+++ b/src/smiol_utils.c
@@ -1,0 +1,220 @@
+#include <stdlib.h>
+#include "smiol_utils.h"
+
+/*
+ * Prototypes for functions used only internally by SMIOL utilities
+ */
+static int comp_sort_0(const void *a, const void *b);
+static int comp_sort_1(const void *a, const void *b);
+static int comp_sort_2(const void *a, const void *b);
+static int comp_search_0(const void *a, const void *b);
+static int comp_search_1(const void *a, const void *b);
+static int comp_search_2(const void *a, const void *b);
+
+
+/*******************************************************************************
+ *
+ * sort_triplet_array
+ *
+ * Sorts an array of triplets of int64_t values in ascending order
+ *
+ * Given a pointer to an array of int64_t triplets, sorts the array in ascending
+ * order on the specified entry: 0 sorts on the first value in the triplets,
+ * 1 sorts on the second value, and 2 sorts on the third.
+ *
+ * If the sort_entry is 1 or 2, the relative position of two triplets whose
+ * values in that entry match will be determined by their values in the first
+ * entry.
+ *
+ * The sort is not guaranteed to be stable.
+ *
+ *******************************************************************************/
+void sort_triplet_array(size_t n_arr, int64_t *arr, int sort_entry)
+{
+	switch (sort_entry) {
+	case 0:
+		qsort((void *)arr, n_arr, sizeof(int64_t) * TRIPLET_SIZE,
+		      comp_sort_0);
+		break;
+	case 1:
+		qsort((void *)arr, n_arr, sizeof(int64_t) * TRIPLET_SIZE,
+		      comp_sort_1);
+		break;
+	case 2:
+		qsort((void *)arr, n_arr, sizeof(int64_t) * TRIPLET_SIZE,
+		      comp_sort_2);
+		break;
+	}
+}
+
+
+/*******************************************************************************
+ *
+ * search_triplet_array
+ *
+ * Searches a sorted array of triplets of int64_t values
+ *
+ * Given a pointer to a sorted array of int64_t triplets, searches the array on
+ * the specified entry for the key value. A search_entry value of 0 searches for
+ * the key in the first entry of each triplet, 1 searches in the second entry,
+ * and 2 searches in the third.
+ *
+ * If the key is found, the address of the triplet will be returned; otherwise,
+ * a NULL pointer is returned.
+ *
+ * If the key occurs in more than one triplet at the specified entry, there is
+ * no guarantee as to which triplet's address will be returned.
+ *
+ *******************************************************************************/
+int64_t *search_triplet_array(int64_t key, size_t n_arr, int64_t *arr,
+                              int search_entry)
+{
+	int64_t *res;
+	int64_t key3[TRIPLET_SIZE];
+
+	key3[search_entry] = key;
+
+	switch (search_entry) {
+	case 0:
+		res = (int64_t *)bsearch((const void *)&key3, (const void *)arr,
+		                         n_arr, sizeof(int64_t) * TRIPLET_SIZE,
+		                         comp_search_0);
+		break;
+	case 1:
+		res = (int64_t *)bsearch((const void *)&key3, (const void *)arr,
+		                         n_arr, sizeof(int64_t) * TRIPLET_SIZE,
+		                         comp_search_1);
+		break;
+	case 2:
+		res = (int64_t *)bsearch((const void *)&key3, (const void *)arr,
+		                         n_arr, sizeof(int64_t) * TRIPLET_SIZE,
+		                         comp_search_2);
+		break;
+	default:
+		res = NULL;
+	}
+
+	return res;
+}
+
+
+/*******************************************************************************
+ *
+ * comp_sort_0
+ *
+ * Compares two int64_t triplets based on their first entry, returning:
+ *  1 if the first is larger than the second,
+ *  0 if the two are equal, and
+ * -1 if the first is less than the second.
+ *
+ *******************************************************************************/
+static int comp_sort_0(const void *a, const void *b)
+{
+	return (((const int64_t *)a)[0] > ((const int64_t *)b)[0])
+	     - (((const int64_t *)a)[0] < ((const int64_t *)b)[0]);
+}
+
+
+/*******************************************************************************
+ *
+ * comp_sort_1
+ *
+ * Compares two int64_t triplets based on their second entry, returning:
+ *  1 if the first is larger than the second,
+ *  0 if the two are equal, and
+ * -1 if the first is less than the second.
+ *
+ * If the triplets a and b have equal values in their second entry, the values
+ * in their first entry will be used to determine the result of the comparison.
+ *
+ *******************************************************************************/
+static int comp_sort_1(const void *a, const void *b)
+{
+	int res;
+
+	res = (((const int64_t *)a)[1] > ((const int64_t *)b)[1])
+	    - (((const int64_t *)a)[1] < ((const int64_t *)b)[1]);
+	if (res == 0) {
+		res = (((const int64_t *)a)[0] > ((const int64_t *)b)[0])
+		    - (((const int64_t *)a)[0] < ((const int64_t *)b)[0]);
+	}
+	return res;
+}
+
+
+/*******************************************************************************
+ *
+ * comp_sort_2
+ *
+ * Compares two int64_t triplets based on their third entry, returning:
+ *  1 if the first is larger than the second,
+ *  0 if the two are equal, and
+ * -1 if the first is less than the second.
+ *
+ * If the triplets a and b have equal values in their third entry, the values
+ * in their first entry will be used to determine the result of the comparison.
+ *
+ *******************************************************************************/
+static int comp_sort_2(const void *a, const void *b)
+{
+	int res;
+
+	res = (((const int64_t *)a)[2] > ((const int64_t *)b)[2])
+	    - (((const int64_t *)a)[2] < ((const int64_t *)b)[2]);
+	if (res == 0) {
+		res = (((const int64_t *)a)[0] > ((const int64_t *)b)[0])
+		    - (((const int64_t *)a)[0] < ((const int64_t *)b)[0]);
+	}
+	return res;
+}
+
+
+/*******************************************************************************
+ *
+ * comp_search_0
+ *
+ * Compares two int64_t triplets based on their first entry, returning:
+ *  1 if the first is larger than the second,
+ *  0 if the two are equal, and
+ * -1 if the first is less than the second.
+ *
+ *******************************************************************************/
+static int comp_search_0(const void *a, const void *b)
+{
+	return (((const int64_t *)a)[0] > ((const int64_t *)b)[0])
+	     - (((const int64_t *)a)[0] < ((const int64_t *)b)[0]);
+}
+
+
+/*******************************************************************************
+ *
+ * comp_search_1
+ *
+ * Compares two int64_t triplets based on their second entry, returning:
+ *  1 if the first is larger than the second,
+ *  0 if the two are equal, and
+ * -1 if the first is less than the second.
+ *
+ *******************************************************************************/
+static int comp_search_1(const void *a, const void *b)
+{
+	return (((const int64_t *)a)[1] > ((const int64_t *)b)[1])
+	     - (((const int64_t *)a)[1] < ((const int64_t *)b)[1]);
+}
+
+
+/*******************************************************************************
+ *
+ * comp_search_2
+ *
+ * Compares two int64_t triplets based on their third entry, returning:
+ *  1 if the first is larger than the second,
+ *  0 if the two are equal, and
+ * -1 if the first is less than the second.
+ *
+ *******************************************************************************/
+static int comp_search_2(const void *a, const void *b)
+{
+	return (((const int64_t *)a)[2] > ((const int64_t *)b)[2])
+	     - (((const int64_t *)a)[2] < ((const int64_t *)b)[2]);
+}

--- a/src/smiol_utils.h
+++ b/src/smiol_utils.h
@@ -1,0 +1,14 @@
+/*******************************************************************************
+ * Utilities and helper functions for SMIOL
+ *******************************************************************************/
+
+#include <stdint.h>
+
+#define TRIPLET_SIZE ((size_t)3)
+
+/*
+ * Searching and sorting
+ */
+void sort_triplet_array(size_t n_arr, int64_t *arr, int sort_entry);
+int64_t *search_triplet_array(int64_t key, size_t n_arr, int64_t *arr,
+                              int search_entry);


### PR DESCRIPTION
This merge adds a new code file, `smiol_utils.c`, along with a header file to
provide routines for searching and sorting. At present, there is one routine
for sorting arrays of triplets of `int64_t` values and one routine for
searching sorted arrays of triplets of `int64_t` values.