### PR TITLE
Add utility function for transferring fields according to a SMIOL_decomp

### DIFF
--- a/src/smiol_utils.h
+++ b/src/smiol_utils.h
@@ -6,6 +6,9 @@
 
 #include "smiol_types.h"
 
+#define SMIOL_COMP_TO_IO 1
+#define SMIOL_IO_TO_COMP 2
+
 
 /*
  * Searching and sorting
@@ -14,6 +17,12 @@ void sort_triplet_array(size_t n_arr, SMIOL_Offset *arr, int sort_entry);
 SMIOL_Offset *search_triplet_array(SMIOL_Offset key,
                                    size_t n_arr, SMIOL_Offset *arr,
                                    int search_entry);
+
+/*
+ * Communication
+ */
+int transfer_field(const struct SMIOL_decomp *decomp, int dir,
+                   size_t element_size, const void *in_field, void *out_field);
 
 /*
  * Debugging


### PR DESCRIPTION
This merge adds a new utility function for transferring fields as described by
a SMIOL_decomp. The transfer_field function uses a SMIOL_decomp structure
to transfer a field of arbitrarily sized elements between compute tasks and
I/O tasks.

Also included in this merge are unit tests for the transfer_field function.