### PR TITLE
Implement SMIOL(f)_create_decomp routines

### DIFF
--- a/smiol_runner.F90
+++ b/smiol_runner.F90
@@ -608,8 +608,8 @@ contains
 
         ! Large number of Compute and IO Elements
         write(test_log,'(a)',advance='no') 'Everything OK for SMIOLf_create_decomp large number of elements: '
-        n_compute_elements = 10000000
-        n_io_elements = 10000000
+        n_compute_elements = 1000000
+        n_io_elements = 1000000
         allocate(compute_elements(n_compute_elements))
         allocate(io_elements(n_io_elements))
         ierr = SMIOLf_create_decomp(context, n_compute_elements, compute_elements, n_io_elements, io_elements, decomp)

--- a/smiol_runner.F90
+++ b/smiol_runner.F90
@@ -126,6 +126,9 @@ program smiol_runner
     allocate(compute_elements(n_compute_elements))
     allocate(io_elements(n_io_elements))
 
+    compute_elements(:) = 0
+    io_elements(:) = 0
+
     if (SMIOLf_create_decomp(context, n_compute_elements, compute_elements, &
                              n_io_elements, io_elements, decomp) /= SMIOL_SUCCESS) then
         write(test_log,'(a)') "Error: SMIOLf_create_decomp was not called successfully"
@@ -600,6 +603,8 @@ contains
         n_io_elements = 1
         allocate(compute_elements(n_compute_elements))
         allocate(io_elements(n_io_elements))
+        compute_elements(:) = 0
+        io_elements(:) = 0
         ierr = SMIOLf_create_decomp(context, n_compute_elements, compute_elements, n_io_elements, io_elements, decomp)
         if (ierr == SMIOL_SUCCESS .and. associated(decomp)) then
             write(test_log,'(a)') "PASS"
@@ -630,6 +635,8 @@ contains
         n_io_elements = 1000000
         allocate(compute_elements(n_compute_elements))
         allocate(io_elements(n_io_elements))
+        compute_elements(:) = 0
+        io_elements(:) = 0
         ierr = SMIOLf_create_decomp(context, n_compute_elements, compute_elements, n_io_elements, io_elements, decomp)
         if (ierr == SMIOL_SUCCESS .and. associated(decomp)) then
             write(test_log,'(a)') "PASS"

--- a/smiol_runner.F90
+++ b/smiol_runner.F90
@@ -525,18 +525,36 @@ contains
 
         integer, intent(in) :: test_log
         integer :: ierrcount
+        integer :: comm_size
+        integer :: comm_rank
         integer(kind=c_size_t) :: n_compute_elements
         integer(kind=c_size_t) :: n_io_elements
+        integer(kind=c_size_t) :: i
         integer(kind=SMIOL_offset_kind), dimension(:), pointer :: compute_elements
         integer(kind=SMIOL_offset_kind), dimension(:), pointer :: io_elements
         type (SMIOLf_context), pointer :: context
         type (SMIOLf_decomp), pointer :: decomp => null()
+        logical :: matched
 
         write(test_log,'(a)') '********************************************************************************'
         write(test_log,'(a)') '************ SMIOLf_create_decomp / SMIOLf_free_decomp tests *******************'
         write(test_log,'(a)') ''
 
         ierrcount = 0
+
+        call MPI_Comm_rank(MPI_COMM_WORLD, comm_rank, ierr)
+        if (ierr /= MPI_SUCCESS) then
+            write(test_log, '(a)') 'Failed to get MPI rank...'
+            ierrcount = -1
+            return
+        end if
+
+        call MPI_Comm_size(MPI_COMM_WORLD, comm_size, ierr)
+        if (ierr /= MPI_SUCCESS) then
+            write(test_log, '(a)') 'Failed to get MPI size...'
+            ierrcount = -1
+            return
+        end if
 
         ! Create a SMIOL context for testing decomp routines
         nullify(context)
@@ -648,6 +666,195 @@ contains
             write(test_log,'(a)') "FAIL - ierr returned SMIOL_SUCCESS, but the decomp became associated..."
             ierrcount = ierrcount + 1
         endif
+
+        !
+        ! The following tests will only be run if there are exactly two MPI tasks.
+        ! In principle, as long as there are at least two MPI ranks in MPI_COMM_WORLD,
+        ! an intracommunicator with exactly two ranks could be created for these tests.
+        !
+        if (comm_size == 2) then
+
+            ! Even/odd compute, half/half I/O
+            write(test_log,'(a)',advance='no') 'Even/odd compute, half/half I/O: '
+            n_compute_elements = 4
+            n_io_elements = 4
+            allocate(compute_elements(n_compute_elements))
+            allocate(io_elements(n_io_elements))
+
+            if (comm_rank == 0) then
+                do i = 1, n_compute_elements
+                    compute_elements(i) = 2 * (i-1) + 1      ! Odd elements
+                end do
+                do i = 1, n_io_elements
+                    io_elements(i) = (i-1)                   ! First half of elements
+                end do
+            else
+                do i = 1, n_compute_elements
+                    compute_elements(i) = 2 * (i-1)          ! Even elements
+                end do
+                do i = 1, n_io_elements
+                    io_elements(i) = 4 + (i-1)               ! Second half of elements
+                end do
+            end if
+
+            ierr = SMIOLf_create_decomp(context, n_compute_elements, compute_elements, n_io_elements, io_elements, decomp)
+            if (ierr == SMIOL_SUCCESS .and. associated(decomp)) then
+
+                ! The correct comp_list and io_list arrays, below, were verified manually
+                if (comm_rank == 0) then
+                    matched = compare_decomps(decomp, &
+                                              [ integer(kind=SMIOL_offset_kind) :: 2, 0, 2, 0, 1, 1, 2, 2, 3 ], &
+                                              [ integer(kind=SMIOL_offset_kind) :: 2, 0, 2, 1, 3, 1, 2, 0, 2 ])
+                else
+                    matched = compare_decomps(decomp, &
+                                              [ integer(kind=SMIOL_offset_kind) :: 2, 0, 2, 0, 1, 1, 2, 2, 3 ], &
+                                              [ integer(kind=SMIOL_offset_kind) :: 2, 0, 2, 1, 3, 1, 2, 0, 2 ])
+                end if
+
+                if (matched) then
+                    write(test_log,'(a)') 'PASS'
+                else
+                    write(test_log,'(a)') 'FAIL - the decomp did not contain the expected values'
+                    ierrcount = ierrcount + 1
+                end if
+            else
+                write(test_log, '(a)') 'FAIL - Either SMIOL_SUCCESS was not returned or decomp was not associated'
+                ierrcount = ierrcount + 1
+            end if
+
+            deallocate(compute_elements)
+            deallocate(io_elements)
+
+            ierr = SMIOLf_free_decomp(decomp)
+            if (ierr /= SMIOL_SUCCESS .or. associated(decomp)) then
+                write(test_log,'(a)') 'After previous unit test, SMIOL_free_decomp was unsuccessful: FAIL'
+                ierrcount = ierrcount + 1
+            end if
+
+
+            ! Even/odd compute, nothing/all I/O
+            write(test_log,'(a)',advance='no') 'Even/odd compute, nothing/all I/O: '
+            n_compute_elements = 4
+            if (comm_rank == 0) then
+                n_io_elements = 0
+            else
+                n_io_elements = 8
+            end if
+            allocate(compute_elements(n_compute_elements))
+            allocate(io_elements(n_io_elements))
+
+            if (comm_rank == 0) then
+                do i = 1, n_compute_elements
+                    compute_elements(i) = 2 * (i-1) + 1      ! Odd elements
+                end do
+
+                ! No I/O elements
+            else
+                do i = 1, n_compute_elements
+                    compute_elements(i) = 2 * (i-1)          ! Even elements
+                end do
+                do i = 1, n_io_elements
+                    io_elements(i) = (i-1)                   ! All I/O elements
+                end do
+            end if
+
+            ierr = SMIOLf_create_decomp(context, n_compute_elements, compute_elements, n_io_elements, io_elements, decomp)
+            if (ierr == SMIOL_SUCCESS .and. associated(decomp)) then
+
+                ! The correct comp_list and io_list arrays, below, were verified manually
+                if (comm_rank == 0) then
+                    matched = compare_decomps(decomp, &
+                                              [ integer(kind=SMIOL_offset_kind) :: 1, 1, 4, 0, 1, 2, 3 ], &
+                                              [ integer(kind=SMIOL_offset_kind) :: 0 ])
+                else
+                    matched = compare_decomps(decomp, &
+                                              [ integer(kind=SMIOL_offset_kind) :: 1, 1, 4, 0, 1, 2, 3 ], &
+                                              [ integer(kind=SMIOL_offset_kind) :: 2, 0, 4, 1, 3, 5, 7, 1, 4, 0, 2, 4, 6 ])
+                end if
+
+                if (matched) then
+                    write(test_log,'(a)') 'PASS'
+                else
+                    write(test_log,'(a)') 'FAIL - the decomp did not contain the expected values'
+                    ierrcount = ierrcount + 1
+                end if
+            else
+                write(test_log, '(a)') 'FAIL - Either SMIOL_SUCCESS was not returned or decomp was not associated'
+                ierrcount = ierrcount + 1
+            end if
+
+            deallocate(compute_elements)
+            deallocate(io_elements)
+
+            ierr = SMIOLf_free_decomp(decomp)
+            if (ierr /= SMIOL_SUCCESS .or. associated(decomp)) then
+                write(test_log,'(a)') 'After previous unit test, SMIOL_free_decomp was unsuccessful: FAIL'
+                ierrcount = ierrcount + 1
+            end if
+
+
+            ! All/nothing compute, nothing/all I/O
+            write(test_log,'(a)',advance='no') 'All/nothing compute, nothing/all I/O: '
+            if (comm_rank == 0) then
+                n_compute_elements = 8
+                n_io_elements = 0
+            else
+                n_compute_elements = 0
+                n_io_elements = 8
+            end if
+            allocate(compute_elements(n_compute_elements))
+            allocate(io_elements(n_io_elements))
+
+            if (comm_rank == 0) then
+                do i = 1, n_compute_elements
+                    compute_elements(i) = (n_compute_elements - i)      ! All compute elements
+                end do
+
+                ! No I/O elements
+            else
+                ! No compute elements
+
+                do i = 1, n_io_elements
+                    io_elements(i) = (i-1)                   ! All I/O elements
+                end do
+            end if
+
+            ierr = SMIOLf_create_decomp(context, n_compute_elements, compute_elements, n_io_elements, io_elements, decomp)
+            if (ierr == SMIOL_SUCCESS .and. associated(decomp)) then
+
+                ! The correct comp_list and io_list arrays, below, were verified manually
+                if (comm_rank == 0) then
+                    matched = compare_decomps(decomp, &
+                                              [ integer(kind=SMIOL_offset_kind) :: 1, 1, 8, 7, 6, 5, 4, 3, 2, 1, 0 ], &
+                                              [ integer(kind=SMIOL_offset_kind) :: 0 ])
+                else
+                    matched = compare_decomps(decomp, &
+                                              [ integer(kind=SMIOL_offset_kind) :: 0], &
+                                              [ integer(kind=SMIOL_offset_kind) :: 1, 0, 8, 0, 1, 2, 3, 4, 5, 6, 7 ])
+                end if
+
+                if (matched) then
+                    write(test_log,'(a)') 'PASS'
+                else
+                    write(test_log,'(a)') 'FAIL - the decomp did not contain the expected values'
+                    ierrcount = ierrcount + 1
+                end if
+            else
+                write(test_log, '(a)') 'FAIL - Either SMIOL_SUCCESS was not returned or decomp was not associated'
+                ierrcount = ierrcount + 1
+            end if
+
+            deallocate(compute_elements)
+            deallocate(io_elements)
+
+            ierr = SMIOLf_free_decomp(decomp)
+            if (ierr /= SMIOL_SUCCESS .or. associated(decomp)) then
+                write(test_log,'(a)') 'After previous unit test, SMIOL_free_decomp was unsuccessful: FAIL'
+                ierrcount = ierrcount + 1
+            end if
+        else
+            write(test_log, '(a)') '<<< Tests that require exactly 2 MPI tasks will not be run >>>'
+        end if
 
         ! Free the SMIOL context
         ierr = SMIOLf_finalize(context)
