### PR TITLE
C Implementation of SMIOL_put/get_var routines

### DIFF
--- a/smiol_runner.c
+++ b/smiol_runner.c
@@ -370,7 +370,7 @@ int main(int argc, char **argv)
 	memset(int_buf, (int) 0, (size_t) 40962);
 	if ((ierr = SMIOL_get_var(file, decomp, "indexToCellID", int_buf)) != SMIOL_SUCCESS) {
 		fprintf(test_log, "ERROR: SMIOL_get_var: %s ",
-			SMIOL_error_string(ierr));
+			SMIOL_lib_error_string(file->context));
 		return 1;
 	}
 	free(int_buf);

--- a/smiol_runner.c
+++ b/smiol_runner.c
@@ -367,11 +367,13 @@ int main(int argc, char **argv)
 		return 1;
 	}
 
-	if ((ierr = SMIOL_get_var()) != SMIOL_SUCCESS) {
+	memset(int_buf, (int) 0, (size_t) 40962);
+	if ((ierr = SMIOL_get_var(file, decomp, "indexToCellID", int_buf)) != SMIOL_SUCCESS) {
 		fprintf(test_log, "ERROR: SMIOL_get_var: %s ",
 			SMIOL_error_string(ierr));
 		return 1;
 	}
+	free(int_buf);
 
 	if ((ierr = SMIOL_close_file(&file)) != SMIOL_SUCCESS) {
 		fprintf(test_log, "ERROR: SMIOL_close_file: %s ", SMIOL_error_string(ierr));

--- a/src/smiol.c
+++ b/src/smiol.c
@@ -954,7 +954,8 @@ int SMIOL_put_var(struct SMIOL_file *file, struct SMIOL_decomp *decomp,
  * Detailed description.
  *
  ********************************************************************************/
-int SMIOL_get_var(void)
+int SMIOL_get_var(struct SMIOL_file *file, struct SMIOL_decomp *decomp,
+                  const char *varname, const void *buf)
 {
 	return SMIOL_SUCCESS;
 }

--- a/src/smiol.c
+++ b/src/smiol.c
@@ -761,8 +761,21 @@ int SMIOL_inquire_var(struct SMIOL_file *file, const char *varname, int *vartype
  * Detailed description.
  *
  ********************************************************************************/
-int SMIOL_put_var(void)
+int SMIOL_put_var(struct SMIOL_file *file, struct SMIOL_decomp *decomp,
+                  const char *varname, const void *buf)
 {
+	if (file == NULL) {
+		return SMIOL_INVALID_ARGUMENT;
+	}
+
+	if (varname == NULL) {
+		return SMIOL_INVALID_ARGUMENT;
+	}
+
+	if (buf == NULL) {
+		return SMIOL_INVALID_ARGUMENT;
+	}
+
 	return SMIOL_SUCCESS;
 }
 

--- a/src/smiol.h
+++ b/src/smiol.h
@@ -33,7 +33,8 @@ int SMIOL_inquire_dim(struct SMIOL_file *file, const char *dimname,
  */
 int SMIOL_define_var(struct SMIOL_file *file, const char *varname, int vartype, int ndims, const char **dimnames);
 int SMIOL_inquire_var(struct SMIOL_file *file, const char *varname, int *vartype, int *ndims, char **dimnames);
-int SMIOL_put_var(void);
+int SMIOL_put_var(struct SMIOL_file *file, struct SMIOL_decomp *decomp,
+                  const char *varname, const void *buf);
 int SMIOL_get_var(void);
 
 /*

--- a/src/smiol.h
+++ b/src/smiol.h
@@ -36,7 +36,7 @@ int SMIOL_inquire_var(struct SMIOL_file *file, const char *varname, int *vartype
 int SMIOL_put_var(struct SMIOL_file *file, struct SMIOL_decomp *decomp,
                   const char *varname, const void *buf);
 int SMIOL_get_var(struct SMIOL_file *file, struct SMIOL_decomp *decomp,
-                  const char *varname, const void *buf);
+                  const char *varname, void *buf);
 
 /*
  * Attribute methods

--- a/src/smiol.h
+++ b/src/smiol.h
@@ -35,7 +35,8 @@ int SMIOL_define_var(struct SMIOL_file *file, const char *varname, int vartype, 
 int SMIOL_inquire_var(struct SMIOL_file *file, const char *varname, int *vartype, int *ndims, char **dimnames);
 int SMIOL_put_var(struct SMIOL_file *file, struct SMIOL_decomp *decomp,
                   const char *varname, const void *buf);
-int SMIOL_get_var(void);
+int SMIOL_get_var(struct SMIOL_file *file, struct SMIOL_decomp *decomp,
+                  const char *varname, const void *buf);
 
 /*
  * Attribute methods


### PR DESCRIPTION
These commits implement SMIOL_put/get_var routines for the C implementation of SMIOL. They are able to read and write all SMIOL variable types, including those dimensioned by the unlimited dimension, and are able to read and write decomposed and non-decomposed variables.

At present, the SMIOL_put/get_var routines cannot write fields over 2GB, but later commits could implement this functionality.