### PR TITLE
C implementation of SMIOL_put_var and SMIOL_get_var

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ endif
 smiol:
 
 	$(MAKE) -C ./src CC=$(CC_PARALLEL) FC=$(FC_PARALLEL) CPPINCLUDES="$(CPPINCLUDES)"
-	$(CC_PARALLEL) -I./src/ $(CPPINCLUDES) $(CFLAGS) -L./ -o smiol_runner_c smiol_runner.c -lsmiol $(LIBS)
+	$(CC_PARALLEL) -I./src/ $(CPPINCLUDES) $(CFLAGS) -L./ -o smiol_runner_c smiol_runner.c -lm -lsmiol $(LIBS)
 	$(FC_PARALLEL) -I./src/ $(CPPINCLUDES) $(FFLAGS) -L./ -o smiol_runner_f smiol_runner.F90 -lsmiolf -lsmiol $(LIBS)
 
 

--- a/smiol_runner.c
+++ b/smiol_runner.c
@@ -115,6 +115,7 @@ int main(int argc, char **argv)
 	char log_fname[17];
 	FILE *test_log = NULL;
 	char **dimnames;
+	float *buf;
 
 	if (MPI_Init(&argc, &argv) != MPI_SUCCESS) {
 		fprintf(stderr, "Error: MPI_Init failed.\n");
@@ -394,14 +395,17 @@ int main(int argc, char **argv)
 		return 1;
 	}
 
-	if ((ierr = SMIOL_close_file(&file)) != SMIOL_SUCCESS) {
-		fprintf(test_log, "ERROR: SMIOL_close_file: %s ", SMIOL_error_string(ierr));
-		return 1;
-	}
-
-	if ((ierr = SMIOL_put_var()) != SMIOL_SUCCESS) {
+	buf = malloc(sizeof(float) * (size_t)40962);
+	memset((void *)buf, 0, sizeof(float) * (size_t)40962);
+	if ((ierr = SMIOL_put_var(file, "theta", NULL, buf)) != SMIOL_SUCCESS) {
 		fprintf(test_log, "ERROR: SMIOL_put_var: %s ",
 			SMIOL_error_string(ierr));
+		return 1;
+	}
+	free(buf);
+
+	if ((ierr = SMIOL_close_file(&file)) != SMIOL_SUCCESS) {
+		fprintf(test_log, "ERROR: SMIOL_close_file: %s ", SMIOL_error_string(ierr));
 		return 1;
 	}
 

--- a/smiol_runner.c
+++ b/smiol_runner.c
@@ -415,16 +415,16 @@ int main(int argc, char **argv)
 			SMIOL_error_string(ierr));
 		return 1;
 	}
+
+	if ((ierr = SMIOL_get_var(file, "theta", NULL, buf)) != SMIOL_SUCCESS) {
+		fprintf(test_log, "ERROR: SMIOL_get_var: %s ",
+			SMIOL_error_string(ierr));
+		return 1;
+	}
 	free(buf);
 
 	if ((ierr = SMIOL_close_file(&file)) != SMIOL_SUCCESS) {
 		fprintf(test_log, "ERROR: SMIOL_close_file: %s ", SMIOL_error_string(ierr));
-		return 1;
-	}
-
-	if ((ierr = SMIOL_get_var()) != SMIOL_SUCCESS) {
-		fprintf(test_log, "ERROR: SMIOL_get_var: %s ",
-			SMIOL_error_string(ierr));
 		return 1;
 	}
 	