@@ -1521,5 +1728,69 @@ contains
         write(test_log,'(a)') ''
 
     end function test_file_sync
+
+
+    !-----------------------------------------------------------------------
+    !  routine compare_decomps
+    !
+    !> \brief Compare a SMIOLf_decomp against known-correct comp_list and io_list
+    !> \details
+    !>  Compares the comp_list and io_list members of a SMIOLf_decomp against
+    !>  comp_list and io_list arrays that contain the correct (reference) values.
+    !>
+    !>  If all values in the comp_list_correct and decomp % comp_list match and
+    !>  if all values in the io_list_correct and decomp % io_list match, a value
+    !>  of .true. is returned; otherwise, .false. is returned.
+    !>
+    !>  Note: If the decomp % comp_list is not at least the size of comp_list_correct,
+    !>        or the decomp % io_list is not at least the size of io_list_correct,
+    !>        this routine may fail unpredictably (perhaps with a segfault), since
+    !>        accessing the lists in the SMIOLf_decomp type requires the use of
+    !>        c_f_pointer with an assumed size for these arrays.
+    !
+    !-----------------------------------------------------------------------
+    function compare_decomps(decomp, comp_list_correct, io_list_correct) result(matched)
+
+        use iso_c_binding, only : c_f_pointer
+
+        implicit none
+
+        ! Arguments
+        type (SMIOLf_decomp), intent(in) :: decomp
+        integer(kind=SMIOL_offset_kind), dimension(:), intent(in) :: comp_list_correct
+        integer(kind=SMIOL_offset_kind), dimension(:), intent(in) :: io_list_correct
+
+        ! Return value
+        logical :: matched
+
+        ! Local variables
+        integer :: i
+        integer(kind=SMIOL_offset_kind), dimension(:), pointer :: comp_list
+        integer(kind=SMIOL_offset_kind), dimension(:), pointer :: io_list
+
+
+        matched = .true.
+
+        ! Get Fortran pointers to the comp_list and io_list members of decomp
+        call c_f_pointer(decomp % comp_list, comp_list, shape=[size(comp_list_correct)])
+        call c_f_pointer(decomp % io_list, io_list, shape=[size(io_list_correct)])
+
+        ! Check comp_list
+        do i = 1, size(comp_list_correct)
+            if (comp_list(i) /= comp_list_correct(i)) then
+                matched = .false.
+                return
+            end if
+        end do
+
+        ! Check io_list
+        do i = 1, size(io_list_correct)
+            if (io_list(i) /= io_list_correct(i)) then
+                matched = .false.
+                return
+            end if
+        end do
+
+    end function compare_decomps
 
 end program smiol_runner

--- a/smiol_runner.c
+++ b/smiol_runner.c
@@ -151,6 +151,9 @@ int main(int argc, char **argv)
 	compute_elements = malloc(sizeof(SMIOL_Offset) * n_compute_elements);
 	io_elements = malloc(sizeof(SMIOL_Offset) * n_io_elements);
 
