### PR TITLE
Add get_io_elements function for generating I/O decompositions

### DIFF
--- a/src/smiol_utils.h
+++ b/src/smiol_utils.h
@@ -25,6 +25,12 @@ int transfer_field(const struct SMIOL_decomp *decomp, int dir,
                    size_t element_size, const void *in_field, void *out_field);
 
 /*
+ * Field decomposition
+ */
+int get_io_elements(int comm_rank, int num_io_tasks, int io_stride,
+                    size_t n_io_elements, size_t *io_start, size_t *io_count);
+
+/*
  * Debugging
  */
 void print_lists(int comm_rank, SMIOL_Offset *comp_list, SMIOL_Offset *io_list);


### PR DESCRIPTION
This PR adds a new utility function, `get_io_elements`, that is intended to be                                                       
used internally by SMIOL to compute I/O decompositions given the number of I/O                                                       
tasks, the stride between I/O tasks, and the total number of elements to be                                                          
read/written.                                                                                                                        
                                                                                                                                     
Included in this PR are unit tests for the `get_io_elements` function.