### PR TITLE
Remove unused symbols from USE statements as identified by the NAG compiler

### DIFF
--- a/src/smiolf.F90
+++ b/src/smiolf.F90
@@ -270,7 +270,7 @@ contains
     !-----------------------------------------------------------------------
     integer function SMIOLf_open_file(context, filename, mode, file) result(ierr)
 
-        use iso_c_binding, only : c_loc, c_ptr, c_null_ptr, c_char, c_null_char, c_associated, c_f_pointer
+        use iso_c_binding, only : c_loc, c_ptr, c_null_ptr, c_char, c_associated, c_f_pointer
 
         implicit none
 
@@ -400,7 +400,7 @@ contains
     !-----------------------------------------------------------------------
     integer function SMIOLf_define_dim(file, dimname, dimsize) result(ierr)
 
-        use iso_c_binding, only : c_char, c_null_char, c_loc, c_ptr, c_null_ptr, c_associated
+        use iso_c_binding, only : c_char, c_loc, c_ptr
 
         implicit none
 
@@ -461,7 +461,7 @@ contains
     !-----------------------------------------------------------------------
     integer function SMIOLf_inquire_dim(file, dimname, dimsize, is_unlimited) result(ierr)
 
-        use iso_c_binding, only : c_char, c_null_char, c_loc, c_ptr, c_null_ptr, c_associated
+        use iso_c_binding, only : c_char, c_loc, c_ptr, c_null_ptr
 
         implicit none
 


### PR DESCRIPTION
This merge removes unused symbols from USE statements in smiolf.F90 following
warning messages from the NAG 7.0 compiler:

```
Warning: smiolf.F90, line 330: C_NULL_CHAR explicitly imported into SMIOLF_OPEN_FILE but not used
Warning: smiolf.F90, line 440: C_ASSOCIATED explicitly imported into SMIOLF_DEFINE_DIM but not used
Warning: smiolf.F90, line 440: C_NULL_CHAR explicitly imported into SMIOLF_DEFINE_DIM but not used
Warning: smiolf.F90, line 440: C_NULL_PTR explicitly imported into SMIOLF_DEFINE_DIM but not used
Warning: smiolf.F90, line 538: C_ASSOCIATED explicitly imported into SMIOLF_INQUIRE_DIM but not used
Warning: smiolf.F90, line 538: C_NULL_CHAR explicitly imported into SMIOLF_INQUIRE_DIM but not used
```

This PR closes Issue #56 .