--- a/src/smiol.c
+++ b/src/smiol.c
@@ -759,11 +759,38 @@ int SMIOL_inquire_var(struct SMIOL_file *file, const char *varname, int *vartype
  *
  * Writes a variable to a file.
  *
- * Detailed description.
+ * Given a pointer to a SMIOL file that was previously opened with write access
+ * and the name of a variable previously defined in the file with a call to
+ * SMIOL_define_var, this routine will write the contents of buf to the variable
+ * according to the decomposition described by decomp.
+ *
+ * If decomp is not NULL, the variable is assumed to be decomposed across MPI
+ * ranks, and all ranks with non-zero-sized partitions of the variable must
+ * provide a valid buffer. For decomposed variables, all MPI ranks must provide
+ * a non-NULL decomp, regardless of whether a rank has a non-zero-sized
+ * partition of the variable.
+ *
+ * If the variable is not decomposed -- that is, all ranks store identical
+ * values for the entire variable -- all MPI ranks must provide a NULL pointer
+ * for the decomp argument. As currently implemented, this routine will write
+ * the buffer for MPI rank 0 to the variable; however, this behavior should not
+ * be relied on.
+ *
+ * If the variable has been successfully written to the file, SMIOL_SUCCESS will
+ * be returned. Otherwise, an error code indicating the nature of the failure
+ * will be returned.
  *
  ********************************************************************************/
-int SMIOL_put_var(void)
+int SMIOL_put_var(struct SMIOL_file *file, const char *varname,
+                  const struct SMIOL_decomp *decomp, const void *buf)
 {
+	/*
+	 * Basic checks on arguments
+	 */
+	if (file == NULL || varname == NULL) {
+		return SMIOL_INVALID_ARGUMENT;
+	}
+
 	return SMIOL_SUCCESS;
 }
 

--- a/src/smiol.c
+++ b/src/smiol.c
@@ -1010,10 +1010,10 @@ int SMIOL_put_var(struct SMIOL_file *file, const char *varname,
 		}
 
 		ierr = ncmpi_put_vara_all(file->ncidp,
-                                          varidp,
-                                          mpi_start, mpi_count,
-                                          buf_p,
-                                          0, MPI_DATATYPE_NULL);
+		                          varidp,
+		                          mpi_start, mpi_count,
+		                          buf_p,
+		                          0, MPI_DATATYPE_NULL);
 
 		free(mpi_start);
 		free(mpi_count);

