### PR TITLE
Implement SMIOL(f)_define_att and SMIOL(f)_inquire_att routines

### DIFF
--- a/smiol_runner.F90
+++ b/smiol_runner.F90
@@ -9,6 +9,8 @@ program smiol_runner
     implicit none
 
     integer :: ierr
+    integer :: i
+    real :: f
     integer :: my_proc_id
     integer :: test_log = 42
     integer(kind=c_size_t) :: n_compute_elements = 1
@@ -190,6 +192,23 @@ program smiol_runner
         stop 1
     endif
 
+    i = 2
+    if (SMIOLf_define_att(file, 'theta', 'time_levels', i) /= SMIOL_SUCCESS) then
+        write(test_log,'(a)') "ERROR: 'SMIOLf_define_att' was not called successfully"
+        stop 1
+    endif
+
+    f = 3.14159265
+    if (SMIOLf_define_att(file, '', 'pi', f) /= SMIOL_SUCCESS) then
+        write(test_log,'(a)') "ERROR: 'SMIOLf_define_att' was not called successfully"
+        stop 1
+    endif
+
+    if (SMIOLf_define_att(file, '', 'title', 'MPAS-Atmosphere v7.0') /= SMIOL_SUCCESS) then
+        write(test_log,'(a)') "ERROR: 'SMIOLf_define_att' was not called successfully"
+        stop 1
+    endif
+
     if (SMIOLf_close_file(file) /= SMIOL_SUCCESS) then
         write(test_log,'(a)') "ERROR: 'SMIOLf_close_file' was not called successfully"
         stop 1
@@ -202,11 +221,6 @@ program smiol_runner
 
     if (SMIOLf_get_var() /= SMIOL_SUCCESS) then
         write(test_log,'(a)') "ERROR: 'SMIOLf_get_var' was not called successfully"
-        stop 1
-    endif
-
-    if (SMIOLf_define_att() /= SMIOL_SUCCESS) then
-        write(test_log,'(a)') "ERROR: 'SMIOLf_define_att' was not called successfully"
         stop 1
     endif
 

--- a/smiol_runner.F90
+++ b/smiol_runner.F90
@@ -92,6 +92,19 @@ program smiol_runner
 
 
     !
+    ! Unit tests for attributes
+    !
+    ierr = test_attributes(test_log)
+    if (ierr == 0) then
+        write(test_log,'(a)') 'All tests PASSED!'
+        write(test_log,'(a)') ''
+    else
+        write(test_log,'(i3,a)') ierr, ' tests FAILED!'
+        write(test_log,'(a)') ''
+    end if
+
+
+    !
     ! Unit tests for SMIOL_create_decomp and SMIOL_free_decomp
     !
     ierr = test_decomp(test_log)
@@ -210,15 +223,29 @@ program smiol_runner
         stop 1
     endif
 
+#ifdef SMIOL_PNETCDF
     if (SMIOLf_inquire_att(file, 'theta', 'time_levels', i) /= SMIOL_SUCCESS) then
         write(test_log,'(a)') "ERROR: 'SMIOLf_inquire_att' was not called successfully"
         stop 1
     endif
+#else
+    if (SMIOLf_inquire_att(file, '', 'title', tempstr) /= SMIOL_WRONG_ARG_TYPE) then
+        write(test_log,'(a)') "ERROR: 'SMIOLf_inquire_att' was not called successfully"
+        stop 1
+    endif
+#endif
 
+#ifdef SMIOL_PNETCDF
     if (SMIOLf_inquire_att(file, '', 'title', tempstr) /= SMIOL_SUCCESS) then
         write(test_log,'(a)') "ERROR: 'SMIOLf_inquire_att' was not called successfully"
         stop 1
     endif
+#else
+    if (SMIOLf_inquire_att(file, '', 'title', tempstr) /= SMIOL_WRONG_ARG_TYPE) then
+        write(test_log,'(a)') "ERROR: 'SMIOLf_inquire_att' was not called successfully"
+        stop 1
+    endif
+#endif
 
     if (SMIOLf_close_file(file) /= SMIOL_SUCCESS) then
         write(test_log,'(a)') "ERROR: 'SMIOLf_close_file' was not called successfully"
@@ -1551,6 +1578,417 @@ contains
         write(test_log,'(a)') ''
 
     end function test_variables
