### PR TITLE
Add a function to convert Fortran strings to C strings

### DIFF
--- a/src/smiolf.F90
+++ b/src/smiolf.F90
@@ -282,9 +282,7 @@ contains
         type (c_ptr) :: c_context = c_null_ptr
         type (c_ptr) :: c_file = c_null_ptr
         integer(kind=c_int) :: c_mode
-        character(kind=c_char), dimension(:), pointer :: c_filename => null()
-
-        integer :: i
+        character(kind=c_char), dimension(:), pointer :: c_filename
 
         ! C interface definitions
         interface
@@ -306,10 +304,7 @@ contains
         ! Convert Fortran string to C character array
         !
         allocate(c_filename(len_trim(filename) + 1))
-        do i=1,len_trim(filename)
-            c_filename(i) = filename(i:i)
-        end do
-        c_filename(i) = c_null_char
+        call SMIOLf_f_to_c_string(filename, c_filename)
 
         c_mode = mode
 
@@ -416,8 +411,6 @@ contains
         type (c_ptr) :: c_file
         character(kind=c_char), dimension(:), pointer :: c_dimname
 
-        integer :: i
-
         ! C interface definitions
         interface
             function SMIOL_define_dim(file, dimname, dimsize) result(ierr) bind(C, name='SMIOL_define_dim')
@@ -438,10 +431,7 @@ contains
         ! Convert Fortran string to C character array
         !
         allocate(c_dimname(len_trim(dimname) + 1))
-        do i=1,len_trim(dimname)
-            c_dimname(i) = dimname(i:i)
-        end do
-        c_dimname(i) = c_null_char
+        call SMIOLf_f_to_c_string(dimname, c_dimname)
 
         ierr = SMIOL_define_dim(c_file, c_dimname, dimsize)
 
@@ -487,7 +477,6 @@ contains
         type (c_ptr) :: c_dimsize_ptr
         type (c_ptr) :: c_is_unlimited_ptr
 
-        integer :: i
 
         ! C interface definitions
         interface
@@ -510,10 +499,7 @@ contains
         ! Convert Fortran string to C character array
         !
         allocate(c_dimname(len_trim(dimname) + 1))
-        do i=1,len_trim(dimname)
-            c_dimname(i) = dimname(i:i)
-        end do
-        c_dimname(i) = c_null_char
+        call SMIOLf_f_to_c_string(dimname, c_dimname)
 
         !
         ! Set C dimsize
@@ -627,10 +613,7 @@ contains
         ! Convert Fortran string to C character array
         !
         allocate(c_varname(len_trim(varname) + 1))
-        do i=1,len_trim(varname)
-            c_varname(i) = varname(i:i)
-        end do
-        c_varname(i) = c_null_char
+        call SMIOLf_f_to_c_string(varname, c_varname)
 
         !
         ! Convert vartype and ndims
@@ -736,10 +719,7 @@ contains
         ! Convert variable name string
         !
         allocate(c_varname(len_trim(varname) + 1))
-        do i=1,len_trim(varname)
-            c_varname(i) = varname(i:i)
-        end do
-        c_varname(i) = c_null_char
+        call SMIOLf_f_to_c_string(varname, c_varname)
 
         !
         ! Set C pointer for variable type

--- a/src/smiolf.F90
+++ b/src/smiolf.F90
@@ -35,7 +35,8 @@ module SMIOLf
               SMIOLf_create_decomp, &
               SMIOLf_free_decomp, &
               SMIOLf_set_frame, &
-              SMIOLf_get_frame
+              SMIOLf_get_frame, &
+              SMIOLf_f_to_c_string
 
 
     integer, parameter :: SMIOL_offset_kind = c_int64_t   ! Must match SMIOL_Offset in smiol_types.h
@@ -1915,5 +1916,44 @@ contains
         end if
 
     end function SMIOLf_free_decomp
+
+    !-----------------------------------------------------------------------
+    !  routine SMIOLf_f_to_c_string
+    !
+    !> \brief Convert a Fortran string to a C null-terminated character array
+    !> \details
+    !>  Converts a Fortran string to a C null-terminated character array.
+    !>  The cstring output argument must be large enough to contain the trimmed
+    !>  Fortran string plus at least one c_null_char character. Any characters
+    !>  beyond len_trim(fstring) of cstring will be filled with c_null_char
+    !>  characters. If the size of cstring  is less than len_trim(fstring)+1,
+    !>  then only size(cstring)-1 characters from fstring will be copied into
+    !>  cstring before the final c_null_char character is added.
+    !
+    !-----------------------------------------------------------------------
+    subroutine SMIOLf_f_to_c_string(fstring, cstring)
+
+        use iso_c_binding, only : c_char, c_null_char
+
+        implicit none
+
+        character(len=*), intent(in) :: fstring
+        character(kind=c_char), dimension(:), intent(out) :: cstring
+
+        integer :: i
+        integer :: nchar
+
+        if (size(cstring) <= 0) then
+            return
+        end if
+
+        nchar = min(size(cstring)-1, len_trim(fstring))
+
+        do i = 1, nchar
+            cstring(i) = fstring(i:i)
+        end do
+        cstring(nchar+1:size(cstring)) = c_null_char
+
+    end subroutine SMIOLf_f_to_c_string
 
 end module SMIOLf


### PR DESCRIPTION
These commits add a new function to smiolf.F90 that converts Fortran strings to C strings and uses that function to replace individual pieces of SMIOLf code that did such conversions.