### PR TITLE
Add ability to inquire about the unlimited dimension

### DIFF
--- a/smiol_runner.F90
+++ b/smiol_runner.F90
@@ -887,6 +887,7 @@ contains
 #endif
         integer(kind=SMIOL_offset_kind) :: dimsize
         integer(kind=SMIOL_offset_kind) :: expected_dimsize
+        logical :: is_unlimited
 
         write(test_log,'(a)') '********************************************************************************'
         write(test_log,'(a)') '************ SMIOL_define_dim / SMIOL_inquire_dim unit tests *******************'
@@ -975,8 +976,52 @@ contains
         end if
 #endif
 
-        ! Everything OK for SMIOL_inquire_dim, unlimited dimension
-        write(test_log,'(a)',advance='no') 'Everything OK - unlimited dimension (SMIOLf_inquire_dim): '
+        ! Everything OK for SMIOL_inquire_dim, not asking for dimsize or is_unlimited
+        write(test_log,'(a)',advance='no') 'Everything OK - No dimsize or is_unlimited argument (SMIOLf_inquire_dim): '
+        ierr = SMIOLf_inquire_dim(file, 'nCells')
+        if (ierr == SMIOL_INVALID_ARGUMENT) then
+            write(test_log,'(a)') 'PASS'
+        else
+            write(test_log,'(a)') 'FAIL - SMIOL_INVALID_ARGUMENT was not returned'
+            ierrcount = ierrcount + 1
+        end if
+
+        ! Everything OK for SMIOL_inquire_dim, inquiry on the unlimited dimension
+        write(test_log,'(a)',advance='no') 'Everything OK - inquire if Time is the unlimited dim (SMIOLf_inquire_dim): '
+        ierr = SMIOLf_inquire_dim(file, 'Time', is_unlimited=is_unlimited)
+        if (ierr == SMIOL_SUCCESS) then
+#ifdef SMIOL_PNETCDF
+            if (is_unlimited) then
+#else
+            if (.not. is_unlimited) then
+#endif
+                write(test_log,'(a)') 'PASS'
+            else
+                write(test_log,'(a)') 'FAIL - SMIOL_SUCCESS was returned but is_unlimited return False'
+                ierrcount = ierrcount + 1
+            endif
+        else
+            write(test_log,'(a)') 'FAIL - SMIOL_SUCCESS was not returned'
+            ierrcount = ierrcount + 1
+        end if
+
+        ! Everything OK for SMIOL_inquire_dim, unlimited inquiry a non-unlimited dimension
+        write(test_log,'(a)',advance='no') 'Everything OK - inquire if nCells is the unlimited dim (SMIOLf_inquire_dim): '
+        ierr = SMIOLf_inquire_dim(file, 'nCells', is_unlimited=is_unlimited)
+        if (ierr == SMIOL_SUCCESS) then
+            if (.not. is_unlimited) then
+                write(test_log,'(a)') 'PASS'
+            else
+                write(test_log,'(a)') 'FAIL - SMIOL_SUCCESS was returned but is_unlimited returned True'
+                ierrcount = ierrcount + 1
+            endif
+        else
+            write(test_log,'(a)') 'FAIL - SMIOL_SUCCESS was not returned'
+            ierrcount = ierrcount + 1
+        end if
+
+        ! Everything OK for SMIOL_inquire_dim, unlimited dimension size
+        write(test_log,'(a)',advance='no') 'Everything OK - unlimited dimension size (SMIOLf_inquire_dim): '
         dimsize = 0_SMIOL_offset_kind
         ierr = SMIOLf_inquire_dim(file, 'Time', dimsize)
         if (ierr == SMIOL_SUCCESS) then
@@ -987,6 +1032,25 @@ contains
                                ' (got ', dimsize, ', expected ', 0_SMIOL_offset_kind, ')'
                 ierrcount = ierrcount + 1
             end if