+
+
+    function test_attributes(test_log) result(ierrcount)
+
+        implicit none
+
+        integer, intent(in) :: test_log
+
+        integer, parameter :: R4KIND = selected_real_kind(6)
+        integer, parameter :: R8KIND = selected_real_kind(12)
+
+        integer :: ierrcount
+        type (SMIOLf_context), pointer :: context
+        type (SMIOLf_file), pointer :: file
+        character(len=32), dimension(2) :: dimnames
+        real(kind=R4KIND) :: real32_att
+        real(kind=R8KIND) :: real64_att
+        integer :: int32_att
+        character(len=32) :: text_att
+
+
+        write(test_log,'(a)') '********************************************************************************'
+        write(test_log,'(a)') '************ SMIOL_define_att / SMIOL_inquire_att unit tests *******************'
+        write(test_log,'(a)') ''
+
+        ierrcount = 0
+
+
+        ! Create a SMIOL context for testing attribute routines
+        nullify(context)
+        ierr = SMIOLf_init(MPI_COMM_WORLD, context)
+        if (ierr /= SMIOL_SUCCESS .or. .not. associated(context)) then
+            write(test_log,'(a)') 'Failed to create a context...'
+            ierrcount = -1
+            return
+        end if
+
+        ! Create a SMIOL file for testing attribute routines
+        nullify(file)
+        ierr = SMIOLf_open_file(context, 'test_atts_fortran.nc', SMIOL_FILE_CREATE, file)
+        if (ierr /= SMIOL_SUCCESS .or. .not. associated(file)) then
+            write(test_log,'(a)') 'Failed to create a file...'
+            ierrcount = -1
+            return
+        end if
+
+        ! Define several dimensions in the file to be used when defining variables
+        if (SMIOLf_define_dim(file, 'Time', -1_SMIOL_offset_kind) /= SMIOL_SUCCESS) then
+            write(test_log,'(a)') 'Failed to create dimension Time...'
+            ierrcount = -1
+            return
+        end if
+
+        if (SMIOLf_define_dim(file, 'nCells', 40962_SMIOL_offset_kind) /= SMIOL_SUCCESS) then
+            write(test_log,'(a)') 'Failed to create dimension nCells...'
+            ierrcount = -1
+            return
+        end if
+
+        ! Define a 32-bit real variable with one non-record dimension and a record dimension
+        dimnames(1) = 'Time'
+        dimnames(2) = 'nCells'
+        if (SMIOLf_define_var(file, 'surface_pressure', SMIOL_REAL32, 2, dimnames) /= SMIOL_SUCCESS) then
+            write(test_log,'(a)') 'Failed to create variable surface_pressure...'
+            ierrcount = -1
+            return
+        end if
+
+        ! Everything OK - Define a global REAL32 attribute
+        write(test_log,'(a)',advance='no') 'Everything OK - Define a global REAL32 attribute: '
+        real32_att = 3.14159_R4KIND
+        ierr = SMIOLf_define_att(file, '', 'pi', real32_att)
+        if (ierr == SMIOL_SUCCESS) then
+            write(test_log,'(a)') 'PASS'
+        else
+            write(test_log,'(a)') 'FAIL - SMIOL_SUCCESS was not returned'
+            ierrcount = ierrcount + 1
+        end if
+
+        ! Everything OK - Define a global REAL64 attribute
+        write(test_log,'(a)',advance='no') 'Everything OK - Define a global REAL64 attribute: '
+        real64_att = 2.718281828_R8KIND
+        ierr = SMIOLf_define_att(file, '', 'e', real64_att)
+        if (ierr == SMIOL_SUCCESS) then
+            write(test_log,'(a)') 'PASS'
+        else
+            write(test_log,'(a)') 'FAIL - SMIOL_SUCCESS was not returned'
+            ierrcount = ierrcount + 1
+        end if
+
+        ! Everything OK - Define another global REAL64 attribute
+        write(test_log,'(a)',advance='no') 'Everything OK - Define another global REAL64 attribute: '
+        real64_att = 1.0_R8KIND
+        ierr = SMIOLf_define_att(file, '', 'unity', real64_att)
+        if (ierr == SMIOL_SUCCESS) then
+            write(test_log,'(a)') 'PASS'
+        else
+            write(test_log,'(a)') 'FAIL - SMIOL_SUCCESS was not returned'
+            ierrcount = ierrcount + 1
+        end if
+
+        ! Everything OK - Define a global INT32 attribute
+        write(test_log,'(a)',advance='no') 'Everything OK - Define a global INT32 attribute: '
+        int32_att = 42
+        ierr = SMIOLf_define_att(file, '', 'grid_id', int32_att)
+        if (ierr == SMIOL_SUCCESS) then
+            write(test_log,'(a)') 'PASS'
+        else
+            write(test_log,'(a)') 'FAIL - SMIOL_SUCCESS was not returned'
+            ierrcount = ierrcount + 1
+        end if
+
+        ! Everything OK - Define a global CHAR attribute
+        write(test_log,'(a)',advance='no') 'Everything OK - Define a global CHAR attribute: '
+        text_att = "Don't panic!"
+        ierr = SMIOLf_define_att(file, '', 'Advice', text_att)
+        if (ierr == SMIOL_SUCCESS) then
+            write(test_log,'(a)') 'PASS'
+        else
+            write(test_log,'(a)') 'FAIL - SMIOL_SUCCESS was not returned'
+            ierrcount = ierrcount + 1
+        end if
+
+        ! Everything OK - Define _FillValue variable attribute
+        write(test_log,'(a)',advance='no') 'Everything OK - Define _FillValue variable attribute: '
+        real32_att = 0.0_R4KIND
+        ierr = SMIOLf_define_att(file, 'surface_pressure', '_FillValue', real32_att)
+        if (ierr == SMIOL_SUCCESS) then
+            write(test_log,'(a)') 'PASS'
+        else
+            write(test_log,'(a)') 'FAIL - SMIOL_SUCCESS was not returned'
+            ierrcount = ierrcount + 1
+        end if
+
+        ! Everything OK - Define a variable REAL32 attribute
+        write(test_log,'(a)',advance='no') 'Everything OK - Define a variable REAL32 attribute: '
+        real32_att = 3.14159_R4KIND
+        ierr = SMIOLf_define_att(file, 'surface_pressure', 'pi', real32_att)
+        if (ierr == SMIOL_SUCCESS) then
+            write(test_log,'(a)') 'PASS'
+        else
+            write(test_log,'(a)') 'FAIL - SMIOL_SUCCESS was not returned'
+            ierrcount = ierrcount + 1
+        end if
+
+        ! Everything OK - Define a variable REAL64 attribute
+        write(test_log,'(a)',advance='no') 'Everything OK - Define a variable REAL64 attribute: '
+        real64_att = 2.718281828_R8KIND
+        ierr = SMIOLf_define_att(file, 'surface_pressure', 'e', real64_att)
+        if (ierr == SMIOL_SUCCESS) then
+            write(test_log,'(a)') 'PASS'
+        else
+            write(test_log,'(a)') 'FAIL - SMIOL_SUCCESS was not returned'
+            ierrcount = ierrcount + 1
+        end if
+
+        ! Everything OK - Define another variable REAL64 attribute
+        write(test_log,'(a)',advance='no') 'Everything OK - Define another variable REAL64 attribute: '
+        real64_att = -1.0_R8KIND
+        ierr = SMIOLf_define_att(file, 'surface_pressure', 'missing_value', real64_att)
+        if (ierr == SMIOL_SUCCESS) then
+            write(test_log,'(a)') 'PASS'
+        else
+            write(test_log,'(a)') 'FAIL - SMIOL_SUCCESS was not returned'
+            ierrcount = ierrcount + 1
+        end if
+
+        ! Everything OK - Define a variable INT32 attribute
+        write(test_log,'(a)',advance='no') 'Everything OK - Define a variable INT32 attribute: '
+        int32_att = 42
+        ierr = SMIOLf_define_att(file, 'surface_pressure', 'grid_id', int32_att)
+        if (ierr == SMIOL_SUCCESS) then
+            write(test_log,'(a)') 'PASS'
+        else
+            write(test_log,'(a)') 'FAIL - SMIOL_SUCCESS was not returned'
+            ierrcount = ierrcount + 1
+        end if
+
+        ! Everything OK - Define a variable CHAR attribute
+        write(test_log,'(a)',advance='no') 'Everything OK - Define a variable CHAR attribute: '
+        text_att = "Don't panic!"
+        ierr = SMIOLf_define_att(file, 'surface_pressure', 'Advice', text_att)
+        if (ierr == SMIOL_SUCCESS) then
+            write(test_log,'(a)') 'PASS'
+        else
+            write(test_log,'(a)') 'FAIL - SMIOL_SUCCESS was not returned'
+            ierrcount = ierrcount + 1
+        end if
+
+#ifdef SMIOL_PNETCDF
+        ! Try to define an attribute for a non-existent variable
+        write(test_log,'(a)',advance='no') 'Try to define an attribute for a non-existent variable: '
+        real64_att = 0.01_R8KIND;
+        ierr = SMIOLf_define_att(file, 'foobar', 'min_val', real64_att)
+        if (ierr == SMIOL_LIBRARY_ERROR) then
+            write(test_log,'(a)') 'PASS'
+        else
+            write(test_log,'(a)') 'FAIL - SMIOL_LIBRARY_ERROR was not returned'
+            ierrcount = ierrcount + 1
+        end if
+#endif
+
+        ! Close the SMIOL file
+        ierr = SMIOLf_close_file(file)
+        if (ierr /= SMIOL_SUCCESS .or. associated(file)) then
+            write(test_log,'(a)') 'Failed to close the file...'
+            ierrcount = -1
+            return
+        end if
+
+        ! Re-open the SMIOL file
+        nullify(file)
+        ierr = SMIOLf_open_file(context, 'test_atts_fortran.nc', SMIOL_FILE_READ, file)
+        if (ierr /= SMIOL_SUCCESS .or. .not. associated(file)) then
+            write(test_log,'(a)') 'Failed to re-open the file...'
+            ierrcount = -1
+            return
+        end if
+
+#ifdef SMIOL_PNETCDF
+        ! Everything OK - Inquire about a global REAL32 attribute
+        write(test_log,'(a)',advance='no') 'Everything OK - Inquire about a global REAL32 attribute: '
+        real32_att = 0.0_R4KIND
+        ierr = SMIOLf_inquire_att(file, '', 'pi', real32_att)
+        if (ierr == SMIOL_SUCCESS .and. real32_att == 3.14159_R4KIND) then
+            write(test_log,'(a)') 'PASS'
+        else
+            write(test_log,'(a)') 'FAIL - SMIOL_SUCCESS was not returned or attribute value was incorrect'
+            ierrcount = ierrcount + 1
+        end if
+
+        ! Everything OK - Inquire about a global REAL64 attribute
+        write(test_log,'(a)',advance='no') 'Everything OK - Inquire about a global REAL64 attribute: '
+        real64_att = 0.0_R8KIND
+        ierr = SMIOLf_inquire_att(file, '', 'e', real64_att)
+        if (ierr == SMIOL_SUCCESS .and. real64_att == 2.718281828_R8KIND) then
+            write(test_log,'(a)') 'PASS'
+        else
+            write(test_log,'(a)') 'FAIL - SMIOL_SUCCESS was not returned or attribute value was incorrect'
+            ierrcount = ierrcount + 1
+        end if
+
+        ! Everything OK - Inquire about a global INT32 attribute
+        write(test_log,'(a)',advance='no') 'Everything OK - Inquire about a global INT32 attribute: '
+        int32_att = 0
+        ierr = SMIOLf_inquire_att(file, '', 'grid_id', int32_att)
+        if (ierr == SMIOL_SUCCESS .and. int32_att == 42) then
+            write(test_log,'(a)') 'PASS'
+        else
+            write(test_log,'(a)') 'FAIL - SMIOL_SUCCESS was not returned or attribute value was incorrect'
+            ierrcount = ierrcount + 1
+        end if
+
+        ! Everything OK - Inquire about a global CHAR attribute
+        write(test_log,'(a)',advance='no') 'Everything OK - Inquire about a global CHAR attribute: '
+        text_att = " "
+        ierr = SMIOLf_inquire_att(file, '', 'Advice', text_att)
+        if (ierr == SMIOL_SUCCESS .and. trim(text_att) == "Don't panic!") then
+            write(test_log,'(a)') 'PASS'
+        else
+            write(test_log,'(a)') 'FAIL - SMIOL_SUCCESS was not returned or attribute value was incorrect'
+            ierrcount = ierrcount + 1
+        end if
+
+        ! Everything OK - Inquire about _FillValue variable attribute
+        write(test_log,'(a)',advance='no') 'Everything OK - Inquire about _FillValue variable attribute: '
+        real32_att = -999.0_R4KIND
+        ierr = SMIOLf_inquire_att(file, 'surface_pressure', '_FillValue', real32_att)
+        if (ierr == SMIOL_SUCCESS .and. real32_att == 0.0_R4KIND) then
+            write(test_log,'(a)') 'PASS'
+        else
+            write(test_log,'(a)') 'FAIL - SMIOL_SUCCESS was not returned or attribute value was incorrect'
+            ierrcount = ierrcount + 1
+        end if
+
+        ! Everything OK - Inquire about a variable REAL32 attribute
+        write(test_log,'(a)',advance='no') 'Everything OK - Inquire about a variable REAL32 attribute: '
+        real32_att = 0.0_R4KIND
+        ierr = SMIOLf_inquire_att(file, 'surface_pressure', 'pi', real32_att)
+        if (ierr == SMIOL_SUCCESS .and. real32_att == 3.14159_R4KIND) then
+            write(test_log,'(a)') 'PASS'
+        else
+            write(test_log,'(a)') 'FAIL - SMIOL_SUCCESS was not returned or attribute value was incorrect'
+            ierrcount = ierrcount + 1
+        end if
+
+        ! Everything OK - Inquire about a variable REAL64 attribute
+        write(test_log,'(a)',advance='no') 'Everything OK - Inquire about a variable REAL64 attribute: '
+        real64_att = 0.0_R8KIND
+        ierr = SMIOLf_inquire_att(file, 'surface_pressure', 'e', real64_att)
+        if (ierr == SMIOL_SUCCESS .and. real64_att == 2.718281828_R8KIND) then
+            write(test_log,'(a)') 'PASS'
+        else
+            write(test_log,'(a)') 'FAIL - SMIOL_SUCCESS was not returned or attribute value was incorrect'
+            ierrcount = ierrcount + 1
+        end if
+
+        ! Everything OK - Inquire about a variable INT32 attribute
+        write(test_log,'(a)',advance='no') 'Everything OK - Inquire about a variable INT32 attribute: '
+        int32_att = 0
+        ierr = SMIOLf_inquire_att(file, 'surface_pressure', 'grid_id', int32_att)
+        if (ierr == SMIOL_SUCCESS .and. int32_att == 42) then
+            write(test_log,'(a)') 'PASS'
+        else
+            write(test_log,'(a)') 'FAIL - SMIOL_SUCCESS was not returned or attribute value was incorrect'
+            ierrcount = ierrcount + 1
+        end if
+
+        ! Everything OK - Inquire about a variable CHAR attribute
+        write(test_log,'(a)',advance='no') 'Everything OK - Inquire about a variable CHAR attribute: '
+        text_att = " "
+        ierr = SMIOLf_inquire_att(file, 'surface_pressure', 'Advice', text_att)
+        if (ierr == SMIOL_SUCCESS .and. trim(text_att) == "Don't panic!") then
+            write(test_log,'(a)') 'PASS'
+        else
+            write(test_log,'(a)') 'FAIL - SMIOL_SUCCESS was not returned or attribute value was incorrect'
+            ierrcount = ierrcount + 1
+        end if
+
+        ! Try to inquire about an attribute for a non-existent variable
+        write(test_log,'(a)',advance='no') 'Try to inquire about an attribute for a non-existent variable: '
+        real64_att = 0.0_R8KIND
+        ierr = SMIOLf_inquire_att(file, 'foobar', 'e', real64_att)
+        if (ierr == SMIOL_LIBRARY_ERROR) then
+            write(test_log,'(a)') 'PASS'
+        else
+            write(test_log,'(a)') 'FAIL - SMIOL_LIBRARY_ERROR was not returned'
+            ierrcount = ierrcount + 1
+        end if
+
+        ! Try to inquire about a non-existent attribute
+        write(test_log,'(a)',advance='no') 'Try to inquire about a non-existent attribute: '
+        real64_att = 0.0_R8KIND
+        ierr = SMIOLf_inquire_att(file, 'surface_pressure', 'blah', real64_att)
+        if (ierr == SMIOL_LIBRARY_ERROR) then
+            write(test_log,'(a)') 'PASS'
+        else
+            write(test_log,'(a)') 'FAIL - SMIOL_LIBRARY_ERROR was not returned'
+            ierrcount = ierrcount + 1
+        end if
+
+        ! Try to inquire about a CHAR attribute with insufficient argument size
+        write(test_log,'(a)',advance='no') 'Try to inquire about a CHAR attribute with insufficient argument size: '
+        ierr = SMIOLf_inquire_att(file, 'surface_pressure', 'Advice', text_att(1:4))
+        if (ierr == SMIOL_INSUFFICIENT_ARG) then
+            write(test_log,'(a)') 'PASS'
+        else
+            write(test_log,'(a)') 'FAIL - SMIOL_INSUFFICIENT_ARG was not returned'
+            ierrcount = ierrcount + 1
+        end if
+#endif
+
+        ! Try to inquire about a REAL32 attribute with wrong variable type
+        write(test_log,'(a)',advance='no') 'Try to inquire about a REAL32 attribute with wrong variable type: '
+        ierr = SMIOLf_inquire_att(file, '', 'pi', int32_att)
+        if (ierr == SMIOL_WRONG_ARG_TYPE) then
+            write(test_log,'(a)') 'PASS'
+        else
+            write(test_log,'(a)') 'FAIL - SMIOL_WRONG_ARG_TYPE was not returned'
+            ierrcount = ierrcount + 1
+        end if
+
+        ! Try to inquire about a REAL64 attribute with wrong variable type
+        write(test_log,'(a)',advance='no') 'Try to inquire about a REAL64 attribute with wrong variable type: '
+        ierr = SMIOLf_inquire_att(file, '', 'e', real32_att)
+        if (ierr == SMIOL_WRONG_ARG_TYPE) then
+            write(test_log,'(a)') 'PASS'
+        else
+            write(test_log,'(a)') 'FAIL - SMIOL_WRONG_ARG_TYPE was not returned'
+            ierrcount = ierrcount + 1
+        end if
+
+        ! Try to inquire about an INT32 attribute with wrong variable type
+        write(test_log,'(a)',advance='no') 'Try to inquire about an INT32 attribute with wrong variable type: '
+        ierr = SMIOLf_inquire_att(file, '', 'grid_id', real64_att)
+        if (ierr == SMIOL_WRONG_ARG_TYPE) then
+            write(test_log,'(a)') 'PASS'
+        else
+            write(test_log,'(a)') 'FAIL - SMIOL_WRONG_ARG_TYPE was not returned'
+            ierrcount = ierrcount + 1
+        end if
+
+        ! Try to inquire about a CHAR attribute with wrong variable type
+        write(test_log,'(a)',advance='no') 'Try to inquire about a CHAR attribute with wrong variable type: '
+        ierr = SMIOLf_inquire_att(file, '', 'grid_id', real64_att)
+        if (ierr == SMIOL_WRONG_ARG_TYPE) then
+            write(test_log,'(a)') 'PASS'
+        else
+            write(test_log,'(a)') 'FAIL - SMIOL_WRONG_ARG_TYPE was not returned'
+            ierrcount = ierrcount + 1
+        end if
+
+        ! Close the SMIOL file
+        ierr = SMIOLf_close_file(file)
+        if (ierr /= SMIOL_SUCCESS .or. associated(file)) then
+            write(test_log,'(a)') 'Failed to close the file...'
+            ierrcount = -1
+            return
+        end if
+
+        ! Free the SMIOL context
+        ierr = SMIOLf_finalize(context)
+        if (ierr /= SMIOL_SUCCESS .or. associated(context)) then
+            write(test_log,'(a)') 'Failed to finalize the context...'
+            ierrcount = -1
+            return
+        end if
+
+        write(test_log,'(a)') ''
+
+    end function test_attributes
 
 
     function test_file_sync(test_log) result(ierrcount)