--- a/src/smiol.c
+++ b/src/smiol.c
@@ -1075,11 +1075,180 @@ int SMIOL_put_var(struct SMIOL_file *file, const char *varname,
 int SMIOL_get_var(struct SMIOL_file *file, const char *varname,
                   const struct SMIOL_decomp *decomp, void *buf)
 {
+	int i;
+	int ierr;
+	int ndims;
+	int vartype;
+	int has_unlimited_dim;
+	char **dimnames;
+	SMIOL_Offset *dimsizes;
+	size_t element_size;
+	void *in_buf;
+	size_t *start;
+	size_t *count;
+
 	/*
 	 * Basic checks on arguments
 	 */
 	if (file == NULL || varname == NULL) {
 		return SMIOL_INVALID_ARGUMENT;
+	}
+
+	/*
+	 * Figure out type of the variable, as well as its dimensions
+	 */
+	ierr = SMIOL_inquire_var(file, varname, &vartype, &ndims, NULL);
+	if (ierr != SMIOL_SUCCESS) {
+		return ierr;
+	}
+
+	dimnames = malloc(sizeof(char *) * (size_t)ndims);
+	for (i = 0; i < ndims; i++) {
+/* TO DO - define maximum string size */
+		dimnames[i] = malloc(sizeof(char) * (size_t)64);
+	}
+/* TO DO - check for malloc errors */
+
+	ierr = SMIOL_inquire_var(file, varname, NULL, NULL, dimnames);
+	if (ierr != SMIOL_SUCCESS) {
+		for (i = 0; i < ndims; i++) {
+			free(dimnames[i]);
+		}
+		free(dimnames);
+		return ierr;
+	}
+
+	dimsizes = malloc(sizeof(SMIOL_Offset) * (size_t)ndims);
+/* TO DO - check for malloc errors */
+
+	/*
+	 * It is assumed that only the first dimension can be an unlimited
+	 * dimension, so by inquiring about dimensions from last to first, we can
+	 * be guaranteed that has_unlimited_dim will be set correctly at the end
+	 * of the loop over dimensions
+	 */
+	for (i = (ndims-1); i >= 0; i--) {
+		ierr = SMIOL_inquire_dim(file, dimnames[i], &dimsizes[i],
+		                         &has_unlimited_dim);
+		if (ierr != SMIOL_SUCCESS) {
+			for (i = 0; i < ndims; i++) {
+				free(dimnames[i]);
+			}
+			free(dimnames);
+			free(dimsizes);
+
+			return ierr;
+		}
+	}
+
+	for (i = 0; i < ndims; i++) {
+		free(dimnames[i]);
+	}
+	free(dimnames);
+
+	/*
+	 * Set basic size of each element in the field; only necessary if the field
+	 * is decomposed and therefore must be transferred prior to writing
+	 */
+	element_size = 1;
+	if (decomp) {
+		switch (vartype) {
+			case SMIOL_REAL32:
+				element_size = sizeof(float);
+				break;
+			case SMIOL_REAL64:
+				element_size = sizeof(double);
+				break;
+			case SMIOL_INT32:
+				element_size = sizeof(int);
+				break;
+			case SMIOL_CHAR:
+				element_size = sizeof(char);
+				break;
+		}
+	}
+
+	start = malloc(sizeof(size_t) * (size_t)ndims);
+	count = malloc(sizeof(size_t) * (size_t)ndims);
+/* TO DO - check for malloc errors */
+
+	/*
+	 * Build start/count description of the part of the variable to be written
+	 * Simultaneously, compute the product of all non-unlimited, non-decomposed
+	 * dimension sizes, scaled by the basic element size to get the effective
+	 * size of each element to be written
+	 */
+	for (i = 0; i < ndims; i++) {
+		start[i] = 0;
+		count[i] = dimsizes[i];
+
+		/*
+		 * If variable has an unlimited dimension, set start to current frame
+		 * and count to one
+		 */
+		if (has_unlimited_dim && i == 0) {
+			start[i] = file->frame;
+			count[i] = 1;
+		}
+
+		/*
+		 * If variable is decomposed, set the slowest-varying, non-record dimension
+		 * start and count based on values from the decomp structure
+		 */
+		if (decomp) {
+			if ((!has_unlimited_dim && i == 0) ||
+			    (has_unlimited_dim && i == 1)) {
+				start[i] = decomp->io_start;
+				count[i] = decomp->io_count;
+			} else {
+				element_size *= count[i];
+			}
+		} else {
+			element_size *= count[i];
+		}
+
+#if 0
+		/*
+		 * If the variable is not decomposed, only MPI rank 0 will have non-zero
+		 * count values
+		 */
+		if (!decomp && file->context->comm_rank != 0) {
+			count[i] = 0;
+		}
+#endif
+	}
+
+	free(dimsizes);
+
+	/*
+	 *
+	 */
+	if (decomp) {
+		in_buf = malloc(element_size * decomp->io_count);
+/* TO DO - check for malloc errors */
+	}
+
+	/*
+	 * Read in_buf
+	 */
+
+	/*
+	 * Free start/count arrays
+	 */
+	free(start);
+	free(count);
+
+	/*
+	 *
+	 */
+	if (decomp) {
+		ierr = transfer_field(decomp, SMIOL_IO_TO_COMP,
+		                      element_size, in_buf, buf);
+		free(in_buf);
+
+		if (ierr != SMIOL_SUCCESS) {
+			return ierr;
+		}
 	}
 
 	return SMIOL_SUCCESS;

--- a/src/smiol.c
+++ b/src/smiol.c
@@ -1295,10 +1295,10 @@ int SMIOL_get_var(struct SMIOL_file *file, const char *varname,
 		}
 
 		ierr = ncmpi_get_vara_all(file->ncidp,
-                                          varidp,
-                                          mpi_start, mpi_count,
-                                          buf_p,
-                                          0, MPI_DATATYPE_NULL);
+		                          varidp,
+		                          mpi_start, mpi_count,
+		                          buf_p,
+		                          0, MPI_DATATYPE_NULL);
 
 		free(mpi_start);
 		free(mpi_count);

--- a/src/smiol.c
+++ b/src/smiol.c
@@ -660,6 +660,17 @@ int SMIOL_inquire_var(struct SMIOL_file *file, const char *varname, int *vartype
 		return SMIOL_SUCCESS;
 	}
 
+	/*
+	 * Provide default values for output arguments in case
+	 * no library-specific below is active
+	 */
+	if (vartype != NULL) {
+		*vartype = SMIOL_UNKNOWN_VAR_TYPE;
+	}
+	if (ndims != NULL) {
+		*ndims = 0;
+	}
+
 #ifdef SMIOL_PNETCDF
 	/*
 	 * Get variable ID

--- a/src/smiol.c
+++ b/src/smiol.c
@@ -1053,11 +1053,35 @@ int SMIOL_put_var(struct SMIOL_file *file, const char *varname,
  *
  * Reads a variable from a file.
  *
- * Detailed description.
+ * Given a pointer to a SMIOL file and the name of a variable previously defined
+ * in the file, this routine will read the contents of the variable into buf
+ * according to the decomposition described by decomp.
+ *
+ * If decomp is not NULL, the variable is assumed to be decomposed across MPI
+ * ranks, and all ranks with non-zero-sized partitions of the variable must
+ * provide a valid buffer. For decomposed variables, all MPI ranks must provide
+ * a non-NULL decomp, regardless of whether a rank has a non-zero-sized
+ * partition of the variable.
+ *
+ * If the variable is not decomposed -- that is, all ranks load identical
+ * values for the entire variable -- all MPI ranks must provide a NULL pointer
+ * for the decomp argument.
+ *
+ * If the variable has been successfully read from the file, SMIOL_SUCCESS will
+ * be returned. Otherwise, an error code indicating the nature of the failure
+ * will be returned.
  *
  ********************************************************************************/
-int SMIOL_get_var(void)
+int SMIOL_get_var(struct SMIOL_file *file, const char *varname,
+                  const struct SMIOL_decomp *decomp, void *buf)
 {
+	/*
+	 * Basic checks on arguments
+	 */
+	if (file == NULL || varname == NULL) {
+		return SMIOL_INVALID_ARGUMENT;
+	}
+
 	return SMIOL_SUCCESS;
 }
 

--- a/src/smiol.h
+++ b/src/smiol.h
@@ -33,7 +33,8 @@ int SMIOL_inquire_dim(struct SMIOL_file *file, const char *dimname,
  */
 int SMIOL_define_var(struct SMIOL_file *file, const char *varname, int vartype, int ndims, const char **dimnames);
 int SMIOL_inquire_var(struct SMIOL_file *file, const char *varname, int *vartype, int *ndims, char **dimnames);
-int SMIOL_put_var(void);
+int SMIOL_put_var(struct SMIOL_file *file, const char *varname,
+                  const struct SMIOL_decomp *decomp, const void *buf);
 int SMIOL_get_var(void);
 
 /*

--- a/src/smiol.h
+++ b/src/smiol.h
@@ -35,7 +35,8 @@ int SMIOL_define_var(struct SMIOL_file *file, const char *varname, int vartype, 
 int SMIOL_inquire_var(struct SMIOL_file *file, const char *varname, int *vartype, int *ndims, char **dimnames);
 int SMIOL_put_var(struct SMIOL_file *file, const char *varname,
                   const struct SMIOL_decomp *decomp, const void *buf);
-int SMIOL_get_var(void);
+int SMIOL_get_var(struct SMIOL_file *file, const char *varname,
+                  const struct SMIOL_decomp *decomp, void *buf);
 
 /*
  * Attribute methods


### PR DESCRIPTION
This merge provides C implementations of the `SMIOL_put_var` and `SMIOL_get_var`
routines, with support for reading and writing via the parallel-netCDF library.
Also included in this merge are unit tests for `SMIOL_put_var` and `SMIOL_get_var`.

Note that at present, the `SMIOL_put_var` and `SMIOL_get_var` routines are not
expected to work correctly when any MPI rank writes or reads more than 2 GB
of data.