### PR TITLE
Fix computation of io_count when comm_rank >= io_stride * num_io_tasks

### DIFF
--- a/src/smiol_utils.c
+++ b/src/smiol_utils.c
@@ -397,6 +397,10 @@ int get_io_elements(int comm_rank, int num_io_tasks, int io_stride,
 		size_t io_rank = (size_t)(comm_rank / io_stride);
 		size_t elems_per_task = (n_io_elements / (size_t)num_io_tasks);
 
+		if (io_rank >= num_io_tasks) {
+			return 0;
+		}
+
 		*io_start = io_rank * elems_per_task;
 		*io_count = elems_per_task;
 


### PR DESCRIPTION
This merge corrects the computation of io_count when 
comm_rank >= io_stride * num_io_tasks.

The get_io_elements function previously assumed that the product of io_stride
and num_io_tasks would be at least as large as comm_size. For MPI ranks that
were a multiple of io_stride and greater than or equal to
(io_stride * num_io_tasks), the get_io_elements utility function incorrectly
returned non-zero io_start and io_count values.

The simple fix to this issue is to return from get_io_elements as soon as
io_rank has been computed as (comm_rank / io_stride) and been found to be equal
to or to exceed the number of I/O tasks (equality necessitates a return, since
io_rank is zero-based).

This PR closes #63 .