--- a/smiol_runner.F90
+++ b/smiol_runner.F90
@@ -23,6 +23,7 @@ program smiol_runner
     character(len=32), dimension(2) :: dimnames
     integer(kind=SMIOL_offset_kind) :: dimsize
     integer :: ndims
+    character(len=32) :: tempstr
 
     call MPI_Init(ierr)
     if (ierr /= MPI_SUCCESS) then
@@ -209,6 +210,16 @@ program smiol_runner
         stop 1
     endif
 
+    if (SMIOLf_inquire_att(file, 'theta', 'time_levels', i) /= SMIOL_SUCCESS) then
+        write(test_log,'(a)') "ERROR: 'SMIOLf_inquire_att' was not called successfully"
+        stop 1
+    endif
+
+    if (SMIOLf_inquire_att(file, '', 'title', tempstr) /= SMIOL_SUCCESS) then
+        write(test_log,'(a)') "ERROR: 'SMIOLf_inquire_att' was not called successfully"
+        stop 1
+    endif
+
     if (SMIOLf_close_file(file) /= SMIOL_SUCCESS) then
         write(test_log,'(a)') "ERROR: 'SMIOLf_close_file' was not called successfully"
         stop 1
@@ -221,11 +232,6 @@ program smiol_runner
 
     if (SMIOLf_get_var() /= SMIOL_SUCCESS) then
         write(test_log,'(a)') "ERROR: 'SMIOLf_get_var' was not called successfully"
-        stop 1
-    endif
-
-    if (SMIOLf_inquire_att() /= SMIOL_SUCCESS) then
-        write(test_log,'(a)') "ERROR: 'SMIOLf_inquire_att' was not called successfully"
         stop 1
     endif
 

--- a/smiol_runner.F90
+++ b/smiol_runner.F90
@@ -248,6 +248,10 @@ program smiol_runner
                trim(SMIOLf_error_string(SMIOL_LIBRARY_ERROR))
     write(test_log,'(a)') "Testing SMIOL_lib_error_string: Could not find matching library for the source of the error: ", &
                trim(SMIOLf_lib_error_string(context))
+    write(test_log,'(a)') "Testing SMIOL_error_string 'argument is of the wrong type': ", &
+               trim(SMIOLf_error_string(SMIOL_WRONG_ARG_TYPE))
+    write(test_log,'(a)') "Testing SMIOL_error_string 'argument is of insufficient size': ", &
+               trim(SMIOLf_error_string(SMIOL_INSUFFICIENT_ARG))
 
     if (SMIOLf_finalize(context) /= SMIOL_SUCCESS) then
         write(test_log,'(a)') "ERROR: 'SMIOLf_finalize' was not called successfully"

--- a/smiol_runner.c
+++ b/smiol_runner.c
@@ -362,6 +362,12 @@ int main(int argc, char **argv)
 		return 1;
 	}
 