+	memset((void *)compute_elements, 0, sizeof(SMIOL_Offset) * n_compute_elements);
+	memset((void *)io_elements, 0, sizeof(SMIOL_Offset) * n_io_elements);
+
 	ierr = SMIOL_create_decomp(context, n_compute_elements, compute_elements, n_io_elements, io_elements, &decomp);
 	if (ierr != SMIOL_SUCCESS) {
 		printf("ERROR: SMIOL_create_decomp - SMIOL_SUCCESS was not returned\n");
@@ -692,6 +695,8 @@ int test_decomp(FILE *test_log)
 	n_io_elements = 1;
 	compute_elements = malloc(sizeof(SMIOL_Offset) * n_compute_elements);
 	io_elements = malloc(sizeof(SMIOL_Offset) * n_io_elements);
+	memset((void *)compute_elements, 0, sizeof(SMIOL_Offset) * n_compute_elements);
+	memset((void *)io_elements, 0, sizeof(SMIOL_Offset) * n_io_elements);
 	ierr = SMIOL_create_decomp(context, n_compute_elements, compute_elements, n_io_elements, io_elements, &decomp);
 	if (ierr == SMIOL_SUCCESS && decomp != NULL) {
 		fprintf(test_log, "PASS\n");
@@ -725,6 +730,8 @@ int test_decomp(FILE *test_log)
 	n_io_elements = 1000000;
 	compute_elements = malloc(sizeof(SMIOL_Offset) * n_compute_elements);
 	io_elements = malloc(sizeof(SMIOL_Offset) * n_io_elements);
+	memset((void *)compute_elements, 0, sizeof(SMIOL_Offset) * n_compute_elements);
+	memset((void *)io_elements, 0, sizeof(SMIOL_Offset) * n_io_elements);
 	ierr = SMIOL_create_decomp(context, n_compute_elements, compute_elements, n_io_elements, io_elements, &decomp);
 	if (ierr == SMIOL_SUCCESS && decomp != NULL) {
 		fprintf(test_log, "PASS\n");

--- a/smiol_runner.c
+++ b/smiol_runner.c
@@ -15,6 +15,9 @@ int test_variables(FILE *test_log);
 int test_decomp(FILE *test_log);
 int test_file_sync(FILE *test_log);
 int test_utils(FILE *test_log);
+int compare_decomps(struct SMIOL_decomp *decomp,
+                    size_t n_comp_list, SMIOL_Offset *comp_list_correct,
+                    size_t n_io_list, SMIOL_Offset *io_list_correct);
 
 int main(int argc, char **argv)
 {
@@ -592,6 +595,9 @@ int test_decomp(FILE *test_log)
 {
 	int ierr;
 	int errcount = 0;
+	int comm_rank;
+	int comm_size;
+	size_t i;
 	size_t n_compute_elements, n_io_elements;
 	SMIOL_Offset *compute_elements = NULL, *io_elements = NULL;
 	struct SMIOL_context *context = NULL;
@@ -600,6 +606,18 @@ int test_decomp(FILE *test_log)
 	fprintf(test_log, "********************************************************************************\n");
 	fprintf(test_log, "************ SMIOL_create_decomp / SMIOL_free_decomp unit tests ****************\n");
 	fprintf(test_log, "\n");
+
+	ierr = MPI_Comm_rank(MPI_COMM_WORLD, &comm_rank);
+	if (ierr != MPI_SUCCESS) {
+		fprintf(test_log, "Failed to get MPI rank...\n");
+		return -1;
+	}
+
+	ierr = MPI_Comm_size(MPI_COMM_WORLD, &comm_size);
+	if (ierr != MPI_SUCCESS) {
+		fprintf(test_log, "Failed to get MPI size...\n");
+		return -1;
+	}
 
 	/* Create a SMIOL context for testing decomp routines */
 	ierr = SMIOL_init(MPI_COMM_WORLD, &context);
@@ -745,6 +763,198 @@ int test_decomp(FILE *test_log)
 	} else if (ierr != SMIOL_SUCCESS && decomp == NULL) {
 		fprintf(test_log, "FAIL - decomp was NULL but did not returned SMIOL_SUCCESS\n");
 		errcount++;
+	}
+
+	/*
+	 * The following tests will only be run if there are exactly two MPI tasks.
+	 * In principle, as long as there are at least two MPI ranks in MPI_COMM_WORLD,
+	 * an intracommunicator with exactly two ranks could be created for these tests.
+	 */
+	if (comm_size == 2) {
+
+		/* Even/odd compute, half/half I/O */
+		fprintf(test_log, "Even/odd compute, half/half I/O: ");
+		n_compute_elements = 4;
+		n_io_elements = 4;
+		compute_elements = malloc(sizeof(SMIOL_Offset) * n_compute_elements);
+		io_elements = malloc(sizeof(SMIOL_Offset) * n_io_elements);
+
+		if (comm_rank == 0) {
+			for (i = 0; i < n_compute_elements; i++) {
+				compute_elements[i] = (SMIOL_Offset)(2 * i + 1);    /* Odd elements */
+			}
+			for (i = 0; i < n_io_elements; i++) {
+				io_elements[i] = (SMIOL_Offset)i;                   /* First half of elements */
+			}
+		} else {
+			for (i = 0; i < n_compute_elements; i++) {
+				compute_elements[i] = (SMIOL_Offset)(2 * i);        /* Even elements */
+			}
+			for (i = 0; i < n_io_elements; i++) {
+				io_elements[i] = (SMIOL_Offset)(4 + i);             /* Second half of elements */
+			}
+		}
+		ierr = SMIOL_create_decomp(context, n_compute_elements, compute_elements, n_io_elements, io_elements, &decomp);
+		if (ierr == SMIOL_SUCCESS && decomp != NULL) {
+
+			/* The correct comp_list and io_list arrays, below, were verified manually */
+			if (comm_rank == 0) {
+				SMIOL_Offset comp_list_correct[] = { 2, 0, 2, 0, 1, 1, 2, 2, 3 };
+				SMIOL_Offset io_list_correct[] = { 2, 0, 2, 1, 3, 1, 2, 0, 2 };
+
+				ierr = compare_decomps(decomp, (size_t)9, comp_list_correct, (size_t)9, io_list_correct);
+			} else {
+				SMIOL_Offset comp_list_correct[] = { 2, 0, 2, 0, 1, 1, 2, 2, 3 };
+				SMIOL_Offset io_list_correct[] = { 2, 0, 2, 1, 3, 1, 2, 0, 2 };
+
+				ierr = compare_decomps(decomp, (size_t)9, comp_list_correct, (size_t)9, io_list_correct);
+			}
+
+			if (ierr == 0) {
+				fprintf(test_log, "PASS\n");
+			} else {
+				fprintf(test_log, "FAIL - the decomp did not contain the expected values\n");
+				errcount++;
+			}
+		} else {
+			fprintf(test_log, "FAIL - SMIOL_SUCCESS was not returned or decomp was NULL\n");
+			errcount++;
+		}
+
+		free(compute_elements);
+		free(io_elements);
+
+		ierr = SMIOL_free_decomp(&decomp);
+		if (ierr != SMIOL_SUCCESS || decomp != NULL) {
+			fprintf(test_log, "After previous unit test, SMIOL_free_decomp was unsuccessful: FAIL\n");
+			errcount++;
+		}
+
+
+		/* Even/odd compute, nothing/all I/O */
+		fprintf(test_log, "Even/odd compute, nothing/all I/O: ");
+		n_compute_elements = 4;
+		if (comm_rank == 0) {
+			n_io_elements = 0;
+		} else {
+			n_io_elements = 8;
+		}
+		compute_elements = malloc(sizeof(SMIOL_Offset) * n_compute_elements);
+		io_elements = malloc(sizeof(SMIOL_Offset) * n_io_elements);
+
+		if (comm_rank == 0) {
+			for (i = 0; i < n_compute_elements; i++) {
+				compute_elements[i] = (SMIOL_Offset)(2 * i + 1);    /* Odd elements */
+			}
+
+			/* No I/O elements */
+		} else {
+			for (i = 0; i < n_compute_elements; i++) {
+				compute_elements[i] = (SMIOL_Offset)(2 * i);        /* Even elements */
+			}
+
+			for (i = 0; i < n_io_elements; i++) {
+				io_elements[i] = (SMIOL_Offset)i;                   /* All I/O elements */
+			}
+		}
+		ierr = SMIOL_create_decomp(context, n_compute_elements, compute_elements, n_io_elements, io_elements, &decomp);
+		if (ierr == SMIOL_SUCCESS && decomp != NULL) {
+
+			/* The correct comp_list and io_list arrays, below, were verified manually */
+			if (comm_rank == 0) {
+				SMIOL_Offset comp_list_correct[] = { 1, 1, 4, 0, 1, 2, 3 };
+				SMIOL_Offset io_list_correct[] = { 0 };
+
+				ierr = compare_decomps(decomp, (size_t)7, comp_list_correct, (size_t)1, io_list_correct);
+			} else {
+				SMIOL_Offset comp_list_correct[] = { 1, 1, 4, 0, 1, 2, 3 };
+				SMIOL_Offset io_list_correct[] = { 2, 0, 4, 1, 3, 5, 7, 1, 4, 0, 2, 4, 6 };
+
+				ierr = compare_decomps(decomp, (size_t)7, comp_list_correct, (size_t)13, io_list_correct);
+			}
+
+			if (ierr == 0) {
+				fprintf(test_log, "PASS\n");
+			} else {
+				fprintf(test_log, "FAIL - the decomp did not contain the expected values\n");
+				errcount++;
+			}
+		} else {
+			fprintf(test_log, "FAIL - SMIOL_SUCCESS was not returned or decomp was NULL\n");
+			errcount++;
+		}
+		free(compute_elements);
+		free(io_elements);
+
+		ierr = SMIOL_free_decomp(&decomp);
+		if (ierr != SMIOL_SUCCESS || decomp != NULL) {
+			fprintf(test_log, "After previous unit test, SMIOL_free_decomp was unsuccessful: FAIL\n");
+			errcount++;
+		}
+
+
+		/* All/nothing compute, nothing/all I/O */
+		fprintf(test_log, "All/nothing compute, nothing/all I/O: ");
+		if (comm_rank == 0) {
+			n_compute_elements = 8;
+			n_io_elements = 0;
+		} else {
+			n_compute_elements = 0;
+			n_io_elements = 8;
+		}
+		compute_elements = malloc(sizeof(SMIOL_Offset) * n_compute_elements);
+		io_elements = malloc(sizeof(SMIOL_Offset) * n_io_elements);
+
+		if (comm_rank == 0) {
+			for (i = 0; i < n_compute_elements; i++) {
+				compute_elements[i] = (SMIOL_Offset)(n_compute_elements - 1 - i);    /* All compute elements */
+			}
+
+			/* No I/O elements */
+		} else {
+			/* No compute elements */
+
+			for (i = 0; i < n_io_elements; i++) {
+				io_elements[i] = (SMIOL_Offset)i;                   /* All I/O elements */
+			}
+		}
+		ierr = SMIOL_create_decomp(context, n_compute_elements, compute_elements, n_io_elements, io_elements, &decomp);
+		if (ierr == SMIOL_SUCCESS && decomp != NULL) {
+
+			/* The correct comp_list and io_list arrays, below, were verified manually */
+			if (comm_rank == 0) {
+				SMIOL_Offset comp_list_correct[] = { 1, 1, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+				SMIOL_Offset io_list_correct[] = { 0 };
+
+				ierr = compare_decomps(decomp, (size_t)11, comp_list_correct, (size_t)1, io_list_correct);
+			} else {
+				SMIOL_Offset comp_list_correct[] = { 0 };
+				SMIOL_Offset io_list_correct[] = { 1, 0, 8, 0, 1, 2, 3, 4, 5, 6, 7 };
+
+				ierr = compare_decomps(decomp, (size_t)1, comp_list_correct, (size_t)11, io_list_correct);
+			}
+
+			if (ierr == 0) {
+				fprintf(test_log, "PASS\n");
+			} else {
+				fprintf(test_log, "FAIL - the decomp did not contain the expected values\n");
+				errcount++;
+			}
+		} else {
+			fprintf(test_log, "FAIL - SMIOL_SUCCESS was not returned or decomp was NULL\n");
+			errcount++;
+		}
+		free(compute_elements);
+		free(io_elements);
+
+		ierr = SMIOL_free_decomp(&decomp);
+		if (ierr != SMIOL_SUCCESS || decomp != NULL) {
+			fprintf(test_log, "After previous unit test, SMIOL_free_decomp was unsuccessful: FAIL\n");
+			errcount++;
+		}
+
+	} else {
+		fprintf(test_log, "<<< Tests that require exactly 2 MPI tasks will not be run >>>\n");
 	}
 
 	/* Free the SMIOL context */
@@ -1944,3 +2154,50 @@ int test_utils(FILE *test_log)
 	return errcount;
 }
 
+
+/********************************************************************************
+ *
+ * compare_decomps
+ *
+ * Compare a SMIOL_decomp against known-correct comp_list and io_list
+ *
+ * Compares the comp_list and io_list members of a SMIOL_decomp against
+ * comp_list and io_list arrays that contain the correct (reference) values.
+ *
+ * If all values in the comp_list_correct and decomp->comp_list match and
+ * if all values in the io_list_correct and decomp->io_list match, a value
+ * of 0 is returned; otherwise, a non-zero value is returned.
+ *
+ * Note: The length of the decomp->comp_list and comp_list_correct arrays must
+ *       be at least n_comp_list, and the decomp->io_list and io_list_correct
+ *       arrays must be at least n_io_list; otherwise, this routine may fail
+ *       unpredictably (perhaps with a segfault).
+ *
+ ********************************************************************************/
+int compare_decomps(struct SMIOL_decomp *decomp,
+                    size_t n_comp_list, SMIOL_Offset *comp_list_correct,
+                    size_t n_io_list, SMIOL_Offset *io_list_correct)
+{
+	size_t i;
+	SMIOL_Offset *comp_list;
+	SMIOL_Offset *io_list;
+
+	comp_list = decomp->comp_list;
+	io_list = decomp->io_list;
+
+	/* Check comp_list */
+	for (i = 0; i < n_comp_list; i++) {
+		if (comp_list[i] != comp_list_correct[i]) {
+			return 1;
+		}
+	}
+
+	/* Check io_list */
+	for (i = 0; i < n_io_list; i++) {
+		if (io_list[i] != io_list_correct[i]) {
+			return 1;
+		}
+	}
+
+	return 0;
+}

--- a/smiol_runner.c
+++ b/smiol_runner.c
@@ -703,8 +703,8 @@ int test_decomp(FILE *test_log)
 
 	/* Create and Free Decomp with large amount of elements */
 	fprintf(test_log, "Everything OK (SMIOL_create_decomp) with large amount of elements: ");
-	n_compute_elements = 100000000;
-	n_io_elements = 100000000;
+	n_compute_elements = 1000000;
+	n_io_elements = 1000000;
 	compute_elements = malloc(sizeof(SMIOL_Offset) * n_compute_elements);
 	io_elements = malloc(sizeof(SMIOL_Offset) * n_io_elements);
 	ierr = SMIOL_create_decomp(context, n_compute_elements, compute_elements, n_io_elements, io_elements, &decomp);

--- a/src/smiol.c
+++ b/src/smiol.c
@@ -1191,6 +1191,9 @@ int SMIOL_create_decomp(struct SMIOL_context *context,
 		return SMIOL_MALLOC_FAILURE;
 	}
 
+	(*decomp)->context = context;
+
+
 	/*
 	 * Scan through io_ids to determine number of unique neighbors that
 	 * compute elements read/written on this task, and also determine

--- a/src/smiol.c
+++ b/src/smiol.c
@@ -1027,6 +1027,7 @@ int SMIOL_create_decomp(struct SMIOL_context *context,
 	buf_out = (SMIOL_Offset *)malloc(sizeof(SMIOL_Offset) * (size_t)2
 	                                 * (size_t)nbuf_out);
 	if (buf_out == NULL) {
+		free(compute_ids);
 		return SMIOL_MALLOC_FAILURE;
 	}
 
@@ -1166,6 +1167,8 @@ int SMIOL_create_decomp(struct SMIOL_context *context,
 	io_ids = (SMIOL_Offset *)malloc(sizeof(SMIOL_Offset) * TRIPLET_SIZE
 	                                * n_io_elements);
 	if (io_ids == NULL) {
+		free(compute_ids);
+		free(buf_out);
 		return SMIOL_MALLOC_FAILURE;
 	}
 
@@ -1188,6 +1191,8 @@ int SMIOL_create_decomp(struct SMIOL_context *context,
 
 	*decomp = (struct SMIOL_decomp *)malloc(sizeof(struct SMIOL_decomp));
 	if ((*decomp) == NULL) {
+		free(compute_ids);
+		free(io_ids);
 		return SMIOL_MALLOC_FAILURE;
 	}
 
@@ -1234,6 +1239,10 @@ int SMIOL_create_decomp(struct SMIOL_context *context,
 	                                 + n_xfer_total);
 	(*decomp)->io_list = (SMIOL_Offset *)malloc(n_list);
 	if ((*decomp)->io_list == NULL) {
+		free(compute_ids);
+		free(io_ids);
+		free(*decomp);
+		*decomp = NULL;
 		return SMIOL_MALLOC_FAILURE;
 	}
 	io_list = (*decomp)->io_list;
@@ -1320,6 +1329,10 @@ int SMIOL_create_decomp(struct SMIOL_context *context,
 	                                 + n_xfer_total);
 	(*decomp)->comp_list = (SMIOL_Offset *)malloc(n_list);
 	if ((*decomp)->comp_list == NULL) {
+		free(compute_ids);
+		free((*decomp)->io_list);
+		free(*decomp);
+		*decomp = NULL;
 		return SMIOL_MALLOC_FAILURE;
 	}
 	comp_list = (*decomp)->comp_list;

--- a/src/smiol.c
+++ b/src/smiol.c
@@ -904,18 +904,23 @@ int SMIOL_set_option(void)
  *
  * Creates a mapping between compute elements and I/O elements.
  *
- * Allocate a SMIOL_decomp and copy compute and I/O elements into it. Upon
- * success, return a valid SMIOL decomp; otherwise return NULL.
+ * Given arrays of global element IDs that each task computes and global element IDs
+ * that each task reads/writes, this routine works out a mapping of elements between
+ * compute and I/O tasks.
+ *
+ * If all input arguments are determined to be valid and if the routine is successful
+ * in working out a mapping, the decomp pointer is allocated and given valid contents,
+ * and SMIOL_SUCCESS is returned; otherwise a non-success error code is returned and
+ * the decomp pointer is NULL.
  *
  ********************************************************************************/
 int SMIOL_create_decomp(struct SMIOL_context *context,
-                        size_t n_compute_elements,
-                        SMIOL_Offset *compute_elements,
-                        size_t n_io_elements,
-                        SMIOL_Offset *io_elements,
+                        size_t n_compute_elements, SMIOL_Offset *compute_elements,
+                        size_t n_io_elements, SMIOL_Offset *io_elements,
                         struct SMIOL_decomp **decomp)
 {
-	size_t i;
+	int comm_size;
+	int i;
 
 	if (context == NULL) {
 		return SMIOL_INVALID_ARGUMENT;
@@ -929,34 +934,140 @@ int SMIOL_create_decomp(struct SMIOL_context *context,
 		return SMIOL_INVALID_ARGUMENT;
 	}
 
-	*decomp = malloc(sizeof(struct SMIOL_decomp));
-	if ((*decomp) == NULL) {
-		return SMIOL_MALLOC_FAILURE;
+	*decomp = (struct SMIOL_decomp *)malloc(sizeof(struct SMIOL_decomp));
+// TODO: Check on malloc result, return SMIOL_MALLOC_FAILURE if needed
+	(*decomp)->comp_list = NULL;
+	(*decomp)->io_list = NULL;
+
+	comm_size = context->comm_size;
+
+
+	/*
+	 * Allocate an array, compute_ids, with three entries for each compute element
+	 *    [0] - element global ID
+	 *    [1] - element local ID
+	 *    [2] - I/O task that reads/writes this element
+	 */
+
+	/*
+	 * Fill in compute_ids array with global and local IDs; rank of I/O task is not yet known
+	 */
+
+	/*
+	 * Sort the compute_ids array on global element ID (first entry for each element)
+	 */
+
+	/*
+	 * Allocate buffer with two entries for each I/O element
+	 *    [0] - I/O element global ID
+	 *    [1] - task that computes this element
+	 */
+
+	/*
+	 * Fill buffer with I/O element IDs; compute task is not yet known
+	 */
+
+	/*
+	 * Iterate through all ranks in the communicator, receiving from "left" neighbor
+	 * and sending to "right" neighbor in each iteration.
+	 * The objective is to identify, for each I/O element, which MPI rank computes
+	 * that element. At the end of iteration, each rank will have seen the I/O element
+	 * list from all other ranks.
+	 */
+	for (i = 0; i < comm_size; i++) {
+
+		/*
+		 * Initiate send of outgoing buffer size and receive of incoming buffer size
+		 */
+
+		/*
+		 * Wait until the incoming buffer size has been received
+		 */
+
+		/*
+		 * Allocate incoming buffer
+		 */
+
+		/*
+		 * Initiate receive of incoming buffer
+		 */
+
+		/*
+		 * Wait until the outgoing buffer size has been sent
+		 */
+
+		/*
+		 * Initiate send of outgoing buffer
+		 */
+
+		/*
+		 * Wait until the incoming buffer has been received
+		 */
+
+		/*
+		 * Loop through the incoming buffer, marking all elements that are computed on this task
+		 */
+
+		/*
+		 * Wait until we have sent the outgoing buffer
+		 */
+
+		/*
+		 * Free outgoing buffer and make the input buffer into the output buffer for next iteration
+		 */
 	}
 
-	(*decomp)->comp_list = malloc(sizeof(SMIOL_Offset) * n_compute_elements);
-	if ((*decomp)->comp_list == NULL) {
-		free(*decomp);
-		*decomp = NULL;
-		return SMIOL_MALLOC_FAILURE;
-	}
+	/*
+	 * The output buffer is now the initial buffer with the compute tasks
+	 * for each I/O element identified
+	 */
 
-	(*decomp)->io_list = malloc(sizeof(SMIOL_Offset) * n_io_elements);
-	if ((*decomp)->io_list == NULL) {
-		free(*decomp);
-		*decomp = NULL;
-		return SMIOL_MALLOC_FAILURE;
-	}
+	/*
+	 * Allocate an array, io_ids, with three entries for each I/O element
+	 *    [0] - element global ID
+	 *    [1] - element local ID
+	 *    [2] - compute task that operates on this element
+	 */
 
-	// Copy compute elements
-	for (i = 0; i < n_compute_elements; i++) {
-		(*decomp)->comp_list[i] = compute_elements[i];
-	}
+	/*
+	 * Fill in io_ids array with global and local IDs, plus the rank of the task that computes each element
+	 */
 
-	// Copy io elements
-	for (i = 0; i < n_io_elements; i++) {
-		(*decomp)->io_list[i] = io_elements[i];
-	}
+	/*
+	 * Sort io_ids array on task ID (third entry for each element)
+	 */
+
+	/*
+	 * Scan through io_ids to determine number of unique neighbors that compute
+	 * elements read/written on this task, and also determine the total number of elements
+	 * computed on other tasks that are read/written on this task
+	 */
+
+	/*
+	 * Based on number of neighbors and total number of elements to transfer allocate the io_list
+	 */
+
+	/*
+	 * Scan through io_ids a second time, filling in the io_list in the process
+	 */
+
+	/*
+	 * Sort compute_ids array on task ID (third entry for each element)
+	 */
+
+	/*
+	 * Scan through compute_ids to determine number of unique neighbors that read/write
+	 * elements computed on this task, and also determine the total number of elements
+	 * read/written on other tasks that are computed on this task
+	 */
+
+	/*
+	 * Based on number of neighbors and total number of elements to transfer allocate the comp_list
+	 */
+
+	/*
+	 * Scan through compute_ids a second time, filling in the comp_list in the process
+	 */
 
 	return SMIOL_SUCCESS;
 }

--- a/src/smiol.c
+++ b/src/smiol.c
@@ -2,6 +2,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include "smiol.h"
+#include "smiol_utils.h"
 
 #ifdef SMIOL_PNETCDF
 #include "pnetcdf.h"
@@ -898,29 +899,49 @@ int SMIOL_set_option(void)
 }
 
 
-/********************************************************************************
+/*******************************************************************************
  *
  * SMIOL_create_decomp
  *
  * Creates a mapping between compute elements and I/O elements.
  *
- * Given arrays of global element IDs that each task computes and global element IDs
- * that each task reads/writes, this routine works out a mapping of elements between
- * compute and I/O tasks.
+ * Given arrays of global element IDs that each task computes and global element
+ * IDs that each task reads/writes, this routine works out a mapping of elements
+ * between compute and I/O tasks.
  *
- * If all input arguments are determined to be valid and if the routine is successful
- * in working out a mapping, the decomp pointer is allocated and given valid contents,
- * and SMIOL_SUCCESS is returned; otherwise a non-success error code is returned and
- * the decomp pointer is NULL.
+ * If all input arguments are determined to be valid and if the routine is
+ * successful in working out a mapping, the decomp pointer is allocated and
+ * given valid contents, and SMIOL_SUCCESS is returned; otherwise a non-success
+ * error code is returned and the decomp pointer is NULL.
  *
- ********************************************************************************/
+ *******************************************************************************/
 int SMIOL_create_decomp(struct SMIOL_context *context,
                         size_t n_compute_elements, SMIOL_Offset *compute_elements,
                         size_t n_io_elements, SMIOL_Offset *io_elements,
                         struct SMIOL_decomp **decomp)
 {
+	MPI_Comm comm;
 	int comm_size;
-	int i;
+	int comm_rank;
+	int ierr;
+	int i, j;
+	int count;
+	int nbuf_in, nbuf_out;
+	SMIOL_Offset *compute_ids;
+	SMIOL_Offset *io_ids;
+	SMIOL_Offset *buf_in, *buf_out;
+	SMIOL_Offset *io_list, *comp_list;
+	SMIOL_Offset neighbor;
+	MPI_Request req_in, req_out;
+	size_t ii;
+	size_t idx;
+	size_t n_neighbors;
+	size_t n_xfer;
+	size_t n_xfer_total;
+	size_t n_list;
+
+	const SMIOL_Offset UNKNOWN_TASK = (SMIOL_Offset)(-1);
+
 
 	if (context == NULL) {
 		return SMIOL_INVALID_ARGUMENT;
@@ -934,87 +955,201 @@ int SMIOL_create_decomp(struct SMIOL_context *context,
 		return SMIOL_INVALID_ARGUMENT;
 	}
 
-	*decomp = (struct SMIOL_decomp *)malloc(sizeof(struct SMIOL_decomp));
-// TODO: Check on malloc result, return SMIOL_MALLOC_FAILURE if needed
-	(*decomp)->comp_list = NULL;
-	(*decomp)->io_list = NULL;
 
+	comm = MPI_Comm_f2c(context->fcomm);
 	comm_size = context->comm_size;
+	comm_rank = context->comm_rank;
 
 
 	/*
-	 * Allocate an array, compute_ids, with three entries for each compute element
+	 * Because the count argument to MPI_Isend and MPI_Irecv is an int, at
+	 * most 2^31-1 elements can be transmitted at a time. In this routine,
+	 * arrays of pairs of SMIOL_Offset values will be transmitted as arrays
+	 * of bytes, so n_compute_elements and n_io_elements can be at most
+	 * 2^31-1 / sizeof(SMIOL_Offset) / 2.
+	 */
+	i = 0;
+	if (n_compute_elements > (((size_t)1 << 31) - 1)
+	                         / sizeof(SMIOL_Offset)
+	                         / (size_t)2) {
+		i = 1;
+	}
+	if (n_io_elements > (((size_t)1 << 31) - 1)
+	                    / sizeof(SMIOL_Offset)
+	                    / (size_t)2) {
+		i = 1;
+	}
+
+	ierr = MPI_Allreduce((const void *)&i, (void *)&j, 1, MPI_INT, MPI_MAX,
+	                     comm);
+	if (j > 0) {
+		return SMIOL_INVALID_ARGUMENT;
+	} else if (ierr != MPI_SUCCESS) {
+		return SMIOL_MPI_ERROR;
+	}
+
+
+	/*
+	 * Allocate an array, compute_ids, with three entries for each compute
+	 * element
 	 *    [0] - element global ID
 	 *    [1] - element local ID
 	 *    [2] - I/O task that reads/writes this element
 	 */
+	compute_ids = (SMIOL_Offset *)malloc(sizeof(SMIOL_Offset) * TRIPLET_SIZE
+	                                     * n_compute_elements);
+	if (compute_ids == NULL) {
+		return SMIOL_MALLOC_FAILURE;
+	}
 
 	/*
-	 * Fill in compute_ids array with global and local IDs; rank of I/O task is not yet known
+	 * Fill in compute_ids array with global and local IDs; rank of I/O task
+	 * is not yet known
 	 */
+	for (ii = 0; ii < n_compute_elements; ii++) {
+		compute_ids[TRIPLET_SIZE*ii] = compute_elements[ii]; /* global ID */
+		compute_ids[TRIPLET_SIZE*ii+1] = (SMIOL_Offset)ii;   /* local ID */
+		compute_ids[TRIPLET_SIZE*ii+2] = UNKNOWN_TASK;       /* I/O task rank */
+	}
 
 	/*
-	 * Sort the compute_ids array on global element ID (first entry for each element)
+	 * Sort the compute_ids array on global element ID
+	 * (first entry for each element)
 	 */
+	sort_triplet_array(n_compute_elements, compute_ids, 0);
 
 	/*
 	 * Allocate buffer with two entries for each I/O element
 	 *    [0] - I/O element global ID
 	 *    [1] - task that computes this element
 	 */
+	nbuf_out = (int)n_io_elements;
+	buf_out = (SMIOL_Offset *)malloc(sizeof(SMIOL_Offset) * (size_t)2
+	                                 * (size_t)nbuf_out);
+	if (buf_out == NULL) {
+		return SMIOL_MALLOC_FAILURE;
+	}
 
 	/*
 	 * Fill buffer with I/O element IDs; compute task is not yet known
 	 */
+	for (ii = 0; ii < n_io_elements; ii++) {
+		buf_out[2*ii] = io_elements[ii];
+		buf_out[2*ii+1] = UNKNOWN_TASK;
+	}
 
 	/*
-	 * Iterate through all ranks in the communicator, receiving from "left" neighbor
-	 * and sending to "right" neighbor in each iteration.
-	 * The objective is to identify, for each I/O element, which MPI rank computes
-	 * that element. At the end of iteration, each rank will have seen the I/O element
-	 * list from all other ranks.
+	 * Iterate through all ranks in the communicator, receiving from "left"
+	 * neighbor and sending to "right" neighbor in each iteration.
+	 * The objective is to identify, for each I/O element, which MPI rank
+	 * computes that element. At the end of iteration, each rank will have
+	 * seen the I/O element list from all other ranks.
 	 */
 	for (i = 0; i < comm_size; i++) {
+		/*
+		 * Compute the rank whose buffer will be received this iteration
+		 */
+		SMIOL_Offset src_rank = (comm_rank - 1 - i + comm_size)
+		                        % comm_size;
 
 		/*
-		 * Initiate send of outgoing buffer size and receive of incoming buffer size
+		 * Initiate send of outgoing buffer size and receive of incoming
+		 * buffer size
 		 */
+		ierr = MPI_Irecv((void *)&nbuf_in, 1, MPI_INT,
+		                 (comm_rank - 1 + comm_size) % comm_size,
+		                 (comm_rank + i), comm, &req_in);
+
+		ierr = MPI_Isend((const void *)&nbuf_out, 1, MPI_INT,
+		                 (comm_rank + 1) % comm_size,
+		                 ((comm_rank + 1) % comm_size + i), comm,
+		                 &req_out);
 
 		/*
 		 * Wait until the incoming buffer size has been received
 		 */
+		ierr = MPI_Wait(&req_in, MPI_STATUS_IGNORE);
 
 		/*
 		 * Allocate incoming buffer
 		 */
+		buf_in = (SMIOL_Offset *)malloc(sizeof(SMIOL_Offset) * (size_t)2
+		                                * (size_t)nbuf_in);
 
 		/*
 		 * Initiate receive of incoming buffer
 		 */
+		count = 2 * nbuf_in;
+		count *= (int)sizeof(SMIOL_Offset);
+		ierr = MPI_Irecv((void *)buf_in, count, MPI_BYTE,
+		                 (comm_rank - 1 + comm_size) % comm_size,
+		                 (comm_rank + i), comm, &req_in);
 
 		/*
 		 * Wait until the outgoing buffer size has been sent
 		 */
+		ierr = MPI_Wait(&req_out, MPI_STATUS_IGNORE);
 
 		/*
 		 * Initiate send of outgoing buffer
 		 */
+		count = 2 * nbuf_out;
+		count *= (int)sizeof(SMIOL_Offset);
+		ierr = MPI_Isend((const void *)buf_out, count, MPI_BYTE,
+		                 (comm_rank + 1) % comm_size,
+		                 ((comm_rank + 1) % comm_size + i), comm,
+		                 &req_out);
 
 		/*
 		 * Wait until the incoming buffer has been received
 		 */
+		ierr = MPI_Wait(&req_in, MPI_STATUS_IGNORE);
 
 		/*
-		 * Loop through the incoming buffer, marking all elements that are computed on this task
+		 * Loop through the incoming buffer, marking all elements that
+		 * are computed on this task
 		 */
+		for (j = 0; j < nbuf_in; j++) {
+			/*
+			 * If I/O element does not yet have a computing task...
+			 */
+			if (buf_in[2*j+1] == UNKNOWN_TASK) {
+				SMIOL_Offset *elem;
+
+				/*
+				 * and if this element is computed on this task...
+				 */
+				elem = search_triplet_array(buf_in[2*j],
+				                            n_compute_elements,
+				                            compute_ids, 0);
+				if (elem != NULL) {
+					/*
+					 * then mark the element as being
+					 * computed on this task
+					 */
+					buf_in[2*j+1] = (SMIOL_Offset)comm_rank;
+
+					/*
+					 * and note locally which task will
+					 * read/write this element
+					 */
+					elem[2] = src_rank;
+				}
+			}
+		}
 
 		/*
 		 * Wait until we have sent the outgoing buffer
 		 */
+		ierr = MPI_Wait(&req_out, MPI_STATUS_IGNORE);
 
 		/*
-		 * Free outgoing buffer and make the input buffer into the output buffer for next iteration
+		 * Free outgoing buffer and make the input buffer into
+		 * the output buffer for next iteration
 		 */
+		free(buf_out);
+		buf_out = buf_in;
+		nbuf_out = nbuf_in;
 	}
 
 	/*
@@ -1028,46 +1163,200 @@ int SMIOL_create_decomp(struct SMIOL_context *context,
 	 *    [1] - element local ID
 	 *    [2] - compute task that operates on this element
 	 */
+	io_ids = (SMIOL_Offset *)malloc(sizeof(SMIOL_Offset) * TRIPLET_SIZE
+	                                * n_io_elements);
+	if (io_ids == NULL) {
+		return SMIOL_MALLOC_FAILURE;
+	}
 
 	/*
-	 * Fill in io_ids array with global and local IDs, plus the rank of the task that computes each element
+	 * Fill in io_ids array with global and local IDs, plus the rank of
+	 * the task that computes each element
 	 */
+	for (ii = 0; ii < n_io_elements; ii++) {
+		io_ids[TRIPLET_SIZE*ii] = buf_out[2*ii+0];    /* global ID */
+		io_ids[TRIPLET_SIZE*ii+1] = (SMIOL_Offset)ii; /* local ID */
+		io_ids[TRIPLET_SIZE*ii+2] = buf_out[2*ii+1];  /* computing task rank */
+	}
+
+	free(buf_out);
 
 	/*
 	 * Sort io_ids array on task ID (third entry for each element)
 	 */
+	sort_triplet_array(n_io_elements, io_ids, 2);
+
+	*decomp = (struct SMIOL_decomp *)malloc(sizeof(struct SMIOL_decomp));
+	if ((*decomp) == NULL) {
+		return SMIOL_MALLOC_FAILURE;
+	}
 
 	/*
-	 * Scan through io_ids to determine number of unique neighbors that compute
-	 * elements read/written on this task, and also determine the total number of elements
+	 * Scan through io_ids to determine number of unique neighbors that
+	 * compute elements read/written on this task, and also determine
+	 * the total number of elements
 	 * computed on other tasks that are read/written on this task
 	 */
+	ii = 0;
+	n_neighbors = 0;
+	n_xfer_total = 0;
+	while (ii < n_io_elements) {
+		/* Task that computes this element */
+		neighbor = io_ids[TRIPLET_SIZE*ii + 2];
+
+		/* Number of elements to read/write for neighbor */
+		n_xfer = 0;
+
+		/*
+		 * Since io_ids is sorted on task, as long as task is unchanged,
+		 * increment n_xfer
+		 */
+		while (ii < n_io_elements
+		       && io_ids[TRIPLET_SIZE*ii+2] == neighbor) {
+			n_xfer++;
+			ii++;
+		}
+		if (neighbor != UNKNOWN_TASK) {
+			n_neighbors++;
+			n_xfer_total += n_xfer;
+		}
+	}
 
 	/*
-	 * Based on number of neighbors and total number of elements to transfer allocate the io_list
+	 * Based on number of neighbors and total number of elements to transfer
+	 * allocate the io_list
 	 */
+	n_list = sizeof(SMIOL_Offset) * ((size_t)1
+	                                 + (size_t)2 * n_neighbors
+	                                 + n_xfer_total);
+	(*decomp)->io_list = (SMIOL_Offset *)malloc(n_list);
+	if ((*decomp)->io_list == NULL) {
+		return SMIOL_MALLOC_FAILURE;
+	}
+	io_list = (*decomp)->io_list;
 
 	/*
-	 * Scan through io_ids a second time, filling in the io_list in the process
+	 * Scan through io_ids a second time, filling in the io_list
 	 */
+	io_list[0] = (SMIOL_Offset)n_neighbors;
+	idx = 1; /* Index in io_list where neighbor ID will be written, followed
+	            by number of elements and element local IDs */
+
+	ii = 0;
+	while (ii < n_io_elements) {
+		/* Task that computes this element */
+		neighbor = io_ids[TRIPLET_SIZE*ii + 2];
+
+		/* Number of elements to read/write for neighbor */
+		n_xfer = 0;
+
+		/*
+		 * Since io_ids is sorted on task, as long as task is unchanged,
+		 * increment n_xfer
+		 */
+		while (ii < n_io_elements
+		       && io_ids[TRIPLET_SIZE*ii+2] == neighbor) {
+			if (neighbor != UNKNOWN_TASK) {
+				/* Save local element ID in list */
+				io_list[idx+2+n_xfer] = io_ids[TRIPLET_SIZE*ii+1];
+				n_xfer++;
+			}
+			ii++;
+		}
+		if (neighbor != UNKNOWN_TASK) {
+			io_list[idx] = neighbor;
+			io_list[idx+1] = (SMIOL_Offset)n_xfer;
+			idx += (2 + n_xfer);
+		}
+	}
+
+	free(io_ids);
 
 	/*
 	 * Sort compute_ids array on task ID (third entry for each element)
 	 */
+	sort_triplet_array(n_compute_elements, compute_ids, 2);
 
 	/*
-	 * Scan through compute_ids to determine number of unique neighbors that read/write
-	 * elements computed on this task, and also determine the total number of elements
-	 * read/written on other tasks that are computed on this task
+	 * Scan through compute_ids to determine number of unique neighbors that
+	 * read/write elements computed on this task, and also determine
+	 * the total number of elements read/written on other tasks that are
+	 * computed on this task
 	 */
+	ii = 0;
+	n_neighbors = 0;
+	n_xfer_total = 0;
+	while (ii < n_compute_elements) {
+		/* Task that reads/writes this element */
+		neighbor = compute_ids[TRIPLET_SIZE*ii + 2];
+
+		/* Number of elements to compute for neighbor */
+		n_xfer = 0;
+
+		/*
+		 * Since compute_ids is sorted on task, as long as task is
+		 * unchanged, increment n_xfer
+		 */
+		while (ii < n_compute_elements
+		       && compute_ids[TRIPLET_SIZE*ii+2] == neighbor) {
+			n_xfer++;
+			ii++;
+		}
+		if (neighbor != UNKNOWN_TASK) {
+			n_neighbors++;
+			n_xfer_total += n_xfer;
+		}
+	}
 
 	/*
-	 * Based on number of neighbors and total number of elements to transfer allocate the comp_list
+	 * Based on number of neighbors and total number of elements to transfer
+	 * allocate the comp_list
 	 */
+	n_list = sizeof(SMIOL_Offset) * ((size_t)1
+	                                 + (size_t)2 * n_neighbors
+	                                 + n_xfer_total);
+	(*decomp)->comp_list = (SMIOL_Offset *)malloc(n_list);
+	if ((*decomp)->comp_list == NULL) {
+		return SMIOL_MALLOC_FAILURE;
+	}
+	comp_list = (*decomp)->comp_list;
 
 	/*
-	 * Scan through compute_ids a second time, filling in the comp_list in the process
+	 * Scan through compute_ids a second time, filling in the comp_list
 	 */
+	comp_list[0] = (SMIOL_Offset)n_neighbors;
+	idx = 1; /* Index in compute_list where neighbor ID will be written,
+	            followed by number of elements and element local IDs */
+
+	ii = 0;
+	while (ii < n_compute_elements) {
+		/* Task that reads/writes this element */
+		neighbor = compute_ids[TRIPLET_SIZE*ii + 2];
+
+		/* Number of elements to compute for neighbor */
+		n_xfer = 0;
+
+		/*
+		 * Since compute_ids is sorted on task, as long as task is
+		 * unchanged, increment n_xfer
+		 */
+		while (ii < n_compute_elements
+		       && compute_ids[TRIPLET_SIZE*ii+2] == neighbor) {
+			if (neighbor != UNKNOWN_TASK) {
+				/* Save local element ID in list */
+				comp_list[idx+2+n_xfer] = compute_ids[TRIPLET_SIZE*ii+1];
+				n_xfer++;
+			}
+			ii++;
+		}
+		if (neighbor != UNKNOWN_TASK) {
+			comp_list[idx] = neighbor;
+			comp_list[idx+1] = (SMIOL_Offset)n_xfer;
+			idx += (2 + n_xfer);
+		}
+	}
+
+	free(compute_ids);
 
 	return SMIOL_SUCCESS;
 }

--- a/src/smiol.h
+++ b/src/smiol.h
@@ -1,54 +1,10 @@
 /*******************************************************************************
  * SMIOL -- The Simple MPAS I/O Library
  *******************************************************************************/
+#ifndef SMIOL_H
+#define SMIOL_H
 
-#include <stdint.h>
-#include "mpi.h"
-
-
-/* If SMIOL_Offset is redefined, interoperable Fortran types and interfaces must also be updated */
-typedef int64_t SMIOL_Offset;
-
-
-/*
- * Types
- */
-struct SMIOL_context {
-	MPI_Fint fcomm; /* Fortran handle to MPI communicator */
-	int comm_size;  /* Size of MPI communicator */
-	int comm_rank;  /* Rank within MPI communicator */
-
-	int lib_ierr;   /* Library-specific error code */
-	int lib_type;   /* From which library the error code originated */
-};
-
-struct SMIOL_file {
-	struct SMIOL_context *context; /* Context for this file */
-#ifdef SMIOL_PNETCDF
-	int state; /* parallel-netCDF file state (i.e. Define or data mode) */
-	int ncidp; /* parallel-netCDF file handle */
-#endif
-};
-
-struct SMIOL_decomp {
-	/*
-	 * The lists below are structured as follows:
-	 *   list[0] - the number of neighbors for which a task sends/recvs
-	 *                                                                             |
-	 *   list[n] - neighbor task ID                                                | repeated for
-	 *   list[n+1] - number of elements, m, to send/recv to/from the neighbor      | each neighbor
-	 *   list[n+2 .. n+2+m] - local element IDs to send/recv to/from the neighbor  |
-	 *                                                                             |
-	 */
-	SMIOL_Offset *comp_list;   /* Elements to be sent/received from/on a compute task */
-	SMIOL_Offset *io_list;     /* Elements to be sent/received from/on an I/O task */
-};
-
-
-/*
- * Return error codes
- */
-#include "smiol_codes.inc"
+#include "smiol_types.h"
 
 
 /*
@@ -101,3 +57,5 @@ int SMIOL_create_decomp(struct SMIOL_context *context,
                         size_t n_io_elements, SMIOL_Offset *io_elements,
                         struct SMIOL_decomp **decomp);
 int SMIOL_free_decomp(struct SMIOL_decomp **decomp);
+
+#endif

--- a/src/smiol_types.h
+++ b/src/smiol_types.h
@@ -47,6 +47,8 @@ struct SMIOL_decomp {
 	 */
 	SMIOL_Offset *comp_list;   /* Elements to be sent/received from/on a compute task */
 	SMIOL_Offset *io_list;     /* Elements to be sent/received from/on an I/O task */
+
+	struct SMIOL_context *context; /* Context for this decomp */
 };
 
 

--- a/src/smiol_types.h
+++ b/src/smiol_types.h
@@ -1,0 +1,58 @@
+/*******************************************************************************
+ * SMIOL -- The Simple MPAS I/O Library
+ *******************************************************************************/
+#ifndef SMIOL_TYPES_H
+#define SMIOL_TYPES_H
+
+#include <stdint.h>
+#include "mpi.h"
+
+
+/* If SMIOL_Offset is redefined, interoperable Fortran types and interfaces must also be updated */
+typedef int64_t SMIOL_Offset;
+
+
+#define TRIPLET_SIZE ((size_t)3)
+
+
+/*
+ * Types
+ */
+struct SMIOL_context {
+	MPI_Fint fcomm; /* Fortran handle to MPI communicator */
+	int comm_size;  /* Size of MPI communicator */
+	int comm_rank;  /* Rank within MPI communicator */
+
+	int lib_ierr;   /* Library-specific error code */
+	int lib_type;   /* From which library the error code originated */
+};
+
+struct SMIOL_file {
+	struct SMIOL_context *context; /* Context for this file */
+#ifdef SMIOL_PNETCDF
+	int state; /* parallel-netCDF file state (i.e. Define or data mode) */
+	int ncidp; /* parallel-netCDF file handle */
+#endif
+};
+
+struct SMIOL_decomp {
+	/*
+	 * The lists below are structured as follows:
+	 *   list[0] - the number of neighbors for which a task sends/recvs
+	 *                                                                             |
+	 *   list[n] - neighbor task ID                                                | repeated for
+	 *   list[n+1] - number of elements, m, to send/recv to/from the neighbor      | each neighbor
+	 *   list[n+2 .. n+2+m] - local element IDs to send/recv to/from the neighbor  |
+	 *                                                                             |
+	 */
+	SMIOL_Offset *comp_list;   /* Elements to be sent/received from/on a compute task */
+	SMIOL_Offset *io_list;     /* Elements to be sent/received from/on an I/O task */
+};
+
+
+/*
+ * Return error codes
+ */
+#include "smiol_codes.inc"
+
+#endif

--- a/src/smiol_utils.c
+++ b/src/smiol_utils.c
@@ -17,11 +17,11 @@ static int comp_search_2(const void *a, const void *b);
  *
  * sort_triplet_array
  *
- * Sorts an array of triplets of int64_t values in ascending order
+ * Sorts an array of triplets of SMIOL_Offset values in ascending order
  *
- * Given a pointer to an array of int64_t triplets, sorts the array in ascending
- * order on the specified entry: 0 sorts on the first value in the triplets,
- * 1 sorts on the second value, and 2 sorts on the third.
+ * Given a pointer to an array of SMIOL_Offset triplets, sorts the array in
+ * ascending order on the specified entry: 0 sorts on the first value in
+ * the triplets, 1 sorts on the second value, and 2 sorts on the third.
  *
  * If the sort_entry is 1 or 2, the relative position of two triplets whose
  * values in that entry match will be determined by their values in the first
@@ -30,20 +30,19 @@ static int comp_search_2(const void *a, const void *b);
  * The sort is not guaranteed to be stable.
  *
  *******************************************************************************/
-void sort_triplet_array(size_t n_arr, int64_t *arr, int sort_entry)
+void sort_triplet_array(size_t n_arr, SMIOL_Offset *arr, int sort_entry)
 {
+	size_t width = sizeof(SMIOL_Offset) * TRIPLET_SIZE;
+
 	switch (sort_entry) {
 	case 0:
-		qsort((void *)arr, n_arr, sizeof(int64_t) * TRIPLET_SIZE,
-		      comp_sort_0);
+		qsort((void *)arr, n_arr, width, comp_sort_0);
 		break;
 	case 1:
-		qsort((void *)arr, n_arr, sizeof(int64_t) * TRIPLET_SIZE,
-		      comp_sort_1);
+		qsort((void *)arr, n_arr, width, comp_sort_1);
 		break;
 	case 2:
-		qsort((void *)arr, n_arr, sizeof(int64_t) * TRIPLET_SIZE,
-		      comp_sort_2);
+		qsort((void *)arr, n_arr, width, comp_sort_2);
 		break;
 	}
 }
@@ -53,12 +52,12 @@ void sort_triplet_array(size_t n_arr, int64_t *arr, int sort_entry)
  *
  * search_triplet_array
  *
- * Searches a sorted array of triplets of int64_t values
+ * Searches a sorted array of triplets of SMIOL_Offset values
  *
- * Given a pointer to a sorted array of int64_t triplets, searches the array on
- * the specified entry for the key value. A search_entry value of 0 searches for
- * the key in the first entry of each triplet, 1 searches in the second entry,
- * and 2 searches in the third.
+ * Given a pointer to a sorted array of SMIOL_Offset triplets, searches
+ * the array on the specified entry for the key value. A search_entry value of
+ * 0 searches for the key in the first entry of each triplet, 1 searches in
+ * the second entry, and 2 searches in the third.
  *
  * If the key is found, the address of the triplet will be returned; otherwise,
  * a NULL pointer is returned.
@@ -67,29 +66,31 @@ void sort_triplet_array(size_t n_arr, int64_t *arr, int sort_entry)
  * no guarantee as to which triplet's address will be returned.
  *
  *******************************************************************************/
-int64_t *search_triplet_array(int64_t key, size_t n_arr, int64_t *arr,
-                              int search_entry)
+SMIOL_Offset *search_triplet_array(SMIOL_Offset key,
+                                   size_t n_arr, SMIOL_Offset *arr,
+                                   int search_entry)
 {
-	int64_t *res;
-	int64_t key3[TRIPLET_SIZE];
+	SMIOL_Offset *res;
+	SMIOL_Offset key3[TRIPLET_SIZE];
+	size_t width = sizeof(SMIOL_Offset) * TRIPLET_SIZE;
 
 	key3[search_entry] = key;
 
 	switch (search_entry) {
 	case 0:
-		res = (int64_t *)bsearch((const void *)&key3, (const void *)arr,
-		                         n_arr, sizeof(int64_t) * TRIPLET_SIZE,
-		                         comp_search_0);
+		res = (SMIOL_Offset *)bsearch((const void *)&key3,
+		                              (const void *)arr, n_arr,
+                                              width, comp_search_0);
 		break;
 	case 1:
-		res = (int64_t *)bsearch((const void *)&key3, (const void *)arr,
-		                         n_arr, sizeof(int64_t) * TRIPLET_SIZE,
-		                         comp_search_1);
+		res = (SMIOL_Offset *)bsearch((const void *)&key3,
+		                              (const void *)arr, n_arr,
+                                              width, comp_search_1);
 		break;
 	case 2:
-		res = (int64_t *)bsearch((const void *)&key3, (const void *)arr,
-		                         n_arr, sizeof(int64_t) * TRIPLET_SIZE,
-		                         comp_search_2);
+		res = (SMIOL_Offset *)bsearch((const void *)&key3,
+		                              (const void *)arr, n_arr,
+                                              width, comp_search_2);
 		break;
 	default:
 		res = NULL;
@@ -113,12 +114,12 @@ int64_t *search_triplet_array(int64_t key, size_t n_arr, int64_t *arr,
  * text file is named list.NNNN.txt, where NNNN is the rank of the task.
  *
  *******************************************************************************/
-void print_lists(int comm_rank, int64_t *comp_list, int64_t *io_list)
+void print_lists(int comm_rank, SMIOL_Offset *comp_list, SMIOL_Offset *io_list)
 {
 	char filename[14];
 	FILE *f;
-	int64_t n_neighbors;
-	int64_t n_elems, neighbor;
+	SMIOL_Offset n_neighbors;
+	SMIOL_Offset n_elems, neighbor;
 	int i, j, k;
 
 	snprintf(filename, 14, "list.%4.4i.txt", comm_rank);
@@ -186,7 +187,7 @@ void print_lists(int comm_rank, int64_t *comp_list, int64_t *io_list)
  *
  * comp_sort_0
  *
- * Compares two int64_t triplets based on their first entry, returning:
+ * Compares two SMIOL_Offset triplets based on their first entry, returning:
  *  1 if the first is larger than the second,
  *  0 if the two are equal, and
  * -1 if the first is less than the second.
@@ -194,8 +195,8 @@ void print_lists(int comm_rank, int64_t *comp_list, int64_t *io_list)
  *******************************************************************************/
 static int comp_sort_0(const void *a, const void *b)
 {
-	return (((const int64_t *)a)[0] > ((const int64_t *)b)[0])
-	     - (((const int64_t *)a)[0] < ((const int64_t *)b)[0]);
+	return (((const SMIOL_Offset *)a)[0] > ((const SMIOL_Offset *)b)[0])
+	     - (((const SMIOL_Offset *)a)[0] < ((const SMIOL_Offset *)b)[0]);
 }
 
 
@@ -203,7 +204,7 @@ static int comp_sort_0(const void *a, const void *b)
  *
  * comp_sort_1
  *
- * Compares two int64_t triplets based on their second entry, returning:
+ * Compares two SMIOL_Offset triplets based on their second entry, returning:
  *  1 if the first is larger than the second,
  *  0 if the two are equal, and
  * -1 if the first is less than the second.
@@ -216,11 +217,11 @@ static int comp_sort_1(const void *a, const void *b)
 {
 	int res;
 
-	res = (((const int64_t *)a)[1] > ((const int64_t *)b)[1])
-	    - (((const int64_t *)a)[1] < ((const int64_t *)b)[1]);
+	res = (((const SMIOL_Offset *)a)[1] > ((const SMIOL_Offset *)b)[1])
+	    - (((const SMIOL_Offset *)a)[1] < ((const SMIOL_Offset *)b)[1]);
 	if (res == 0) {
-		res = (((const int64_t *)a)[0] > ((const int64_t *)b)[0])
-		    - (((const int64_t *)a)[0] < ((const int64_t *)b)[0]);
+		res = (((const SMIOL_Offset *)a)[0] > ((const SMIOL_Offset *)b)[0])
+		    - (((const SMIOL_Offset *)a)[0] < ((const SMIOL_Offset *)b)[0]);
 	}
 	return res;
 }
@@ -230,7 +231,7 @@ static int comp_sort_1(const void *a, const void *b)
  *
  * comp_sort_2
  *
- * Compares two int64_t triplets based on their third entry, returning:
+ * Compares two SMIOL_Offset triplets based on their third entry, returning:
  *  1 if the first is larger than the second,
  *  0 if the two are equal, and
  * -1 if the first is less than the second.
@@ -243,11 +244,11 @@ static int comp_sort_2(const void *a, const void *b)
 {
 	int res;
 
-	res = (((const int64_t *)a)[2] > ((const int64_t *)b)[2])
-	    - (((const int64_t *)a)[2] < ((const int64_t *)b)[2]);
+	res = (((const SMIOL_Offset *)a)[2] > ((const SMIOL_Offset *)b)[2])
+	    - (((const SMIOL_Offset *)a)[2] < ((const SMIOL_Offset *)b)[2]);
 	if (res == 0) {
-		res = (((const int64_t *)a)[0] > ((const int64_t *)b)[0])
-		    - (((const int64_t *)a)[0] < ((const int64_t *)b)[0]);
+		res = (((const SMIOL_Offset *)a)[0] > ((const SMIOL_Offset *)b)[0])
+		    - (((const SMIOL_Offset *)a)[0] < ((const SMIOL_Offset *)b)[0]);
 	}
 	return res;
 }
@@ -257,7 +258,7 @@ static int comp_sort_2(const void *a, const void *b)
  *
  * comp_search_0
  *
- * Compares two int64_t triplets based on their first entry, returning:
+ * Compares two SMIOL_Offset triplets based on their first entry, returning:
  *  1 if the first is larger than the second,
  *  0 if the two are equal, and
  * -1 if the first is less than the second.
@@ -265,8 +266,8 @@ static int comp_sort_2(const void *a, const void *b)
  *******************************************************************************/
 static int comp_search_0(const void *a, const void *b)
 {
-	return (((const int64_t *)a)[0] > ((const int64_t *)b)[0])
-	     - (((const int64_t *)a)[0] < ((const int64_t *)b)[0]);
+	return (((const SMIOL_Offset *)a)[0] > ((const SMIOL_Offset *)b)[0])
+	     - (((const SMIOL_Offset *)a)[0] < ((const SMIOL_Offset *)b)[0]);
 }
 
 
@@ -274,7 +275,7 @@ static int comp_search_0(const void *a, const void *b)
  *
  * comp_search_1
  *
- * Compares two int64_t triplets based on their second entry, returning:
+ * Compares two SMIOL_Offset triplets based on their second entry, returning:
  *  1 if the first is larger than the second,
  *  0 if the two are equal, and
  * -1 if the first is less than the second.
@@ -282,8 +283,8 @@ static int comp_search_0(const void *a, const void *b)
  *******************************************************************************/
 static int comp_search_1(const void *a, const void *b)
 {
-	return (((const int64_t *)a)[1] > ((const int64_t *)b)[1])
-	     - (((const int64_t *)a)[1] < ((const int64_t *)b)[1]);
+	return (((const SMIOL_Offset *)a)[1] > ((const SMIOL_Offset *)b)[1])
+	     - (((const SMIOL_Offset *)a)[1] < ((const SMIOL_Offset *)b)[1]);
 }
 
 
@@ -291,7 +292,7 @@ static int comp_search_1(const void *a, const void *b)
  *
  * comp_search_2
  *
- * Compares two int64_t triplets based on their third entry, returning:
+ * Compares two SMIOL_Offset triplets based on their third entry, returning:
  *  1 if the first is larger than the second,
  *  0 if the two are equal, and
  * -1 if the first is less than the second.
@@ -299,6 +300,6 @@ static int comp_search_1(const void *a, const void *b)
  *******************************************************************************/
 static int comp_search_2(const void *a, const void *b)
 {
-	return (((const int64_t *)a)[2] > ((const int64_t *)b)[2])
-	     - (((const int64_t *)a)[2] < ((const int64_t *)b)[2]);
+	return (((const SMIOL_Offset *)a)[2] > ((const SMIOL_Offset *)b)[2])
+	     - (((const SMIOL_Offset *)a)[2] < ((const SMIOL_Offset *)b)[2]);
 }

--- a/src/smiol_utils.h
+++ b/src/smiol_utils.h
@@ -10,13 +10,14 @@
 /*
  * Searching and sorting
  */
-void sort_triplet_array(size_t n_arr, int64_t *arr, int sort_entry);
-int64_t *search_triplet_array(int64_t key, size_t n_arr, int64_t *arr,
-                              int search_entry);
+void sort_triplet_array(size_t n_arr, SMIOL_Offset *arr, int sort_entry);
+SMIOL_Offset *search_triplet_array(SMIOL_Offset key,
+                                   size_t n_arr, SMIOL_Offset *arr,
+                                   int search_entry);
 
 /*
  * Debugging
  */
-void print_lists(int comm_rank, int64_t *comp_list, int64_t *io_list);
+void print_lists(int comm_rank, SMIOL_Offset *comp_list, SMIOL_Offset *io_list);
 
 #endif

--- a/src/smiol_utils.h
+++ b/src/smiol_utils.h
@@ -1,10 +1,11 @@
 /*******************************************************************************
  * Utilities and helper functions for SMIOL
  *******************************************************************************/
+#ifndef SMIOL_UTILS_H
+#define SMIOL_UTILS_H
 
-#include <stdint.h>
+#include "smiol_types.h"
 
-#define TRIPLET_SIZE ((size_t)3)
 
 /*
  * Searching and sorting
@@ -17,3 +18,5 @@ int64_t *search_triplet_array(int64_t key, size_t n_arr, int64_t *arr,
  * Debugging
  */
 void print_lists(int comm_rank, int64_t *comp_list, int64_t *io_list);
+
+#endif

--- a/src/smiol_utils.h
+++ b/src/smiol_utils.h
@@ -12,3 +12,8 @@
 void sort_triplet_array(size_t n_arr, int64_t *arr, int sort_entry);
 int64_t *search_triplet_array(int64_t key, size_t n_arr, int64_t *arr,
                               int search_entry);
+
+/*
+ * Debugging
+ */
+void print_lists(int comm_rank, int64_t *comp_list, int64_t *io_list);

--- a/src/smiolf.F90
+++ b/src/smiolf.F90
@@ -977,31 +977,36 @@ contains
     !
     !> \brief Creates a mapping between compute elements and I/O elements
     !> \details
-    !>  Allocate a SMIOLf_decomp and copy compute_elements and io_elements into 
-    !>  it. On success, SMIOL_SUCCESS is returned and decomp will point to a 
-    !>  valid SMIOL decomp. On error, decomp will be unassociated and a SMIOL 
-    !>  error code will be returned.
+    !>  Given arrays of global element IDs that each task computes and global
+    !>  element IDs that each task reads/writes, this routine works out a mapping
+    !>  of elements between compute and I/O tasks.
+    !>
+    !>  If all input arguments are determined to be valid and if the routine is
+    !>  successful in working out a mapping, the decomp pointer is allocated
+    !>  and given valid contents, and SMIOL_SUCCESS is returned; otherwise
+    !>  a non-success error code is returned and the decomp pointer is unassociated.
     !
     !-----------------------------------------------------------------------
     integer function SMIOLf_create_decomp(context, n_compute_elements, compute_elements, n_io_elements, io_elements, decomp) &
                                           result(ierr)
 
-        use iso_c_binding, only : c_size_t
-        use iso_c_binding, only : c_ptr, c_null_ptr, c_loc, c_f_pointer, c_associated
+        use iso_c_binding, only : c_size_t, c_ptr, c_null_ptr, c_loc, c_f_pointer, c_associated
 
         implicit none
 
-        type (SMIOLf_context), pointer :: context
+        ! Arguments
+        type (SMIOLf_context), target, intent(in) :: context
         integer(kind=c_size_t), intent(in) :: n_compute_elements
         integer(kind=SMIOL_offset_kind), dimension(n_compute_elements), target, intent(in) :: compute_elements
         integer(kind=c_size_t), intent(in) :: n_io_elements
         integer(kind=SMIOL_offset_kind), dimension(n_io_elements), target, intent(in) :: io_elements
         type (SMIOLf_decomp), pointer, intent(inout) :: decomp
 
-        type (c_ptr) :: c_context = c_null_ptr
-        type (c_ptr) :: c_decomp = c_null_ptr
-        type (c_ptr) :: c_compute_elements = c_null_ptr
-        type (c_ptr) :: c_io_elements = c_null_ptr
+        ! Local variables
+        type (c_ptr) :: c_context
+        type (c_ptr) :: c_decomp
+        type (c_ptr) :: c_compute_elements
+        type (c_ptr) :: c_io_elements
         
         interface
             function SMIOL_create_decomp(context, n_compute_elements, compute_elements, n_io_elements, io_elements, decomp) &
@@ -1009,35 +1014,40 @@ contains
                 use iso_c_binding, only : c_size_t, c_ptr, c_int
                 type (c_ptr), value :: context
                 integer(c_size_t), value :: n_compute_elements
-                type(c_ptr), value :: compute_elements
+                type (c_ptr), value :: compute_elements
                 integer(c_size_t), value :: n_io_elements
-                type(c_ptr), value :: io_elements
+                type (c_ptr), value :: io_elements
                 integer(kind=c_int) :: ierr
-                type(c_ptr) :: decomp
+                type (c_ptr) :: decomp
             end function
         end interface
 
-        ierr = SMIOL_SUCCESS
 
-        ! Translate Fortran types into C interoperable types
 
-        if (associated(context)) then
-            c_context = c_loc(context)
-        end if
-
+        ! Get C pointers to Fortran types
+        c_context = c_loc(context)
         c_compute_elements = c_loc(compute_elements)
         c_io_elements = c_loc(io_elements)
 
-        ! Create SMIOL_decomp type via c SMIOL_create_decomp
-        ierr = SMIOL_create_decomp(c_context, n_compute_elements, c_compute_elements, n_io_elements, c_io_elements, c_decomp)
+        c_decomp = c_null_ptr
 
-        ! Error check and translate c_decomp ptr into Fortran SMIOLf_decomp 
-        if (.not. c_associated(c_decomp)) then
-            nullify(decomp)
-            ierr = SMIOL_FORTRAN_ERROR
+        ierr = SMIOL_create_decomp(c_context, n_compute_elements, c_compute_elements, &
+                                   n_io_elements, c_io_elements, c_decomp)
+
+        ! Error check and translate c_decomp pointer into a Fortran SMIOLf_decomp pointer
+        if (ierr == SMIOL_SUCCESS) then
+            if (c_associated(c_decomp)) then
+                call c_f_pointer(c_decomp, decomp)
+            else
+                nullify(decomp)
+                ierr = SMIOL_FORTRAN_ERROR
+            end if
         else
-            call c_f_pointer(c_decomp, decomp)
-        endif
+            nullify(decomp)
+            if (c_associated(c_decomp)) then
+                ierr = SMIOL_FORTRAN_ERROR
+            endif
+        end if
 
     end function SMIOLf_create_decomp
 

--- a/src/smiolf.F90
+++ b/src/smiolf.F90
@@ -36,7 +36,7 @@ module SMIOLf
               SMIOLf_free_decomp
 
 
-    integer, parameter :: SMIOL_offset_kind = c_int64_t   ! Must match SMIOL_Offset in smiol.h
+    integer, parameter :: SMIOL_offset_kind = c_int64_t   ! Must match SMIOL_Offset in smiol_types.h
 
 
     type, bind(C) :: SMIOLf_context

--- a/src/smiolf.F90
+++ b/src/smiolf.F90
@@ -68,6 +68,8 @@ module SMIOLf
         !
         type(c_ptr) :: comp_list  ! Elements to be sent/received from/on a compute task
         type(c_ptr) :: io_list    ! Elements to be send/received from/on an I/O task
+
+        type (c_ptr) :: context   ! Pointer to (struct SMIOL_context); the context for this decomp
     end type SMIOLf_decomp
 
 


### PR DESCRIPTION
This merge adds implementations of the `SMIOL(f)_create_decomp` routines.
Along with these routines, several unit tests have been developed to verify
that the routines return correct `SMIOL_decomp` structures.