+        else
+            write(test_log,'(a)') 'FAIL - SMIOL_SUCCESS was not returned'
+            ierrcount = ierrcount + 1
+        end if
+
+        ! Everything OK for SMIOL_inquire_dim, unlimited and dimsize inquiry
+        write(test_log,'(a)',advance='no') 'Everything OK - inquire about dimsize and is_unlimited: '
+        ierr = SMIOLf_inquire_dim(file, 'Time', dimsize, is_unlimited)
+        if (ierr == SMIOL_SUCCESS) then
+#ifdef SMIOL_PNETCDF
+            if (is_unlimited .and. dimsize == 0_SMIOL_offset_kind) then
+#else
+            if (.not. is_unlimited) then
+#endif
+                write(test_log,'(a)') 'PASS'
+            else
+                write(test_log,'(a)') 'FAIL - SMIOL_SUCCESS was returned but is_unlimited returned False or dimsize was incorrect'
+                ierrcount = ierrcount + 1
+            endif
         else
             write(test_log,'(a)') 'FAIL - SMIOL_SUCCESS was not returned'
             ierrcount = ierrcount + 1

--- a/smiol_runner.c
+++ b/smiol_runner.c
@@ -303,7 +303,7 @@ int main(int argc, char **argv)
 		return 1;
 	}
 
-	if ((ierr = SMIOL_inquire_dim(file, "nCells", &dimsize)) != SMIOL_SUCCESS) {
+	if ((ierr = SMIOL_inquire_dim(file, "nCells", &dimsize, NULL)) != SMIOL_SUCCESS) {
 		fprintf(test_log, "ERROR: SMIOL_inquire_dim: %s ", SMIOL_error_string(ierr));
 		return 1;
 	}
@@ -1414,7 +1414,7 @@ int test_dimensions(FILE *test_log)
 
 	/* Handle NULL file handle */
 	fprintf(test_log, "Handle NULL file handle (SMIOL_inquire_dim): ");
-	ierr = SMIOL_inquire_dim(NULL, "invalid_dim", &dimsize);
+	ierr = SMIOL_inquire_dim(NULL, "invalid_dim", &dimsize, NULL);
 	if (ierr != SMIOL_SUCCESS) {
 		fprintf(test_log, "PASS\n");
 	}
@@ -1425,7 +1425,7 @@ int test_dimensions(FILE *test_log)
 
 	/* Handle NULL dimension name */
 	fprintf(test_log, "Handle NULL dimension name (SMIOL_inquire_dim): ");
-	ierr = SMIOL_inquire_dim(file, NULL, &dimsize);
+	ierr = SMIOL_inquire_dim(file, NULL, &dimsize, NULL);
 	if (ierr != SMIOL_SUCCESS) {
 		fprintf(test_log, "PASS\n");
 	}
@@ -1435,9 +1435,9 @@ int test_dimensions(FILE *test_log)
 	}
 
 	/* Handle NULL dimension size */