+	if ((ierr = SMIOL_inquire_att(file, NULL, "title", NULL, NULL, NULL)) != SMIOL_SUCCESS) {
+		fprintf(test_log, "ERROR: SMIOL_inquire_att: %s ",
+			SMIOL_error_string(ierr));
+		return 1;
+	}
+
 	if ((ierr = SMIOL_close_file(&file)) != SMIOL_SUCCESS) {
 		fprintf(test_log, "ERROR: SMIOL_close_file: %s ", SMIOL_error_string(ierr));
 		return 1;
@@ -375,12 +381,6 @@ int main(int argc, char **argv)
 
 	if ((ierr = SMIOL_get_var()) != SMIOL_SUCCESS) {
 		fprintf(test_log, "ERROR: SMIOL_get_var: %s ",
-			SMIOL_error_string(ierr));
-		return 1;
-	}
-
-	if ((ierr = SMIOL_inquire_att()) != SMIOL_SUCCESS) {
-		fprintf(test_log, "ERROR: SMIOL_inquire_att: %s ",
 			SMIOL_error_string(ierr));
 		return 1;
 	}

--- a/smiol_runner.c
+++ b/smiol_runner.c
@@ -100,6 +100,8 @@ transfer_type(transfer_char, char)
 int main(int argc, char **argv)
 {
 	int ierr;
+	int i;
+	float f;
 	int my_proc_id;
 	SMIOL_Offset dimsize;
 	size_t n_compute_elements;
@@ -337,6 +339,29 @@ int main(int argc, char **argv)
 	free(dimnames[1]);
 	free(dimnames);
 
+	i = 2;
+	if ((ierr = SMIOL_define_att(file, "theta", "time_levels", SMIOL_INT32,
+	                             (const void *)&i)) != SMIOL_SUCCESS) {
+		fprintf(test_log, "ERROR: SMIOL_define_att: %s ",
+			SMIOL_error_string(ierr));
+		return 1;
+	}
+
+	f = (float)3.14159265;
+	if ((ierr = SMIOL_define_att(file, NULL, "pi", SMIOL_REAL32,
+	                             (const void *)&f)) != SMIOL_SUCCESS) {
+		fprintf(test_log, "ERROR: SMIOL_define_att: %s ",
+			SMIOL_error_string(ierr));
+		return 1;
+	}
+
+	if ((ierr = SMIOL_define_att(file, NULL, "title", SMIOL_CHAR,
+	                             "MPAS-Atmosphere v7.0")) != SMIOL_SUCCESS) {
+		fprintf(test_log, "ERROR: SMIOL_define_att: %s ",
+			SMIOL_error_string(ierr));
+		return 1;
+	}
+
 	if ((ierr = SMIOL_close_file(&file)) != SMIOL_SUCCESS) {
 		fprintf(test_log, "ERROR: SMIOL_close_file: %s ", SMIOL_error_string(ierr));
 		return 1;
@@ -350,12 +375,6 @@ int main(int argc, char **argv)
 
 	if ((ierr = SMIOL_get_var()) != SMIOL_SUCCESS) {
 		fprintf(test_log, "ERROR: SMIOL_get_var: %s ",
-			SMIOL_error_string(ierr));
-		return 1;
-	}
-		
-	if ((ierr = SMIOL_define_att()) != SMIOL_SUCCESS) {
-		fprintf(test_log, "ERROR: SMIOL_define_att: %s ",
 			SMIOL_error_string(ierr));
 		return 1;
 	}

--- a/smiol_runner.c
+++ b/smiol_runner.c
@@ -405,9 +405,12 @@ int main(int argc, char **argv)
 		SMIOL_error_string(SMIOL_FORTRAN_ERROR));
 	fprintf(test_log, "SMIOL_error_string test 'bad return code from a library call': %s\n",
 		SMIOL_error_string(SMIOL_LIBRARY_ERROR));
-
 	fprintf(test_log, "SMIOL_lib_error_string 'Could not find matching library for the source of the error': %s\n",
 		SMIOL_lib_error_string(context));
+	fprintf(test_log, "SMIOL_error_string test 'argument is of the wrong type': %s\n",
+		SMIOL_error_string(SMIOL_WRONG_ARG_TYPE));
+	fprintf(test_log, "SMIOL_error_string test 'argument is of insufficient size': %s\n",
+		SMIOL_error_string(SMIOL_INSUFFICIENT_ARG));
 
 	if ((ierr = SMIOL_finalize(&context)) != SMIOL_SUCCESS) {
 		fprintf(test_log, "ERROR: SMIOL_finalize: %s ", SMIOL_error_string(ierr));

--- a/smiol_runner.c
+++ b/smiol_runner.c
@@ -12,6 +12,7 @@ int test_init_finalize(FILE *test_log);
 int test_open_close(FILE *test_log);
 int test_dimensions(FILE *test_log);
 int test_variables(FILE *test_log);
+int test_attributes(FILE *test_log);
 int test_decomp(FILE *test_log);
 int test_build_exch(FILE *test_log);
 int test_transfer(FILE *test_log);
@@ -170,6 +171,18 @@ int main(int argc, char **argv)
 	 * Unit tests for variables
 	 */
 	ierr = test_variables(test_log);
+	if (ierr == 0) {
+		fprintf(test_log, "All tests PASSED!\n\n");
+	}
+	else {
+		fprintf(test_log, "%i tests FAILED!\n\n", ierr);
+	}
+
+
+	/*
+	 * Unit tests for attributes
+	 */
+	ierr = test_attributes(test_log);
 	if (ierr == 0) {
 		fprintf(test_log, "All tests PASSED!\n\n");
 	}
@@ -2473,6 +2486,463 @@ int test_variables(FILE *test_log)
 		fprintf(test_log, "Failed to close SMIOL file...\n");
 		return -1;
 	}
+
+	/* Free the SMIOL context */
+	ierr = SMIOL_finalize(&context);
+	if (ierr != SMIOL_SUCCESS || context != NULL) {
+		fprintf(test_log, "Failed to free SMIOL context...\n");
+		return -1;
+	}
+
+	fflush(test_log);
+	ierr = MPI_Barrier(MPI_COMM_WORLD);
+
+	fprintf(test_log, "\n");
+
+	return errcount;
+}
+
+int test_attributes(FILE *test_log)
+{
+	int errcount;
+	int ierr;
+	int i;
+	char **dimnames;
+	struct SMIOL_context *context;
+	struct SMIOL_file *file;
+	float real32_att;
+	double real64_att;
+	int int32_att;
+	char text_att[32];
+
+
+	fprintf(test_log, "********************************************************************************\n");
+	fprintf(test_log, "************ SMIOL_define_att / SMIOL_inquire_att ******************************\n");
+	fprintf(test_log, "\n");
+
+	errcount = 0;
+
+	/* Create a SMIOL context for testing attribute routines */
+	context = NULL;
+	ierr = SMIOL_init(MPI_COMM_WORLD, &context);
+	if (ierr != SMIOL_SUCCESS || context == NULL) {
+		fprintf(test_log, "Failed to create SMIOL context...\n");
+		return -1;
+	}
+
+	/* Create a SMIOL file for testing attribute routines */
+	file = NULL;
+	ierr = SMIOL_open_file(context, "test_atts.nc", SMIOL_FILE_CREATE, &file);
+	if (ierr != SMIOL_SUCCESS || file == NULL) {
+		fprintf(test_log, "Failed to create SMIOL file...\n");
+		return -1;
+	}
+
+	/* Define several dimensions in the file to be used when defining variables */
+	ierr = SMIOL_define_dim(file, "Time", (SMIOL_Offset)-1);
+	if (ierr != SMIOL_SUCCESS) {
+		fprintf(test_log, "Failed to create dimension Time...\n");
+		return -1;
+	}
+
+	ierr = SMIOL_define_dim(file, "nCells", (SMIOL_Offset)40962);
+	if (ierr != SMIOL_SUCCESS) {
+		fprintf(test_log, "Failed to create dimension nCells...\n");
+		return -1;
+	}
+
+	dimnames = (char **)malloc(sizeof(char *) * (size_t)2);
+	for (i = 0; i < 2; i++) {
+		dimnames[i] = (char *)malloc(sizeof(char) * (size_t)32);
+	}
+
+	/* Define a 32-bit real variable with one non-record dimension and a record dimension */
+	snprintf(dimnames[0], 32, "Time");
+	snprintf(dimnames[1], 32, "nCells");
+	ierr = SMIOL_define_var(file, "surface_pressure", SMIOL_REAL32, 2, (const char **)dimnames);
+	if (ierr != SMIOL_SUCCESS) {
+		fprintf(test_log, "Failed to create variable surface_pressure...\n");
+		return -1;
+	}
+
+	/* Everything OK - Define a global REAL32 attribute */
+	fprintf(test_log, "Everything OK - Define a global REAL32 attribute: ");
+	real32_att = 3.14159;
+	ierr = SMIOL_define_att(file, NULL, "pi", SMIOL_REAL32,
+	                        (const void *)&real32_att);
+	if (ierr == SMIOL_SUCCESS) {
+		fprintf(test_log, "PASS\n");
+	} else {
+		fprintf(test_log, "FAIL - SMIOL_SUCCESS was not returned\n");
+		errcount++;
+	}
+
+	/* Everything OK - Define a global REAL64 attribute */
+	fprintf(test_log, "Everything OK - Define a global REAL64 attribute: ");
+	real64_att = 2.718281828;
+	ierr = SMIOL_define_att(file, NULL, "e", SMIOL_REAL64,
+	                        (const void *)&real64_att);
+	if (ierr == SMIOL_SUCCESS) {
+		fprintf(test_log, "PASS\n");
+	} else {
+		fprintf(test_log, "FAIL - SMIOL_SUCCESS was not returned\n");
+		errcount++;
+	}
+
+	/* Everything OK - Define another global REAL64 attribute */
+	fprintf(test_log, "Everything OK - Define another global REAL64 attribute: ");
+	real64_att = 1.0;
+	ierr = SMIOL_define_att(file, NULL, "unity", SMIOL_REAL64,
+	                        (const void *)&real64_att);
+	if (ierr == SMIOL_SUCCESS) {
+		fprintf(test_log, "PASS\n");
+	} else {
+		fprintf(test_log, "FAIL - SMIOL_SUCCESS was not returned\n");
+		errcount++;
+	}
+
+	/* Everything OK - Define a global INT32 attribute */
+	fprintf(test_log, "Everything OK - Define a global INT32 attribute: ");
+	int32_att = 42;
+	ierr = SMIOL_define_att(file, NULL, "grid_id", SMIOL_INT32,
+	                        (const void *)&int32_att);
+	if (ierr == SMIOL_SUCCESS) {
+		fprintf(test_log, "PASS\n");
+	} else {
+		fprintf(test_log, "FAIL - SMIOL_SUCCESS was not returned\n");
+		errcount++;
+	}
+
+	/* Everything OK - Define a global CHAR attribute */
+	fprintf(test_log, "Everything OK - Define a global CHAR attribute: ");
+	snprintf(text_att, 32, "Don't panic!");
+	ierr = SMIOL_define_att(file, NULL, "Advice", SMIOL_CHAR,
+	                        (const void *)text_att);
+	if (ierr == SMIOL_SUCCESS) {
+		fprintf(test_log, "PASS\n");
+	} else {
+		fprintf(test_log, "FAIL - SMIOL_SUCCESS was not returned\n");
+		errcount++;
+	}
+
+	/* Everything OK - Define _FillValue variable attribute */
+	fprintf(test_log, "Everything OK - Define _FillValue variable attribute: ");
+	real32_att = 0.0;
+	ierr = SMIOL_define_att(file, "surface_pressure", "_FillValue", SMIOL_REAL32,
+	                        (const void *)&real32_att);
+	if (ierr == SMIOL_SUCCESS) {
+		fprintf(test_log, "PASS\n");
+	} else {
+		fprintf(test_log, "FAIL - SMIOL_SUCCESS was not returned\n");
+		errcount++;
+	}
+
+	/* Everything OK - Define a variable REAL32 attribute */
+	fprintf(test_log, "Everything OK - Define a variable REAL32 attribute: ");
+	real32_att = 3.14159;
+	ierr = SMIOL_define_att(file, "surface_pressure", "pi", SMIOL_REAL32,
+	                        (const void *)&real32_att);
+	if (ierr == SMIOL_SUCCESS) {
+		fprintf(test_log, "PASS\n");
+	} else {
+		fprintf(test_log, "FAIL - SMIOL_SUCCESS was not returned\n");
+		errcount++;
+	}
+
+	/* Everything OK - Define a variable REAL64 attribute */
+	fprintf(test_log, "Everything OK - Define a variable REAL64 attribute: ");
+	real64_att = 2.718281828;
+	ierr = SMIOL_define_att(file, "surface_pressure", "e", SMIOL_REAL64,
+	                        (const void *)&real64_att);
+	if (ierr == SMIOL_SUCCESS) {
+		fprintf(test_log, "PASS\n");
+	} else {
+		fprintf(test_log, "FAIL - SMIOL_SUCCESS was not returned\n");
+		errcount++;
+	}
+
+	/* Everything OK - Define another variable REAL64 attribute */
+	fprintf(test_log, "Everything OK - Define another variable REAL64 attribute: ");
+	real64_att = -1.0;
+	ierr = SMIOL_define_att(file, "surface_pressure", "missing_value", SMIOL_REAL64,
+	                        (const void *)&real64_att);
+	if (ierr == SMIOL_SUCCESS) {
+		fprintf(test_log, "PASS\n");
+	} else {
+		fprintf(test_log, "FAIL - SMIOL_SUCCESS was not returned\n");
+		errcount++;
+	}
+
+	/* Everything OK - Define a variable INT32 attribute */
+	fprintf(test_log, "Everything OK - Define a variable INT32 attribute: ");
+	int32_att = 42;
+	ierr = SMIOL_define_att(file, "surface_pressure", "grid_id", SMIOL_INT32,
+	                        (const void *)&int32_att);
+	if (ierr == SMIOL_SUCCESS) {
+		fprintf(test_log, "PASS\n");
+	} else {
+		fprintf(test_log, "FAIL - SMIOL_SUCCESS was not returned\n");
+		errcount++;
+	}
+
+	/* Everything OK - Define a variable CHAR attribute */
+	fprintf(test_log, "Everything OK - Define a variable CHAR attribute: ");
+	snprintf(text_att, 32, "Don't panic!");
+	ierr = SMIOL_define_att(file, "surface_pressure", "Advice", SMIOL_CHAR,
+	                        (const void *)text_att);
+	if (ierr == SMIOL_SUCCESS) {
+		fprintf(test_log, "PASS\n");
+	} else {
+		fprintf(test_log, "FAIL - SMIOL_SUCCESS was not returned\n");
+		errcount++;
+	}
+
+#ifdef SMIOL_PNETCDF
+	/* Try to define an attribute for a non-existent variable */
+	fprintf(test_log, "Try to define an attribute for a non-existent variable: ");
+	real64_att = 0.01;
+	ierr = SMIOL_define_att(file, "foobar", "min_val", SMIOL_REAL64,
+	                        (const void *)&real64_att);
+	if (ierr == SMIOL_LIBRARY_ERROR) {
+		fprintf(test_log, "PASS\n");
+	} else {
+		fprintf(test_log, "FAIL - SMIOL_LIBRARY_ERROR was not returned\n");
+		errcount++;
+	}
+
+	/* Try to define an attribute with an invalid type */
+	fprintf(test_log, "Try to define an attribute with an invalid type: ");
+	real64_att = 0.01;
+	ierr = SMIOL_define_att(file, NULL, "min_val", SMIOL_UNKNOWN_VAR_TYPE,
+	                        (const void *)&real64_att);
+	if (ierr == SMIOL_INVALID_ARGUMENT) {
+		fprintf(test_log, "PASS\n");
+	} else {
+		fprintf(test_log, "FAIL - SMIOL_INVALID_ARGUMENT was not returned\n");
+		errcount++;
+	}
+#endif
+
+	/* Call SMIOL_define_att with NULL file pointer */
+	fprintf(test_log, "Call SMIOL_define_att with NULL file pointer: ");
+	real64_att = 0.01;
+	ierr = SMIOL_define_att(NULL, NULL, "blah", SMIOL_REAL64,
+	                        (const void *)&real64_att);
+	if (ierr == SMIOL_INVALID_ARGUMENT) {
+		fprintf(test_log, "PASS\n");
+	} else {
+		fprintf(test_log, "FAIL - SMIOL_INVALID_ARGUMENT was not returned\n");
+		errcount++;
+	}
+
+	/* Call SMIOL_define_att with NULL attribute name */
+	fprintf(test_log, "Call SMIOL_define_att with NULL attribute name: ");
+	real64_att = 0.01;
+	ierr = SMIOL_define_att(file, NULL, NULL, SMIOL_REAL64,
+	                        (const void *)&real64_att);
+	if (ierr == SMIOL_INVALID_ARGUMENT) {
+		fprintf(test_log, "PASS\n");
+	} else {
+		fprintf(test_log, "FAIL - SMIOL_INVALID_ARGUMENT was not returned\n");
+		errcount++;
+	}
+
+	/* Call SMIOL_define_att with NULL attribute pointer */
+	fprintf(test_log, "Call SMIOL_define_att with NULL attribute pointer: ");
+	real64_att = 0.01;
+	ierr = SMIOL_define_att(file, NULL, "blah", SMIOL_REAL64, NULL);
+	if (ierr == SMIOL_INVALID_ARGUMENT) {
+		fprintf(test_log, "PASS\n");
+	} else {
+		fprintf(test_log, "FAIL - SMIOL_INVALID_ARGUMENT was not returned\n");
+		errcount++;
+	}
+
+	/* Close the SMIOL file */
+	ierr = SMIOL_close_file(&file);
+	if (ierr != SMIOL_SUCCESS || file != NULL) {
+		fprintf(test_log, "Failed to close SMIOL file...\n");
+		return -1;
+	}
+
+	/* Re-open the SMIOL file */
+	file = NULL;
+	ierr = SMIOL_open_file(context, "test_atts.nc", SMIOL_FILE_READ, &file);
+	if (ierr != SMIOL_SUCCESS || file == NULL) {
+		fprintf(test_log, "Failed to re-open SMIOL file...\n");
+		return -1;
+	}
+
+#ifdef SMIOL_PNETCDF
+	/* Everything OK - Inquire about a global REAL32 attribute */
+	fprintf(test_log, "Everything OK - Inquire about a global REAL32 attribute: ");
+	real32_att = 0.0;
+	ierr = SMIOL_inquire_att(file, NULL, "pi", NULL, NULL,
+	                         (void *)&real32_att);
+	if (ierr == SMIOL_SUCCESS && real32_att == (float)3.14159) {
+		fprintf(test_log, "PASS\n");
+	} else {
+		fprintf(test_log, "FAIL - SMIOL_SUCCESS was not returned or attribute value was incorrect\n");
+		errcount++;
+	}
+
+	/* Everything OK - Inquire about a global REAL64 attribute */
+	fprintf(test_log, "Everything OK - Inquire about a global REAL64 attribute: ");
+	real64_att = 0.0;
+	ierr = SMIOL_inquire_att(file, NULL, "e", NULL, NULL,
+	                         (void *)&real64_att);
+	if (ierr == SMIOL_SUCCESS && real64_att == (double)2.718281828) {
+		fprintf(test_log, "PASS\n");
+	} else {
+		fprintf(test_log, "FAIL - SMIOL_SUCCESS was not returned or attribute value was incorrect\n");
+		errcount++;
+	}
+
+	/* Everything OK - Inquire about a global INT32 attribute */
+	fprintf(test_log, "Everything OK - Inquire about a global INT32 attribute: ");
+	int32_att = 0;
+	ierr = SMIOL_inquire_att(file, NULL, "grid_id", NULL, NULL,
+	                         (void *)&int32_att);
+	if (ierr == SMIOL_SUCCESS && int32_att == 42) {
+		fprintf(test_log, "PASS\n");
+	} else {
+		fprintf(test_log, "FAIL - SMIOL_SUCCESS was not returned or attribute value was incorrect\n");
+		errcount++;
+	}
+
+	/* Everything OK - Inquire about a global CHAR attribute */
+	fprintf(test_log, "Everything OK - Inquire about a global CHAR attribute: ");
+	memset((void *)text_att, 0, 32);
+	ierr = SMIOL_inquire_att(file, NULL, "Advice", NULL, NULL,
+	                         (void *)text_att);
+	if (ierr == SMIOL_SUCCESS && strncmp("Don't panic!", text_att, 32) == 0) {
+		fprintf(test_log, "PASS\n");
+	} else {
+		fprintf(test_log, "FAIL - SMIOL_SUCCESS was not returned or attribute value was incorrect\n");
+		fprintf(test_log, "%s\n", text_att);
+		errcount++;
+	}
+
+	/* Everything OK - Inquire about _FillValue variable attribute */
+	fprintf(test_log, "Everything OK - Inquire about _FillValue variable attribute: ");
+	real32_att = -999.0;
+	ierr = SMIOL_inquire_att(file, "surface_pressure", "_FillValue", NULL, NULL,
+	                         (void *)&real32_att);
+	if (ierr == SMIOL_SUCCESS && real32_att == 0.0) {
+		fprintf(test_log, "PASS\n");
+	} else {
+		fprintf(test_log, "FAIL - SMIOL_SUCCESS was not returned or attribute value was incorrect\n");
+		errcount++;
+	}
+
+	/* Everything OK - Inquire about a variable REAL32 attribute */
+	fprintf(test_log, "Everything OK - Inquire about a variable REAL32 attribute: ");
+	real32_att = 0.0;
+	ierr = SMIOL_inquire_att(file, "surface_pressure", "pi", NULL, NULL,
+	                         (void *)&real32_att);
+	if (ierr == SMIOL_SUCCESS && real32_att == (float)3.14159) {
+		fprintf(test_log, "PASS\n");
+	} else {
+		fprintf(test_log, "FAIL - SMIOL_SUCCESS was not returned or attribute value was incorrect\n");
+		errcount++;
+	}
+
+	/* Everything OK - Inquire about a variable REAL64 attribute */
+	fprintf(test_log, "Everything OK - Inquire about a variable REAL64 attribute: ");
+	real64_att = 0.0;
+	ierr = SMIOL_inquire_att(file, "surface_pressure", "e", NULL, NULL,
+	                         (void *)&real64_att);
+	if (ierr == SMIOL_SUCCESS && real64_att == (double)2.718281828) {
+		fprintf(test_log, "PASS\n");
+	} else {
+		fprintf(test_log, "FAIL - SMIOL_SUCCESS was not returned or attribute value was incorrect\n");
+		errcount++;
+	}
+
+	/* Everything OK - Inquire about a variable INT32 attribute */
+	fprintf(test_log, "Everything OK - Inquire about a variable INT32 attribute: ");
+	int32_att = 0;
+	ierr = SMIOL_inquire_att(file, "surface_pressure", "grid_id", NULL, NULL,
+	                         (void *)&int32_att);
+	if (ierr == SMIOL_SUCCESS && int32_att == 42) {
+		fprintf(test_log, "PASS\n");
+	} else {
+		fprintf(test_log, "FAIL - SMIOL_SUCCESS was not returned or attribute value was incorrect\n");
+		errcount++;
+	}
+
+	/* Everything OK - Inquire about a variable CHAR attribute */
+	fprintf(test_log, "Everything OK - Inquire about a variable CHAR attribute: ");
+	memset((void *)text_att, 0, 32);
+	ierr = SMIOL_inquire_att(file, "surface_pressure", "Advice", NULL, NULL,
+	                         (void *)text_att);
+	if (ierr == SMIOL_SUCCESS && strncmp("Don't panic!", text_att, 32) == 0) {
+		fprintf(test_log, "PASS\n");
+	} else {
+		fprintf(test_log, "FAIL - SMIOL_SUCCESS was not returned or attribute value was incorrect\n");
+		errcount++;
+	}
+
+	/* Try to inquire about an attribute for a non-existent variable */
+	fprintf(test_log, "Try to inquire about an attribute for a non-existent variable: ");
+	real64_att = 0.0;
+	ierr = SMIOL_inquire_att(file, "foobar", "e", NULL, NULL,
+	                         (void *)&real64_att);
+	if (ierr == SMIOL_LIBRARY_ERROR) {
+		fprintf(test_log, "PASS\n");
+	} else {
+		fprintf(test_log, "FAIL - SMIOL_LIBRARY_ERROR was not returned\n");
+		errcount++;
+	}
+
+	/* Try to inquire about a non-existent attribute */
+	fprintf(test_log, "Try to inquire about a non-existent attribute: ");
+	real64_att = 0.0;
+	ierr = SMIOL_inquire_att(file, "surface_pressure", "blah", NULL, NULL,
+	                         (void *)&real64_att);
+	if (ierr == SMIOL_LIBRARY_ERROR) {
+		fprintf(test_log, "PASS\n");
+	} else {
+		fprintf(test_log, "FAIL - SMIOL_LIBRARY_ERROR was not returned\n");
+		errcount++;
+	}
+#endif
+
+	/* Call SMIOL_inquire_att with NULL file pointer */
+	fprintf(test_log, "Call SMIOL_inquire_att with NULL file pointer: ");
+	real64_att = 0.0;
+	ierr = SMIOL_inquire_att(NULL, "surface_pressure", "e", NULL, NULL,
+	                         (void *)&real64_att);
+	if (ierr == SMIOL_INVALID_ARGUMENT) {
+		fprintf(test_log, "PASS\n");
+	} else {
+		fprintf(test_log, "FAIL - SMIOL_INVALID_ARGUMENT was not returned\n");
+		errcount++;
+	}
+
+	/* Call SMIOL_inquire_att with NULL attribute name */
+	fprintf(test_log, "Call SMIOL_inquire_att with NULL attribute name: ");
+	real64_att = 0.0;
+	ierr = SMIOL_inquire_att(file, "surface_pressure", NULL, NULL, NULL,
+	                         (void *)&real64_att);
+	if (ierr == SMIOL_INVALID_ARGUMENT) {
+		fprintf(test_log, "PASS\n");
+	} else {
+		fprintf(test_log, "FAIL - SMIOL_INVALID_ARGUMENT was not returned\n");
+		errcount++;
+	}
+
+	/* Close the SMIOL file */
+	ierr = SMIOL_close_file(&file);
+	if (ierr != SMIOL_SUCCESS || file != NULL) {
+		fprintf(test_log, "Failed to close SMIOL file...\n");
+		return -1;
+	}
+
+	for (i = 0; i < 2; i++) {
+		free(dimnames[i]);
+	}
+	free(dimnames);
 
 	/* Free the SMIOL context */
 	ierr = SMIOL_finalize(&context);

--- a/src/smiol.c
+++ b/src/smiol.c
@@ -937,6 +937,10 @@ const char *SMIOL_error_string(int errno)
 		return "Fortran wrapper detected an inconsistency in C return values";
 	case SMIOL_LIBRARY_ERROR:
 		return "bad return code from a library call";
+	case SMIOL_WRONG_ARG_TYPE:
+		return "argument is of the wrong type";
+	case SMIOL_INSUFFICIENT_ARG:
+		return "argument is of insufficient size";
 	default:
 		return "Unknown error";
 	}

--- a/src/smiol.h
+++ b/src/smiol.h
@@ -40,7 +40,10 @@ int SMIOL_get_var(void);
  */
 int SMIOL_define_att(struct SMIOL_file *file, const char *varname,
                      const char *att_name, int att_type, const void *att);
-int SMIOL_inquire_att(void);
+
+int SMIOL_inquire_att(struct SMIOL_file *file, const char *varname,
+                      const char *att_name, int *att_type,
+                      SMIOL_Offset *att_len, void *att);
 
 /*
  * Control methods

--- a/src/smiol.h
+++ b/src/smiol.h
@@ -38,7 +38,8 @@ int SMIOL_get_var(void);
 /*
  * Attribute methods
  */
-int SMIOL_define_att(void);
+int SMIOL_define_att(struct SMIOL_file *file, const char *varname,
+                     const char *att_name, int att_type, const void *att);
 int SMIOL_inquire_att(void);
 
 /*

--- a/src/smiol_codes.inc
+++ b/src/smiol_codes.inc
@@ -4,6 +4,8 @@
 #define SMIOL_MPI_ERROR          (-3)
 #define SMIOL_FORTRAN_ERROR      (-4)
 #define SMIOL_LIBRARY_ERROR      (-5)
+#define SMIOL_WRONG_ARG_TYPE     (-6)
+#define SMIOL_INSUFFICIENT_ARG   (-7)
 
 #define SMIOL_FILE_CREATE         (1)
 #define SMIOL_FILE_READ           (2)

--- a/src/smiolf.F90
+++ b/src/smiolf.F90
@@ -82,6 +82,19 @@ module SMIOLf
         module procedure SMIOLf_define_att_text
     end interface
 
+    ! C interface definitions used in multiple routines
+    interface
+        function SMIOL_define_att(file, varname, att_name, att_type, att) result(ierr) bind(C, name='SMIOL_define_att')
+            use iso_c_binding, only : c_ptr, c_char, c_int
+            type (c_ptr), value :: file
+            type (c_ptr), value :: varname
+            character(kind=c_char), dimension(*) :: att_name
+            integer(kind=c_int), value :: att_type
+            type (c_ptr), value :: att
+            integer(kind=c_int) :: ierr
+        end function
+    end interface
+
 
 contains
 
@@ -820,18 +833,6 @@ contains
         type (c_ptr) :: att_ptr
         type (c_ptr) :: c_varname_ptr
 
-        ! C interface definitions
-        interface
-            function SMIOL_define_att(file, varname, att_name, att_type, att) result(ierr) bind(C, name='SMIOL_define_att')
-                use iso_c_binding, only : c_ptr, c_char, c_int
-                type (c_ptr), value :: file
-                type (c_ptr), value :: varname
-                character(kind=c_char), dimension(*) :: att_name
-                integer(kind=c_int), value :: att_type
-                type (c_ptr), value :: att
-                integer(kind=c_int) :: ierr
-            end function
-        end interface
 
         c_file = c_loc(file)
 
@@ -899,18 +900,6 @@ contains
         type (c_ptr) :: att_ptr
         type (c_ptr) :: c_varname_ptr
 
-        ! C interface definitions
-        interface
-            function SMIOL_define_att(file, varname, att_name, att_type, att) result(ierr) bind(C, name='SMIOL_define_att')
-                use iso_c_binding, only : c_ptr, c_char, c_int
-                type (c_ptr), value :: file
-                type (c_ptr), value :: varname
-                character(kind=c_char), dimension(*) :: att_name
-                integer(kind=c_int), value :: att_type
-                type (c_ptr), value :: att
-                integer(kind=c_int) :: ierr
-            end function
-        end interface
 
         c_file = c_loc(file)
 
@@ -978,18 +967,6 @@ contains
         type (c_ptr) :: att_ptr
         type (c_ptr) :: c_varname_ptr
 
-        ! C interface definitions
-        interface
-            function SMIOL_define_att(file, varname, att_name, att_type, att) result(ierr) bind(C, name='SMIOL_define_att')
-                use iso_c_binding, only : c_ptr, c_char, c_int
-                type (c_ptr), value :: file
-                type (c_ptr), value :: varname
-                character(kind=c_char), dimension(*) :: att_name
-                integer(kind=c_int), value :: att_type
-                type (c_ptr), value :: att
-                integer(kind=c_int) :: ierr
-            end function
-        end interface
 
         c_file = c_loc(file)
 
@@ -1058,18 +1035,6 @@ contains
         type (c_ptr) :: att_ptr
         type (c_ptr) :: c_varname_ptr
 
-        ! C interface definitions
-        interface
-            function SMIOL_define_att(file, varname, att_name, att_type, att) result(ierr) bind(C, name='SMIOL_define_att')
-                use iso_c_binding, only : c_ptr, c_char, c_int
-                type (c_ptr), value :: file
-                type (c_ptr), value :: varname
-                character(kind=c_char), dimension(*) :: att_name
-                integer(kind=c_int), value :: att_type
-                type (c_ptr), value :: att
-                integer(kind=c_int) :: ierr
-            end function
-        end interface
 
         c_file = c_loc(file)
 

--- a/src/smiolf.F90
+++ b/src/smiolf.F90
@@ -82,6 +82,13 @@ module SMIOLf
         module procedure SMIOLf_define_att_text
     end interface
 
+    interface SMIOLf_inquire_att
+        module procedure SMIOLf_inquire_att_int
+        module procedure SMIOLf_inquire_att_float
+        module procedure SMIOLf_inquire_att_double
+        module procedure SMIOLf_inquire_att_text
+    end interface
+
     ! C interface definitions used in multiple routines
     interface
         function SMIOL_define_att(file, varname, att_name, att_type, att) result(ierr) bind(C, name='SMIOL_define_att')
@@ -90,6 +97,17 @@ module SMIOLf
             type (c_ptr), value :: varname
             character(kind=c_char), dimension(*) :: att_name
             integer(kind=c_int), value :: att_type
+            type (c_ptr), value :: att
+            integer(kind=c_int) :: ierr
+        end function
+
+        function SMIOL_inquire_att(file, varname, att_name, att_type, att_len, att) result(ierr) bind(C, name='SMIOL_inquire_att')
+            use iso_c_binding, only : c_ptr, c_char, c_int
+            type (c_ptr), value :: file
+            type (c_ptr), value :: varname
+            character(kind=c_char), dimension(*) :: att_name
+            type (c_ptr), value :: att_type
+            type (c_ptr), value :: att_len
             type (c_ptr), value :: att
             integer(kind=c_int) :: ierr
         end function
@@ -1078,20 +1096,411 @@ contains
 
 
     !-----------------------------------------------------------------------
-    !  routine SMIOLf_inquire_att
+    !  routine SMIOLf_inquire_att_int
     !
-    !> \brief Inquires about an attribute in a file
+    !> \brief Inquires about an integer attribute
     !> \details
-    !>  Detailed description of what this routine does.
+    !>  Inquires about a variable attribute if varname is not an empty string,
+    !>  or a global attribute otherwise.
+    !>
+    !>  If the requested attribute is found, and if it is integer-valued, then
+    !>  SMIOL_SUCCESS is returned and the att output argument will contain
+    !>  the attribute value. If the attribute was found, but it is not an integer
+    !>  attribute, SMIOL_WRONG_ARG_TYPE is returned, and the contents of att are
+    !>  undefined.
+    !>
+    !>  If SMIOL was not compiled with support for any file library, this routine
+    !>  will always return SMIOL_WRONG_ARG_TYPE.
     !
     !-----------------------------------------------------------------------
-    integer function SMIOLf_inquire_att() result(ierr)
+    integer function SMIOLf_inquire_att_int(file, varname, att_name, att) result(ierr)
+
+        use iso_c_binding, only : c_char, c_int, c_null_char, c_null_ptr, c_ptr, c_loc
 
         implicit none
 
-        ierr = 0
+        ! Arguments
+        type (SMIOLf_file), target :: file
+        character(len=*), intent(in) :: varname
+        character(len=*), intent(in) :: att_name
+        integer(kind=c_int), intent(out), target :: att
 
-    end function SMIOLf_inquire_att
+        ! Local variables
+        integer :: i
+        integer(kind=c_int), target :: att_type
+        type (c_ptr) :: c_file
+        character(kind=c_char), dimension(:), allocatable, target :: c_varname
+        character(kind=c_char), dimension(:), pointer :: c_att_name
+        type (c_ptr) :: att_ptr
+        type (c_ptr) :: att_type_ptr
+        type (c_ptr) :: c_varname_ptr
+
+
+        c_file = c_loc(file)
+        att_type_ptr = c_loc(att_type)
+
+        !
+        ! Convert Fortran string to C character array
+        !
+        if (len_trim(varname) > 0) then
+            allocate(c_varname(len_trim(varname) + 1))
+            do i=1,len_trim(varname)
+                c_varname(i) = varname(i:i)
+            end do
+            c_varname(i) = c_null_char
+            c_varname_ptr = c_loc(c_varname)
+        else
+            c_varname_ptr = c_null_ptr
+        end if
+
+        allocate(c_att_name(len_trim(att_name) + 1))
+        do i=1,len_trim(att_name)
+            c_att_name(i) = att_name(i:i)
+        end do
+        c_att_name(i) = c_null_char
+
+        !
+        ! First, inquire about the attribute type
+        !
+        ierr = SMIOL_inquire_att(c_file, c_varname_ptr, c_att_name, &
+                                 att_type_ptr, c_null_ptr, c_null_ptr)
+
+        if (ierr /= SMIOL_SUCCESS .or. att_type /= SMIOL_INT32) then
+            if (len_trim(varname) > 0) then
+                deallocate(c_varname)
+            end if
+            deallocate(c_att_name)
+            if (ierr == SMIOL_SUCCESS) then
+                ierr = SMIOL_WRONG_ARG_TYPE
+            end if
+            return
+        end if
+
+        att_ptr = c_loc(att)
+
+        ierr = SMIOL_inquire_att(c_file, c_varname_ptr, c_att_name, &
+                                 c_null_ptr, c_null_ptr, att_ptr)
+
+        if (len_trim(varname) > 0) then
+            deallocate(c_varname)
+        end if
+        deallocate(c_att_name)
+
+    end function SMIOLf_inquire_att_int
+
+
+    !-----------------------------------------------------------------------
+    !  routine SMIOLf_inquire_att_float
+    !
+    !> \brief Inquires about a float attribute
+    !> \details
+    !>  Inquires about a variable attribute if varname is not an empty string,
+    !>  or a global attribute otherwise.
+    !>
+    !>  If the requested attribute is found, and if it is float-valued, then
+    !>  SMIOL_SUCCESS is returned and the att output argument will contain
+    !>  the attribute value. If the attribute was found, but it is not a float
+    !>  attribute, SMIOL_WRONG_ARG_TYPE is returned, and the contents of att are
+    !>  undefined.
+    !>
+    !>  If SMIOL was not compiled with support for any file library, this routine
+    !>  will always return SMIOL_WRONG_ARG_TYPE.
+    !
+    !-----------------------------------------------------------------------
+    integer function SMIOLf_inquire_att_float(file, varname, att_name, att) result(ierr)
+
+        use iso_c_binding, only : c_char, c_float, c_null_char, c_null_ptr, c_ptr, c_loc
+
+        implicit none
+
+        ! Arguments
+        type (SMIOLf_file), target :: file
+        character(len=*), intent(in) :: varname
+        character(len=*), intent(in) :: att_name
+        real(kind=c_float), intent(out), target :: att
+
+        ! Local variables
+        integer :: i
+        integer(kind=c_int), target :: att_type
+        type (c_ptr) :: c_file
+        character(kind=c_char), dimension(:), allocatable, target :: c_varname
+        character(kind=c_char), dimension(:), pointer :: c_att_name
+        type (c_ptr) :: att_ptr
+        type (c_ptr) :: att_type_ptr
+        type (c_ptr) :: c_varname_ptr
+
+
+        c_file = c_loc(file)
+        att_type_ptr = c_loc(att_type)
+
+        !
+        ! Convert Fortran string to C character array
+        !
+        if (len_trim(varname) > 0) then
+            allocate(c_varname(len_trim(varname) + 1))
+            do i=1,len_trim(varname)
+                c_varname(i) = varname(i:i)
+            end do
+            c_varname(i) = c_null_char
+            c_varname_ptr = c_loc(c_varname)
+        else
+            c_varname_ptr = c_null_ptr
+        end if
+
+        allocate(c_att_name(len_trim(att_name) + 1))
+        do i=1,len_trim(att_name)
+            c_att_name(i) = att_name(i:i)
+        end do
+        c_att_name(i) = c_null_char
+
+        !
+        ! First, inquire about the attribute type
+        !
+        ierr = SMIOL_inquire_att(c_file, c_varname_ptr, c_att_name, &
+                                 att_type_ptr, c_null_ptr, c_null_ptr)
+
+        if (ierr /= SMIOL_SUCCESS .or. att_type /= SMIOL_REAL32) then
+            if (len_trim(varname) > 0) then
+                deallocate(c_varname)
+            end if
+            deallocate(c_att_name)
+            if (ierr == SMIOL_SUCCESS) then
+                ierr = SMIOL_WRONG_ARG_TYPE
+            end if
+            return
+        end if
+
+        att_ptr = c_loc(att)
+
+        ierr = SMIOL_inquire_att(c_file, c_varname_ptr, c_att_name, &
+                                 c_null_ptr, c_null_ptr, att_ptr)
+
+        if (len_trim(varname) > 0) then
+            deallocate(c_varname)
+        end if
+        deallocate(c_att_name)
+
+    end function SMIOLf_inquire_att_float
+
+
+    !-----------------------------------------------------------------------
+    !  routine SMIOLf_inquire_att_double
+    !
+    !> \brief Inquires about a double attribute
+    !> \details
+    !>  Inquires about a variable attribute if varname is not an empty string,
+    !>  or a global attribute otherwise.
+    !>
+    !>  If the requested attribute is found, and if it is double-valued, then
+    !>  SMIOL_SUCCESS is returned and the att output argument will contain
+    !>  the attribute value. If the attribute was found, but it is not a double
+    !>  attribute, SMIOL_WRONG_ARG_TYPE is returned, and the contents of att are
+    !>  undefined.
+    !>
+    !>  If SMIOL was not compiled with support for any file library, this routine
+    !>  will always return SMIOL_WRONG_ARG_TYPE.
+    !
+    !-----------------------------------------------------------------------
+    integer function SMIOLf_inquire_att_double(file, varname, att_name, att) result(ierr)
+
+        use iso_c_binding, only : c_char, c_double, c_null_char, c_null_ptr, c_ptr, c_loc
+
+        implicit none
+
+        ! Arguments
+        type (SMIOLf_file), target :: file
+        character(len=*), intent(in) :: varname
+        character(len=*), intent(in) :: att_name
+        real(kind=c_double), intent(out), target :: att
+
+        ! Local variables
+        integer :: i
+        integer(kind=c_int), target :: att_type
+        type (c_ptr) :: c_file
+        character(kind=c_char), dimension(:), allocatable, target :: c_varname
+        character(kind=c_char), dimension(:), pointer :: c_att_name
+        type (c_ptr) :: att_ptr
+        type (c_ptr) :: att_type_ptr
+        type (c_ptr) :: c_varname_ptr
+
+
+        c_file = c_loc(file)
+        att_type_ptr = c_loc(att_type)
+
+        !
+        ! Convert Fortran string to C character array
+        !
+        if (len_trim(varname) > 0) then
+            allocate(c_varname(len_trim(varname) + 1))
+            do i=1,len_trim(varname)
+                c_varname(i) = varname(i:i)
+            end do
+            c_varname(i) = c_null_char
+            c_varname_ptr = c_loc(c_varname)
+        else
+            c_varname_ptr = c_null_ptr
+        end if
+
+        allocate(c_att_name(len_trim(att_name) + 1))
+        do i=1,len_trim(att_name)
+            c_att_name(i) = att_name(i:i)
+        end do
+        c_att_name(i) = c_null_char
+
+        !
+        ! First, inquire about the attribute type
+        !
+        ierr = SMIOL_inquire_att(c_file, c_varname_ptr, c_att_name, &
+                                 att_type_ptr, c_null_ptr, c_null_ptr)
+
+        if (ierr /= SMIOL_SUCCESS .or. att_type /= SMIOL_REAL64) then
+            if (len_trim(varname) > 0) then
+                deallocate(c_varname)
+            end if
+            deallocate(c_att_name)
+            if (ierr == SMIOL_SUCCESS) then
+                ierr = SMIOL_WRONG_ARG_TYPE
+            end if
+            return
+        end if
+
+        att_ptr = c_loc(att)
+
+        ierr = SMIOL_inquire_att(c_file, c_varname_ptr, c_att_name, &
+                                 c_null_ptr, c_null_ptr, att_ptr)
+
+        if (len_trim(varname) > 0) then
+            deallocate(c_varname)
+        end if
+        deallocate(c_att_name)
+
+    end function SMIOLf_inquire_att_double
+
+
+    !-----------------------------------------------------------------------
+    !  routine SMIOLf_inquire_att_text
+    !
+    !> \brief Inquires about a text attribute
+    !> \details
+    !>  Inquires about a variable attribute if varname is not an empty string,
+    !>  or a global attribute otherwise.
+    !>
+    !>  If the requested attribute is found, if it is character-valued, and if
+    !>  the att output argument is long enough to contain the attribute value,
+    !>  then SMIOL_SUCCESS is returned and the att output argument will contain
+    !>  the attribute value. If the attribute was found, but it is not a character
+    !>  attribute, SMIOL_WRONG_ARG_TYPE is returned, and the contents of att are
+    !>  undefined. If the attribute was found, and it is a character attribute,
+    !>  but the att output argument is not long enough to contain the attribute
+    !>  value, then SMIOL_INSUFFICIENT_ARG is returned, and the contents of att
+    !>  are undefined.
+    !>
+    !>  If SMIOL was not compiled with support for any file library, this routine
+    !>  will always return SMIOL_WRONG_ARG_TYPE.
+    !
+    !-----------------------------------------------------------------------
+    integer function SMIOLf_inquire_att_text(file, varname, att_name, att) result(ierr)
+
+        use iso_c_binding, only : c_char, c_int, c_null_char, c_null_ptr, c_ptr, c_loc
+
+        implicit none
+
+        ! Arguments
+        type (SMIOLf_file), target :: file
+        character(len=*), intent(in) :: varname
+        character(len=*), intent(in) :: att_name
+        character(len=*), intent(out) :: att
+
+        ! Local variables
+        integer :: i
+        integer(kind=c_int), target :: att_type
+        integer(kind=SMIOL_offset_kind), target :: att_len
+        type (c_ptr) :: c_file
+        character(kind=c_char), dimension(:), allocatable, target :: c_varname
+        character(kind=c_char), dimension(:), pointer :: c_att_name
+        character(kind=c_char), dimension(:), allocatable, target :: c_att
+        type (c_ptr) :: att_ptr
+        type (c_ptr) :: att_type_ptr
+        type (c_ptr) :: att_len_ptr
+        type (c_ptr) :: c_varname_ptr
+
+
+        c_file = c_loc(file)
+        att_type_ptr = c_loc(att_type)
+        att_len_ptr = c_loc(att_len)
+        c_file = c_loc(file)
+
+        !
+        ! Convert Fortran string to C character array
+        !
+        if (len_trim(varname) > 0) then
+            allocate(c_varname(len_trim(varname) + 1))
+            do i=1,len_trim(varname)
+                c_varname(i) = varname(i:i)
+            end do
+            c_varname(i) = c_null_char
+            c_varname_ptr = c_loc(c_varname)
+        else
+            c_varname_ptr = c_null_ptr
+        end if
+
+        allocate(c_att_name(len_trim(att_name) + 1))
+        do i=1,len_trim(att_name)
+            c_att_name(i) = att_name(i:i)
+        end do
+        c_att_name(i) = c_null_char
+
+        !
+        ! First, inquire about the attribute type and length
+        !
+        ierr = SMIOL_inquire_att(c_file, c_varname_ptr, c_att_name, &
+                                 att_type_ptr, att_len_ptr, c_null_ptr)
+
+        if (ierr /= SMIOL_SUCCESS .or. att_type /= SMIOL_CHAR) then
+            if (len_trim(varname) > 0) then
+                deallocate(c_varname)
+            end if
+            deallocate(c_att_name)
+            if (ierr == SMIOL_SUCCESS) then
+                ierr = SMIOL_WRONG_ARG_TYPE
+            end if
+            return
+        end if
+
+        if (len(att) < att_len) then
+            if (len_trim(varname) > 0) then
+                deallocate(c_varname)
+            end if
+            deallocate(c_att_name)
+            ierr = SMIOL_INSUFFICIENT_ARG
+            return
+        end if
+
+        !
+        ! Next, allocate a local c_char array
+        !
+        allocate(c_att(att_len))
+        att_ptr = c_loc(c_att)
+
+        !
+        ! Finally, inquire about the attribute itself
+        !
+        ierr = SMIOL_inquire_att(c_file, c_varname_ptr, c_att_name, &
+                                 c_null_ptr, c_null_ptr, att_ptr)
+
+        !
+        ! Copy c_char array to Fortran string
+        !
+        att(1:att_len) = transfer(c_att(1:att_len), att)
+        att = att(1:att_len)
+
+        if (len_trim(varname) > 0) then
+            deallocate(c_varname)
+        end if
+        deallocate(c_att_name)
+        deallocate(c_att)
+
+    end function SMIOLf_inquire_att_text
 
 
     !

--- a/src/smiolf.F90
+++ b/src/smiolf.F90
@@ -75,6 +75,13 @@ module SMIOLf
         integer(c_size_t) :: io_count;  ! The number of elements for I/O by a task
     end type SMIOLf_decomp
 
+    interface SMIOLf_define_att
+        module procedure SMIOLf_define_att_int
+        module procedure SMIOLf_define_att_float
+        module procedure SMIOLf_define_att_double
+        module procedure SMIOLf_define_att_text
+    end interface
+
 
 contains
 
@@ -782,20 +789,327 @@ contains
     !
 
     !-----------------------------------------------------------------------
-    !  routine SMIOLf_define_att
+    !  routine SMIOLf_define_att_int
     !
-    !> \brief Defines a new attribute in a file
+    !> \brief Defines a new integer attribute
     !> \details
-    !>  Detailed description of what this routine does.
+    !>  Defines a new integer attribute for a variable if varname is not
+    !>  an empty string, or a global attribute otherwise.
+    !>
+    !>  If the attribute has been successfully defined for the variable or file,
+    !>  SMIOL_SUCCESS is returned.
     !
     !-----------------------------------------------------------------------
-    integer function SMIOLf_define_att() result(ierr)
+    integer function SMIOLf_define_att_int(file, varname, att_name, att) result(ierr)
+
+        use iso_c_binding, only : c_char, c_int, c_null_char, c_null_ptr, c_ptr, c_loc
 
         implicit none
 
-        ierr = 0
+        ! Arguments
+        type (SMIOLf_file), target :: file
+        character(len=*), intent(in) :: varname
+        character(len=*), intent(in) :: att_name
+        integer(kind=c_int), intent(in), target :: att
 
-    end function SMIOLf_define_att
+        ! Local variables
+        integer :: i
+        type (c_ptr) :: c_file
+        character(kind=c_char), dimension(:), allocatable, target :: c_varname
+        character(kind=c_char), dimension(:), pointer :: c_att_name
+        type (c_ptr) :: att_ptr
+        type (c_ptr) :: c_varname_ptr
+
+        ! C interface definitions
+        interface
+            function SMIOL_define_att(file, varname, att_name, att_type, att) result(ierr) bind(C, name='SMIOL_define_att')
+                use iso_c_binding, only : c_ptr, c_char, c_int
+                type (c_ptr), value :: file
+                type (c_ptr), value :: varname
+                character(kind=c_char), dimension(*) :: att_name
+                integer(kind=c_int), value :: att_type
+                type (c_ptr), value :: att
+                integer(kind=c_int) :: ierr
+            end function
+        end interface
+
+        c_file = c_loc(file)
+
+        !
+        ! Convert Fortran string to C character array
+        !
+        if (len_trim(varname) > 0) then
+            allocate(c_varname(len_trim(varname) + 1))
+            do i=1,len_trim(varname)
+                c_varname(i) = varname(i:i)
+            end do
+            c_varname(i) = c_null_char
+            c_varname_ptr = c_loc(c_varname)
+        else
+            c_varname_ptr = c_null_ptr
+        end if
+
+        allocate(c_att_name(len_trim(att_name) + 1))
+        do i=1,len_trim(att_name)
+            c_att_name(i) = att_name(i:i)
+        end do
+        c_att_name(i) = c_null_char
+
+        att_ptr = c_loc(att)
+
+        ierr = SMIOL_define_att(c_file, c_varname_ptr, c_att_name, SMIOL_INT32, att_ptr)
+
+        if (len_trim(varname) > 0) then
+            deallocate(c_varname)
+        end if
+        deallocate(c_att_name)
+
+    end function SMIOLf_define_att_int
+
+
+    !-----------------------------------------------------------------------
+    !  routine SMIOLf_define_att_float
+    !
+    !> \brief Defines a new float attribute
+    !> \details
+    !>  Defines a new float attribute for a variable if varname is not an empty
+    !>  string, or a global attribute otherwise.
+    !>
+    !>  If the attribute has been successfully defined for the variable or file,
+    !>  SMIOL_SUCCESS is returned.
+    !
+    !-----------------------------------------------------------------------
+    integer function SMIOLf_define_att_float(file, varname, att_name, att) result(ierr)
+
+        use iso_c_binding, only : c_char, c_float, c_null_char, c_null_ptr, c_ptr, c_loc
+
+        implicit none
+
+        ! Arguments
+        type (SMIOLf_file), target :: file
+        character(len=*), intent(in) :: varname
+        character(len=*), intent(in) :: att_name
+        real(kind=c_float), intent(in), target :: att
+
+        ! Local variables
+        integer :: i
+        type (c_ptr) :: c_file
+        character(kind=c_char), dimension(:), allocatable, target :: c_varname
+        character(kind=c_char), dimension(:), pointer :: c_att_name
+        type (c_ptr) :: att_ptr
+        type (c_ptr) :: c_varname_ptr
+
+        ! C interface definitions
+        interface
+            function SMIOL_define_att(file, varname, att_name, att_type, att) result(ierr) bind(C, name='SMIOL_define_att')
+                use iso_c_binding, only : c_ptr, c_char, c_int
+                type (c_ptr), value :: file
+                type (c_ptr), value :: varname
+                character(kind=c_char), dimension(*) :: att_name
+                integer(kind=c_int), value :: att_type
+                type (c_ptr), value :: att
+                integer(kind=c_int) :: ierr
+            end function
+        end interface
+
+        c_file = c_loc(file)
+
+        !
+        ! Convert Fortran string to C character array
+        !
+        if (len_trim(varname) > 0) then
+            allocate(c_varname(len_trim(varname) + 1))
+            do i=1,len_trim(varname)
+                c_varname(i) = varname(i:i)
+            end do
+            c_varname(i) = c_null_char
+            c_varname_ptr = c_loc(c_varname)
+        else
+            c_varname_ptr = c_null_ptr
+        end if
+
+        allocate(c_att_name(len_trim(att_name) + 1))
+        do i=1,len_trim(att_name)
+            c_att_name(i) = att_name(i:i)
+        end do
+        c_att_name(i) = c_null_char
+
+        att_ptr = c_loc(att)
+
+        ierr = SMIOL_define_att(c_file, c_varname_ptr, c_att_name, SMIOL_REAL32, att_ptr)
+
+        if (len_trim(varname) > 0) then
+            deallocate(c_varname)
+        end if
+        deallocate(c_att_name)
+
+    end function SMIOLf_define_att_float
+
+
+    !-----------------------------------------------------------------------
+    !  routine SMIOLf_define_att_double
+    !
+    !> \brief Defines a new double attribute
+    !> \details
+    !>  Defines a new double attribute for a variable if varname is not an empty
+    !>  string, or a global attribute otherwise.
+    !>
+    !>  If the attribute has been successfully defined for the variable or file,
+    !>  SMIOL_SUCCESS is returned.
+    !
+    !-----------------------------------------------------------------------
+    integer function SMIOLf_define_att_double(file, varname, att_name, att) result(ierr)
+
+        use iso_c_binding, only : c_char, c_double, c_null_char, c_null_ptr, c_ptr, c_loc
+
+        implicit none
+
+        ! Arguments
+        type (SMIOLf_file), target :: file
+        character(len=*), intent(in) :: varname
+        character(len=*), intent(in) :: att_name
+        real(kind=c_double), intent(in), target :: att
+
+        ! Local variables
+        integer :: i
+        type (c_ptr) :: c_file
+        character(kind=c_char), dimension(:), allocatable, target :: c_varname
+        character(kind=c_char), dimension(:), pointer :: c_att_name
+        type (c_ptr) :: att_ptr
+        type (c_ptr) :: c_varname_ptr
+
+        ! C interface definitions
+        interface
+            function SMIOL_define_att(file, varname, att_name, att_type, att) result(ierr) bind(C, name='SMIOL_define_att')
+                use iso_c_binding, only : c_ptr, c_char, c_int
+                type (c_ptr), value :: file
+                type (c_ptr), value :: varname
+                character(kind=c_char), dimension(*) :: att_name
+                integer(kind=c_int), value :: att_type
+                type (c_ptr), value :: att
+                integer(kind=c_int) :: ierr
+            end function
+        end interface
+
+        c_file = c_loc(file)
+
+        !
+        ! Convert Fortran string to C character array
+        !
+        if (len_trim(varname) > 0) then
+            allocate(c_varname(len_trim(varname) + 1))
+            do i=1,len_trim(varname)
+                c_varname(i) = varname(i:i)
+            end do
+            c_varname(i) = c_null_char
+            c_varname_ptr = c_loc(c_varname)
+        else
+            c_varname_ptr = c_null_ptr
+        end if
+
+        allocate(c_att_name(len_trim(att_name) + 1))
+        do i=1,len_trim(att_name)
+            c_att_name(i) = att_name(i:i)
+        end do
+        c_att_name(i) = c_null_char
+
+        att_ptr = c_loc(att)
+
+        ierr = SMIOL_define_att(c_file, c_varname_ptr, c_att_name, SMIOL_REAL64, att_ptr)
+
+        if (len_trim(varname) > 0) then
+            deallocate(c_varname)
+        end if
+        deallocate(c_att_name)
+
+    end function SMIOLf_define_att_double
+
+
+    !-----------------------------------------------------------------------
+    !  routine SMIOLf_define_att_text
+    !
+    !> \brief Defines a new text attribute
+    !> \details
+    !>  Defines a new text attribute for a variable if varname is not an empty
+    !>  string, or a global attribute otherwise.
+    !>
+    !>  If the attribute has been successfully defined for the variable or file,
+    !>  SMIOL_SUCCESS is returned.
+    !
+    !-----------------------------------------------------------------------
+    integer function SMIOLf_define_att_text(file, varname, att_name, att) result(ierr)
+
+        use iso_c_binding, only : c_char, c_null_char, c_null_ptr, c_ptr, c_loc
+
+        implicit none
+
+        ! Arguments
+        type (SMIOLf_file), target :: file
+        character(len=*), intent(in) :: varname
+        character(len=*), intent(in) :: att_name
+        character(len=*), intent(in) :: att
+
+        ! Local variables
+        integer :: i
+        type (c_ptr) :: c_file
+        character(kind=c_char), dimension(:), allocatable, target :: c_varname
+        character(kind=c_char), dimension(:), pointer :: c_att_name
+        character(kind=c_char), dimension(:), allocatable, target :: c_att
+        type (c_ptr) :: att_ptr
+        type (c_ptr) :: c_varname_ptr
+
+        ! C interface definitions
+        interface
+            function SMIOL_define_att(file, varname, att_name, att_type, att) result(ierr) bind(C, name='SMIOL_define_att')
+                use iso_c_binding, only : c_ptr, c_char, c_int
+                type (c_ptr), value :: file
+                type (c_ptr), value :: varname
+                character(kind=c_char), dimension(*) :: att_name
+                integer(kind=c_int), value :: att_type
+                type (c_ptr), value :: att
+                integer(kind=c_int) :: ierr
+            end function
+        end interface
+
+        c_file = c_loc(file)
+
+        !
+        ! Convert Fortran string to C character array
+        !
+        if (len_trim(varname) > 0) then
+            allocate(c_varname(len_trim(varname) + 1))
+            do i=1,len_trim(varname)
+                c_varname(i) = varname(i:i)
+            end do
+            c_varname(i) = c_null_char
+            c_varname_ptr = c_loc(c_varname)
+        else
+            c_varname_ptr = c_null_ptr
+        end if
+
+        allocate(c_att_name(len_trim(att_name) + 1))
+        do i=1,len_trim(att_name)
+            c_att_name(i) = att_name(i:i)
+        end do
+        c_att_name(i) = c_null_char
+
+        allocate(c_att(len_trim(att) + 1))
+        do i=1,len_trim(att)
+            c_att(i) = att(i:i)
+        end do
+        c_att(i) = c_null_char
+
+        att_ptr = c_loc(c_att)
+
+        ierr = SMIOL_define_att(c_file, c_varname_ptr, c_att_name, SMIOL_CHAR, att_ptr)
+
+        if (len_trim(varname) > 0) then
+            deallocate(c_varname)
+        end if
+        deallocate(c_att_name)
+        deallocate(c_att)
+
+    end function SMIOLf_define_att_text
 
 
     !-----------------------------------------------------------------------


### PR DESCRIPTION
This merge adds implementations of the C and Fortran routines for defining and inquiring about
global attributes and variable attributes. It also includes unit tests for the new attribute routines.