### PR TITLE
Avoid zero-sized compute_elements argument to C_LOC in SMIOLf_create_decomp

### DIFF
--- a/src/smiolf.F90
+++ b/src/smiolf.F90
@@ -1830,7 +1830,11 @@ contains
 
         ! Get C pointers to Fortran types
         c_context = c_loc(context)
-        c_compute_elements = c_loc(compute_elements)
+        if (size(compute_elements) > 0) then
+            c_compute_elements = c_loc(compute_elements)
+        else
+            c_compute_elements = c_null_ptr
+        end if
 
         c_decomp = c_null_ptr
 


### PR DESCRIPTION
This merge avoids the use of a zero-sized `compute_elements` argument to the C_LOC
intrinsic in `SMIOLf_create_decomp`.

In `SMIOLf_create_decomp`, MPI ranks with no compute elements pass a zero-sized
array as the `compute_elements` argument, and this led to a call to C_LOC with
a zero-sized array.
```
According to the Fortran 2003 standard, the argument of C_LOC shall be
"...an allocated allocatable variable that has the TARGET attribute and is not
an array of zero size..."
```
Now, if the size of the `compute_elements` array is zero, the C pointer to
`compute_elements`, `c_compute_elements`, is set to C_NULL_PTR; otherwise, this
pointer is set using `C_LOC(compute_elements)` as before.

This PR closes #60 .