### PR TITLE
Avoid zero-sized c_dimnames argument to C_LOC in SMIOLf_define_var

### DIFF
--- a/src/smiolf.F90
+++ b/src/smiolf.F90
@@ -558,7 +558,7 @@ contains
     !-----------------------------------------------------------------------
     integer function SMIOLf_define_var(file, varname, vartype, ndims, dimnames) result(ierr)
 
-        use iso_c_binding, only : c_int, c_char, c_null_char, c_ptr, c_loc
+        use iso_c_binding, only : c_int, c_char, c_null_char, c_ptr, c_loc, c_null_ptr
 
         implicit none
 
@@ -573,6 +573,7 @@ contains
         integer(kind=c_int) :: c_vartype
         integer(kind=c_int) :: c_ndims
 
+        type (c_ptr) :: c_dimnames_ptr
         type (c_ptr), dimension(:), allocatable, target :: c_dimnames
 
         integer :: i, j
@@ -637,7 +638,13 @@ contains
             c_dimnames(j) = c_loc(strings(j) % str)
         end do
 
-        ierr = SMIOL_define_var(c_file, c_varname, c_vartype, c_ndims, c_loc(c_dimnames))
+        if (ndims > 0) then
+            c_dimnames_ptr = c_loc(c_dimnames)
+        else
+            c_dimnames_ptr = c_null_ptr
+        end if
+
+        ierr = SMIOL_define_var(c_file, c_varname, c_vartype, c_ndims, c_dimnames_ptr)
 
         do j=1,ndims
             deallocate(strings(j) % str)


### PR DESCRIPTION
This merge ensures that a zero-sized c_dimnames array is never used
as an argument to the C_LOC intrinsic in SMIOLf_define_var.

In SMIOLf_define_var, the definition of variables with zero dimensions
(i.e., scalar variables) led to a situation in which the argument of
the C_LOC intrinsic was a zero-sized array. Specifically, this argument
was the c_dimnames array.

According to the Fortran 2003 standard, the argument of C_LOC shall be
"...an allocated allocatable variable that has the TARGET attribute and is not
an array of zero size..."

To avoid this problem, an actual argument, c_dimnames_ptr, is declared in
SMIOLf_define_var, and is set to either C_LOC(c_dimnames) or C_NULL_PTR,
depending on whether the variable being defined has more than zero dimensions.

This PR closes Issue #58 