-	fprintf(test_log, "Handle NULL dimension size (SMIOL_inquire_dim): ");
-	ierr = SMIOL_inquire_dim(file, "nCells", NULL);
-	if (ierr != SMIOL_SUCCESS) {
+	fprintf(test_log, "Handle NULL dimension size and NULL unlimited argument (SMIOL_inquire_dim): ");
+	ierr = SMIOL_inquire_dim(file, "nCells", NULL, NULL);
+	if (ierr == SMIOL_INVALID_ARGUMENT) {
 		fprintf(test_log, "PASS\n");
 	}
 	else {
@@ -1447,7 +1447,7 @@ int test_dimensions(FILE *test_log)
 
 	/* Handle undefined dimension */
 	fprintf(test_log, "Handle undefined dimension (SMIOL_inquire_dim): ");
-	ierr = SMIOL_inquire_dim(file, "foobar", &dimsize);
+	ierr = SMIOL_inquire_dim(file, "foobar", &dimsize, NULL);
 #ifdef SMIOL_PNETCDF
 	if (ierr == SMIOL_LIBRARY_ERROR) {
 		fprintf(test_log, "PASS (%s)\n", SMIOL_lib_error_string(context));
@@ -1469,7 +1469,7 @@ int test_dimensions(FILE *test_log)
 	/* Everything OK for SMIOL_inquire_dim, unlimited dimension */
 	fprintf(test_log, "Everything OK - unlimited dimension (SMIOL_inquire_dim): ");
 	dimsize = (SMIOL_Offset)0;
-	ierr = SMIOL_inquire_dim(file, "Time", &dimsize);
+	ierr = SMIOL_inquire_dim(file, "Time", &dimsize, NULL);
 	if (ierr == SMIOL_SUCCESS) {
 		if (dimsize == (SMIOL_Offset)0) {
 			fprintf(test_log, "PASS\n");
@@ -1493,7 +1493,7 @@ int test_dimensions(FILE *test_log)
 #else
 	expected_dimsize = (SMIOL_Offset)0;
 #endif
-	ierr = SMIOL_inquire_dim(file, "nCells", &dimsize);
+	ierr = SMIOL_inquire_dim(file, "nCells", &dimsize, NULL);
 	if (ierr == SMIOL_SUCCESS) {
 		if (dimsize == expected_dimsize) {
 			fprintf(test_log, "PASS\n");
@@ -1517,7 +1517,7 @@ int test_dimensions(FILE *test_log)
 #else
 	expected_dimsize = (SMIOL_Offset)0;
 #endif
-	ierr = SMIOL_inquire_dim(file, "nElements", &dimsize);
+	ierr = SMIOL_inquire_dim(file, "nElements", &dimsize, NULL);
 	if (ierr == SMIOL_SUCCESS) {
 		if (dimsize == expected_dimsize) {
 			fprintf(test_log, "PASS\n");
@@ -1551,7 +1551,7 @@ int test_dimensions(FILE *test_log)
 	/* Existing file for SMIOL_inquire_dim, unlimited dimension */
 	fprintf(test_log, "Existing file - unlimited dimension (SMIOL_inquire_dim): ");
 	dimsize = (SMIOL_Offset)0;
-	ierr = SMIOL_inquire_dim(file, "Time", &dimsize);
+	ierr = SMIOL_inquire_dim(file, "Time", &dimsize, NULL);
 	if (ierr == SMIOL_SUCCESS) {
 		if (dimsize == (SMIOL_Offset)0) {
 			fprintf(test_log, "PASS\n");
@@ -1575,7 +1575,7 @@ int test_dimensions(FILE *test_log)
 #else
 	expected_dimsize = (SMIOL_Offset)0;
 #endif
-	ierr = SMIOL_inquire_dim(file, "nCells", &dimsize);
+	ierr = SMIOL_inquire_dim(file, "nCells", &dimsize, NULL);
 	if (ierr == SMIOL_SUCCESS) {
 		if (dimsize == expected_dimsize) {
 			fprintf(test_log, "PASS\n");
@@ -1599,7 +1599,7 @@ int test_dimensions(FILE *test_log)
 #else
 	expected_dimsize = (SMIOL_Offset)0;
 #endif
-	ierr = SMIOL_inquire_dim(file, "nElements", &dimsize);
+	ierr = SMIOL_inquire_dim(file, "nElements", &dimsize, NULL);
 	if (ierr == SMIOL_SUCCESS) {
 		if (dimsize == expected_dimsize) {
 			fprintf(test_log, "PASS\n");

--- a/src/smiol.h
+++ b/src/smiol.h
@@ -25,7 +25,8 @@ int SMIOL_close_file(struct SMIOL_file **file);
  * Dimension methods
  */
 int SMIOL_define_dim(struct SMIOL_file *file, const char *dimname, SMIOL_Offset dimsize);
-int SMIOL_inquire_dim(struct SMIOL_file *file, const char *dimname, SMIOL_Offset *dimsize);
+int SMIOL_inquire_dim(struct SMIOL_file *file, const char *dimname,
+                      SMIOL_Offset *dimsize, int *is_unlimited);
 
 /*
  * Variable methods


### PR DESCRIPTION
These commits add a new argument to both `SMIOL_inquire_dim` and `SMIOLf_inquire_dim`, `record`,  which, if present will return whether or not if the requested dimension is the unlimited dimension or not.