### PR TITLE
Implement Fortran interfaces to SMIOL_put_var and SMIOL_get_var

### DIFF
--- a/smiol_runner.F90
+++ b/smiol_runner.F90
@@ -2,7 +2,7 @@
 
 program smiol_runner
 
-    use iso_c_binding, only : c_size_t
+    use iso_c_binding, only : c_size_t, c_float
     use SMIOLf
     use mpi
 
@@ -24,6 +24,7 @@ program smiol_runner
     integer(kind=SMIOL_offset_kind) :: dimsize
     integer :: ndims
     character(len=32) :: tempstr
+    real(kind=c_float), dimension(:), pointer :: real32_buf
 
     call MPI_Init(ierr)
     if (ierr /= MPI_SUCCESS) then
@@ -271,18 +272,21 @@ program smiol_runner
     endif
 #endif
 
-    if (SMIOLf_close_file(file) /= SMIOL_SUCCESS) then
-        write(test_log,'(a)') "ERROR: 'SMIOLf_close_file' was not called successfully"
-        stop 1
-    endif
-
-    if (SMIOLf_put_var() /= SMIOL_SUCCESS) then
+    allocate(real32_buf(40962))
+    real32_buf(:) = 0.0
+    if (SMIOLf_put_var(file, 'theta', decomp, real32_buf) /= SMIOL_SUCCESS) then
         write(test_log,'(a)') "ERROR: 'SMIOLf_put_var' was not called successfully"
         stop 1
     endif
 
-    if (SMIOLf_get_var() /= SMIOL_SUCCESS) then
+    if (SMIOLf_get_var(file, 'theta', decomp, real32_buf) /= SMIOL_SUCCESS) then
         write(test_log,'(a)') "ERROR: 'SMIOLf_get_var' was not called successfully"
+        stop 1
+    endif
+    deallocate(real32_buf)
+
+    if (SMIOLf_close_file(file) /= SMIOL_SUCCESS) then
+        write(test_log,'(a)') "ERROR: 'SMIOLf_close_file' was not called successfully"
         stop 1
     endif
 

--- a/src/gen_put_get.sh
+++ b/src/gen_put_get.sh
@@ -1,0 +1,402 @@
+#!/usr/bin/env sh
+
+filename=smiolf_put_get_var.inc
+
+
+################################################################################
+#
+# gen_put_get_var
+#
+# Generate a function body for a specific "SMIOLf_put/get_var" function
+# Required variables:
+#  d = 0, 1, 2, 3
+#  io = put, get
+#  colon_list = ":,:,:"
+#  dim_list = "d1,d1,d3"
+#  type = real32, real64
+#  kind = c_float, c_double
+#  base_type = real, integer
+#  size_args = "size(buf,dim=1), size(buf,dim=2)"
+#
+################################################################################
+gen_put_get_var()
+{
+    #
+    # For non-scalars, build, e.g., " dimension(:,:,:),"
+    #
+    if [ $d -ge 1 ]; then
+        dim=" dimension(${colon_list}),"
+        c_loc_invocation="            !
+            ! Invoke a Fortran 2003-compliant function to get the c_ptr
+            ! of the assumed shape array buf
+            !
+            c_buf = c_loc_assumed_shape_${d}d_${type}(buf${size_args})"
+    else
+        dim=""
+        c_loc_invocation="            c_buf = c_loc(buf)"
+    fi
+
+    #
+    # Character variables need special copying code...
+    #
+    if [ "${kind}" = "c_char" ]; then
+
+        if [ "${io}" = "put" ]; then
+
+            char_copyin="            allocate(char_buf(len(buf)))
+            do i=1,len(buf)
+                char_buf(i) = buf(i:i)
+            end do"
+
+            char_copyout="        if (associated(buf)) then
+            deallocate(char_buf)
+        end if"
+
+        else
+
+            char_copyin="            allocate(char_buf(len(buf)))"
+
+            char_copyout="        if (associated(buf)) then
+            do i=1,len(buf)
+                buf(i:i) = char_buf(i)
+            end do
+
+            deallocate(char_buf)
+        end if"
+
+        fi
+
+        dummy_buf_decl="        ${base_type},${dim} pointer :: buf"
+        char_buf_decl="        character(kind=c_char), dimension(:), allocatable, target :: char_buf"
+        c_loc_invocation="            c_buf = c_loc(char_buf)"
+
+    else
+        char_copyin=""
+        char_copyout=""
+        dummy_buf_decl="        ${base_type}(kind=${kind}),${dim} pointer :: buf"
+        char_buf_decl=""
+    fi
+
+
+    #
+    # Build function documentation block
+    #
+    if [ "${io}" = "put" ]; then
+
+    header="    !-----------------------------------------------------------------------
+    !  routine SMIOLf_put_var_d${d}_${type}
+    !
+    !> \brief Writes a ${d}-d ${type} variable to a file.
+    !> \details
+    !>  Given a SMIOL file that was previously opened with write access and the name
+    !>  of a variable previously defined in the file with a call to SMIOLf_define_var,
+    !>  this routine will write the contents of buf to the variable according to
+    !>  the decomposition described by decomp.
+    !>
+    !>  If decomp is an associated pointer, the variable is assumed to be decomposed
+    !>  across MPI ranks, and all ranks with non-zero-sized partitions of the variable
+    !>  must provide a valid buffer. For decomposed variables, all MPI ranks must provide
+    !>  an associated decomp pointer, regardless of whether a rank has a non-zero-sized
+    !>  partition of the variable.
+    !>
+    !>  If the variable is not decomposed -- that is, all ranks store identical
+    !>  values for the entire variable -- all MPI ranks must provide an unassociated
+    !>  pointer for the decomp argument. As currently implemented, this routine will write
+    !>  the buffer for MPI rank 0 to the variable; however, this behavior should not
+    !>  be relied on.
+    !>
+    !>  If the variable has been successfully written to the file, SMIOL_SUCCESS will
+    !>  be returned. Otherwise, an error code indicating the nature of the failure
+    !>  will be returned.
+    !
+    !-----------------------------------------------------------------------"
+
+    else
+
+    header="    !-----------------------------------------------------------------------
+    !  routine SMIOLf_get_var_d${d}_${type}
+    !
+    !> \brief Reads a ${d}-d ${type} variable from a file.
+    !> \details
+    !>  Given a SMIOL file and the name of a variable previously defined in the file,
+    !>  this routine will read the contents of the variable into buf according to
+    !>  the decomposition described by decomp.
+    !>
+    !>  If decomp is an associated pointer, the variable is assumed to be decomposed
+    !>  across MPI ranks, and all ranks with non-zero-sized partitions of the variable
+    !>  must provide a valid buffer. For decomposed variables, all MPI ranks must provide
+    !>  an associated decomp pointer, regardless of whether a rank has a non-zero-sized
+    !>  partition of the variable.
+    !>
+    !>  If the variable is not decomposed -- that is, all ranks load identical
+    !>  values for the entire variable -- all MPI ranks must provide an unassociated
+    !>  pointer for the decomp argument.
+    !>
+    !>  If the variable has been successfully read from the file, SMIOL_SUCCESS will
+    !>  be returned. Otherwise, an error code indicating the nature of the failure
+    !>  will be returned.
+    !
+    !-----------------------------------------------------------------------"
+
+    fi
+
+    cat >> ${filename} << EOF
+$header
+    function SMIOLf_${io}_var_${d}d_${type}(file, varname, decomp, buf) result(ierr)
+
+        use iso_c_binding, only : ${kind}, c_char, c_loc, c_ptr, c_null_ptr, c_null_char
+
+        implicit none
+
+        ! Arguments
+        type(SMIOLf_file), target :: file
+        character(len=*), intent(in) :: varname
+        type(SMIOLf_decomp), pointer :: decomp
+${dummy_buf_decl}
+
+        ! Return status code
+        integer :: ierr
+
+        ! Local variables
+        integer :: i
+        character(kind=c_char), dimension(:), pointer :: c_varname
+        type (c_ptr) :: c_file
+        type (c_ptr) :: c_decomp
+        type (c_ptr) :: c_buf
+${char_buf_decl}
+
+        !
+        ! file is a target, so no need to check that it is associated
+        !
+        c_file = c_loc(file)
+
+        !
+        ! decomp may be an unassociated pointer if the corresponding field is
+        ! not decomposed
+        !
+        if (associated(decomp)) then
+            c_decomp = c_loc(decomp)
+        else
+            c_decomp = c_null_ptr
+        end if
+
+        !
+        ! Convert variable name string
+        !
+        allocate(c_varname(len_trim(varname) + 1))
+        do i=1,len_trim(varname)
+            c_varname(i) = varname(i:i)
+        end do
+        c_varname(i) = c_null_char
+
+        !
+        ! buf may be an unassociated pointer if the calling task does not read
+        ! or write any elements of the field
+        !
+        if (associated(buf)) then
+${char_copyin}
+${c_loc_invocation}
+        else
+            c_buf = c_null_ptr
+        end if
+
+        ierr = SMIOL_${io}_var(c_file, c_varname, c_decomp, c_buf)
+
+${char_copyout}
+        deallocate(c_varname)
+
+    end function SMIOLf_${io}_var_${d}d_${type}
+
+
+EOF
+}
+
+
+################################################################################
+#
+# gen_c_loc
+#
+# Generate a function body for a specific "c_loc_assumed_shape" function
+# Required variables:
+#  d = 1, 2, 3
+#  dim_args = , d1, d1, d3
+#  dim_list = d1,d1,d3
+#  type = real32, real64
+#  kind = c_float, c_double
+#  base_type = real, integer
+#
+################################################################################
+gen_c_loc()
+{
+    #
+    # Build, e.g., " dimension(d1,d2,d3),"
+    #
+    dim=" dimension(${dim_list}),"
+
+    #
+    # Build list of dimension argument declarations
+    #
+    d_decl="integer, intent(in) :: d1"
+    i=2
+    while [ $i -le $d ]; do
+        d_decl="${d_decl}, d$i"
+        i=$(($i+1))
+    done
+
+    #
+    # Build function documentation block
+    #
+    header="    !-----------------------------------------------------------------------
+    !  routine c_loc_assumed_shape_${d}d_${type}
+    !
+    !> \brief Returns a C_PTR for an array with given dimensions
+    !> \details
+    !>  The Fortran 2003 standard does not permit the use of C_LOC with
+    !>  assumed shape arrays. This routine may be used to obtain a C_PTR for
+    !>  an assumed shape array by invoking the routine with the first actual
+    !>  argument as the assumed-shape array, and subsequent actual arguments
+    !>  as, e.g., SIZE(a,DIM=1).
+    !>
+    !>  Internally, the first dummy argument of this routine can be declared
+    !>  as an explicit shape array, which can then be used as an argument to
+    !>  C_LOC.
+    !>
+    !>  Upon success, a C_PTR for the array argument is returned.
+    !>
+    !>  Note: The actual array argument must not be a zero-sized array.
+    !>        Section 15.1.2.5 of the Fortran 2003 standard specifies that
+    !>        the argument to C_LOC '...is not an array of zero size...'.
+    !
+    !-----------------------------------------------------------------------"
+
+    cat >> ${filename} << EOF
+${header}
+    function c_loc_assumed_shape_${d}d_${type}(a${dim_args}) result(a_ptr)
+
+        use iso_c_binding, only : c_ptr, c_loc, ${kind}
+
+        implicit none
+
+        ! Arguments
+        ${d_decl}
+        ${base_type}(kind=${kind}),${dim} target, intent(in) :: a
+
+        ! Return value
+        type (c_ptr) :: a_ptr
+
+        a_ptr = c_loc(a)
+
+    end function c_loc_assumed_shape_${d}d_${type}
+
+
+EOF
+}
+
+
+################################################################################
+#
+# gen_put_get.sh
+#
+################################################################################
+printf "" > ${filename}
+
+#
+# For each type, handle each dimensionality
+#
+for d in 0 1 2 3 4 5; do
+
+    #
+    # Build list of dimension formal arguments, e.g. ", d1, d2, d3"
+    #
+    dim_args=''
+    i=1
+    while [ $i -le $d ]; do
+       dim_args="${dim_args}, d$i"
+       i=$(($i+1))
+    done
+
+    #
+    # Build explicit shape list, e.g., "d1,d2,d3"
+    #
+    dim_list=''
+    i=1
+    while [ $i -le $d ]; do
+        dim_list="${dim_list}d$i"
+        if [ $i -lt $d ]; then
+            dim_list="${dim_list},"
+        fi
+        i=$(($i+1))
+    done
+
+    #
+    # Build assumed shape list, e.g., ":,:,:"
+    #
+    colon_list=''
+    i=1
+    while [ $i -le $d ]; do
+        colon_list="${colon_list}:"
+        if [ $i -lt $d ]; then
+            colon_list="${colon_list},"
+        fi
+        i=$(($i+1))
+    done
+
+    #
+    # Build array size actual arguments , e.g., "size(buf,dim=1), size(buf,dim=2)"
+    #
+    size_args=''
+    i=1
+    while [ $i -le $d ]; do
+
+        # Break long lines after three dimensions
+        if [ $i -eq 4 -a $d -ge 4 ]; then
+            size_args="${size_args}, &
+                                           size(buf,dim=$i)"
+        else
+            size_args="${size_args}, size(buf,dim=$i)"
+        fi
+
+        i=$(($i+1))
+
+    done
+
+    #
+    # Create functions for each type
+    #
+    for type in char real32 real64 int32; do
+
+        # Only up to 0-d char interfaces
+        if [ "${type}" = "char" ] && [ $d -gt 0 ]; then
+            continue
+        fi
+
+        # Only up to 4-d int32 interfaces
+        if [ "${type}" = "int32" ] && [ $d -gt 4 ]; then
+            continue
+        fi
+
+        if [ "$type" = "real32" ]; then
+            kind="c_float"
+            base_type="real"
+        elif [ "$type" = "real64" ]; then
+            kind="c_double"
+            base_type="real"
+        elif [ "$type" = "int32" ]; then
+            kind="c_int"
+            base_type="integer"
+        elif [ "$type" = "char" ]; then
+            kind="c_char"
+            base_type="character(len=:)"
+        fi
+
+        if [ $d -ge 1 ]; then
+            gen_c_loc
+        fi
+
+        for io in put get; do
+            gen_put_get_var
+        done
+
+    done
+
+done

--- a/src/smiolf.F90
+++ b/src/smiolf.F90
@@ -93,6 +93,58 @@ module SMIOLf
         module procedure SMIOLf_inquire_att_text
     end interface
 
+    !
+    ! Note: The implementations of the specific SMIOLf_put_var routines
+    !       are found in the file smiolf_put_get_var.inc, which is included
+    !       in this module with a pre-processor directive
+    !
+    interface SMIOLf_put_var
+        module procedure SMIOLf_put_var_0d_char
+        module procedure SMIOLf_put_var_0d_int32
+        module procedure SMIOLf_put_var_0d_real32
+        module procedure SMIOLf_put_var_0d_real64
+        module procedure SMIOLf_put_var_1d_int32
+        module procedure SMIOLf_put_var_1d_real32
+        module procedure SMIOLf_put_var_1d_real64
+        module procedure SMIOLf_put_var_2d_int32
+        module procedure SMIOLf_put_var_2d_real32
+        module procedure SMIOLf_put_var_2d_real64
+        module procedure SMIOLf_put_var_3d_int32
+        module procedure SMIOLf_put_var_3d_real32
+        module procedure SMIOLf_put_var_3d_real64
+        module procedure SMIOLf_put_var_4d_int32
+        module procedure SMIOLf_put_var_4d_real32
+        module procedure SMIOLf_put_var_4d_real64
+        module procedure SMIOLf_put_var_5d_real32
+        module procedure SMIOLf_put_var_5d_real64
+    end interface SMIOLf_put_var
+
+    !
+    ! Note: The implementations of the specific SMIOLf_get_var routines
+    !       are found in the file smiolf_put_get_var.inc, which is included
+    !       in this module with a pre-processor directive
+    !
+    interface SMIOLf_get_var
+        module procedure SMIOLf_get_var_0d_char
+        module procedure SMIOLf_get_var_0d_int32
+        module procedure SMIOLf_get_var_0d_real32
+        module procedure SMIOLf_get_var_0d_real64
+        module procedure SMIOLf_get_var_1d_int32
+        module procedure SMIOLf_get_var_1d_real32
+        module procedure SMIOLf_get_var_1d_real64
+        module procedure SMIOLf_get_var_2d_int32
+        module procedure SMIOLf_get_var_2d_real32
+        module procedure SMIOLf_get_var_2d_real64
+        module procedure SMIOLf_get_var_3d_int32
+        module procedure SMIOLf_get_var_3d_real32
+        module procedure SMIOLf_get_var_3d_real64
+        module procedure SMIOLf_get_var_4d_int32
+        module procedure SMIOLf_get_var_4d_real32
+        module procedure SMIOLf_get_var_4d_real64
+        module procedure SMIOLf_get_var_5d_real32
+        module procedure SMIOLf_get_var_5d_real64
+    end interface SMIOLf_get_var
+
     ! C interface definitions used in multiple routines
     interface
         function SMIOL_define_att(file, varname, att_name, att_type, att) result(ierr) bind(C, name='SMIOL_define_att')
@@ -114,6 +166,24 @@ module SMIOLf
             type (c_ptr), value :: att_len
             type (c_ptr), value :: att
             integer(kind=c_int) :: ierr
+        end function
+
+        function SMIOL_put_var(file, varname, decomp, buf) result(ierr) bind(C, name='SMIOL_put_var')
+             use iso_c_binding, only : c_ptr, c_char, c_int
+             type (c_ptr), value :: file
+             character (kind=c_char), dimension(*) :: varname
+             type (c_ptr), value :: decomp
+             type (c_ptr), value :: buf
+             integer (kind=c_int) :: ierr
+        end function
+
+        function SMIOL_get_var(file, varname, decomp, buf) result(ierr) bind(C, name='SMIOL_get_var')
+             use iso_c_binding, only : c_ptr, c_char, c_int
+             type (c_ptr), value :: file
+             character (kind=c_char), dimension(*) :: varname
+             type (c_ptr), value :: decomp
+             type (c_ptr), value :: buf
+             integer (kind=c_int) :: ierr
         end function
     end interface
 
@@ -813,38 +883,7 @@ contains
     end function SMIOLf_inquire_var
 
 
-    !-----------------------------------------------------------------------
-    !  routine SMIOLf_put_var
-    !
-    !> \brief Writes a variable to a file
-    !> \details
-    !>  Detailed description of what this routine does.
-    !
-    !-----------------------------------------------------------------------
-    integer function SMIOLf_put_var() result(ierr)
-
-        implicit none
-
-        ierr = 0
-
-    end function SMIOLf_put_var
-
-
-    !-----------------------------------------------------------------------
-    !  routine SMIOLf_get_var
-    !
-    !> \brief Reads a variable from a file
-    !> \details
-    !>  Detailed description of what this routine does.
-    !
-    !-----------------------------------------------------------------------
-    integer function SMIOLf_get_var() result(ierr)
-
-        implicit none
-
-        ierr = 0
-
-    end function SMIOLf_get_var
+#include "smiolf_put_get_var.inc"
 
 
     !

--- a/src/smiolf_put_get_var.inc
+++ b/src/smiolf_put_get_var.inc
@@ -1,0 +1,3987 @@
+    !-----------------------------------------------------------------------
+    !  routine SMIOLf_put_var_d0_char
+    !
+    !> \brief Writes a 0-d char variable to a file.
+    !> \details
+    !>  Given a SMIOL file that was previously opened with write access and the name
+    !>  of a variable previously defined in the file with a call to SMIOLf_define_var,
+    !>  this routine will write the contents of buf to the variable according to
+    !>  the decomposition described by decomp.
+    !>
+    !>  If decomp is an associated pointer, the variable is assumed to be decomposed
+    !>  across MPI ranks, and all ranks with non-zero-sized partitions of the variable
+    !>  must provide a valid buffer. For decomposed variables, all MPI ranks must provide
+    !>  an associated decomp pointer, regardless of whether a rank has a non-zero-sized
+    !>  partition of the variable.
+    !>
+    !>  If the variable is not decomposed -- that is, all ranks store identical
+    !>  values for the entire variable -- all MPI ranks must provide an unassociated
+    !>  pointer for the decomp argument. As currently implemented, this routine will write
+    !>  the buffer for MPI rank 0 to the variable; however, this behavior should not
+    !>  be relied on.
+    !>
+    !>  If the variable has been successfully written to the file, SMIOL_SUCCESS will
+    !>  be returned. Otherwise, an error code indicating the nature of the failure
+    !>  will be returned.
+    !
+    !-----------------------------------------------------------------------
+    function SMIOLf_put_var_0d_char(file, varname, decomp, buf) result(ierr)
+
+        use iso_c_binding, only : c_char, c_char, c_loc, c_ptr, c_null_ptr, c_null_char
+
+        implicit none
+
+        ! Arguments
+        type(SMIOLf_file), target :: file
+        character(len=*), intent(in) :: varname
+        type(SMIOLf_decomp), pointer :: decomp
+        character(len=:), pointer :: buf
+
+        ! Return status code
+        integer :: ierr
+
+        ! Local variables
+        integer :: i
+        character(kind=c_char), dimension(:), pointer :: c_varname
+        type (c_ptr) :: c_file
+        type (c_ptr) :: c_decomp
+        type (c_ptr) :: c_buf
+        character(kind=c_char), dimension(:), allocatable, target :: char_buf
+
+        !
+        ! file is a target, so no need to check that it is associated
+        !
+        c_file = c_loc(file)
+
+        !
+        ! decomp may be an unassociated pointer if the corresponding field is
+        ! not decomposed
+        !
+        if (associated(decomp)) then
+            c_decomp = c_loc(decomp)
+        else
+            c_decomp = c_null_ptr
+        end if
+
+        !
+        ! Convert variable name string
+        !
+        allocate(c_varname(len_trim(varname) + 1))
+        do i=1,len_trim(varname)
+            c_varname(i) = varname(i:i)
+        end do
+        c_varname(i) = c_null_char
+
+        !
+        ! buf may be an unassociated pointer if the calling task does not read
+        ! or write any elements of the field
+        !
+        if (associated(buf)) then
+            allocate(char_buf(len(buf)))
+            do i=1,len(buf)
+                char_buf(i) = buf(i:i)
+            end do
+            c_buf = c_loc(char_buf)
+        else
+            c_buf = c_null_ptr
+        end if
+
+        ierr = SMIOL_put_var(c_file, c_varname, c_decomp, c_buf)
+
+        if (associated(buf)) then
+            deallocate(char_buf)
+        end if
+        deallocate(c_varname)
+
+    end function SMIOLf_put_var_0d_char
+
+
+    !-----------------------------------------------------------------------
+    !  routine SMIOLf_get_var_d0_char
+    !
+    !> \brief Reads a 0-d char variable from a file.
+    !> \details
+    !>  Given a SMIOL file and the name of a variable previously defined in the file,
+    !>  this routine will read the contents of the variable into buf according to
+    !>  the decomposition described by decomp.
+    !>
+    !>  If decomp is an associated pointer, the variable is assumed to be decomposed
+    !>  across MPI ranks, and all ranks with non-zero-sized partitions of the variable
+    !>  must provide a valid buffer. For decomposed variables, all MPI ranks must provide
+    !>  an associated decomp pointer, regardless of whether a rank has a non-zero-sized
+    !>  partition of the variable.
+    !>
+    !>  If the variable is not decomposed -- that is, all ranks load identical
+    !>  values for the entire variable -- all MPI ranks must provide an unassociated
+    !>  pointer for the decomp argument.
+    !>
+    !>  If the variable has been successfully read from the file, SMIOL_SUCCESS will
+    !>  be returned. Otherwise, an error code indicating the nature of the failure
+    !>  will be returned.
+    !
+    !-----------------------------------------------------------------------
+    function SMIOLf_get_var_0d_char(file, varname, decomp, buf) result(ierr)
+
+        use iso_c_binding, only : c_char, c_char, c_loc, c_ptr, c_null_ptr, c_null_char
+
+        implicit none
+
+        ! Arguments
+        type(SMIOLf_file), target :: file
+        character(len=*), intent(in) :: varname
+        type(SMIOLf_decomp), pointer :: decomp
+        character(len=:), pointer :: buf
+
+        ! Return status code
+        integer :: ierr
+
+        ! Local variables
+        integer :: i
+        character(kind=c_char), dimension(:), pointer :: c_varname
+        type (c_ptr) :: c_file
+        type (c_ptr) :: c_decomp
+        type (c_ptr) :: c_buf
+        character(kind=c_char), dimension(:), allocatable, target :: char_buf
+
+        !
+        ! file is a target, so no need to check that it is associated
+        !
+        c_file = c_loc(file)
+
+        !
+        ! decomp may be an unassociated pointer if the corresponding field is
+        ! not decomposed
+        !
+        if (associated(decomp)) then
+            c_decomp = c_loc(decomp)
+        else
+            c_decomp = c_null_ptr
+        end if
+
+        !
+        ! Convert variable name string
+        !
+        allocate(c_varname(len_trim(varname) + 1))
+        do i=1,len_trim(varname)
+            c_varname(i) = varname(i:i)
+        end do
+        c_varname(i) = c_null_char
+
+        !
+        ! buf may be an unassociated pointer if the calling task does not read
+        ! or write any elements of the field
+        !
+        if (associated(buf)) then
+            allocate(char_buf(len(buf)))
+            c_buf = c_loc(char_buf)
+        else
+            c_buf = c_null_ptr
+        end if
+
+        ierr = SMIOL_get_var(c_file, c_varname, c_decomp, c_buf)
+
+        if (associated(buf)) then
+            do i=1,len(buf)
+                buf(i:i) = char_buf(i)
+            end do
+
+            deallocate(char_buf)
+        end if
+        deallocate(c_varname)
+
+    end function SMIOLf_get_var_0d_char
+
+
+    !-----------------------------------------------------------------------
+    !  routine SMIOLf_put_var_d0_real32
+    !
+    !> \brief Writes a 0-d real32 variable to a file.
+    !> \details
+    !>  Given a SMIOL file that was previously opened with write access and the name
+    !>  of a variable previously defined in the file with a call to SMIOLf_define_var,
+    !>  this routine will write the contents of buf to the variable according to
+    !>  the decomposition described by decomp.
+    !>
+    !>  If decomp is an associated pointer, the variable is assumed to be decomposed
+    !>  across MPI ranks, and all ranks with non-zero-sized partitions of the variable
+    !>  must provide a valid buffer. For decomposed variables, all MPI ranks must provide
+    !>  an associated decomp pointer, regardless of whether a rank has a non-zero-sized
+    !>  partition of the variable.
+    !>
+    !>  If the variable is not decomposed -- that is, all ranks store identical
+    !>  values for the entire variable -- all MPI ranks must provide an unassociated
+    !>  pointer for the decomp argument. As currently implemented, this routine will write
+    !>  the buffer for MPI rank 0 to the variable; however, this behavior should not
+    !>  be relied on.
+    !>
+    !>  If the variable has been successfully written to the file, SMIOL_SUCCESS will
+    !>  be returned. Otherwise, an error code indicating the nature of the failure
+    !>  will be returned.
+    !
+    !-----------------------------------------------------------------------
+    function SMIOLf_put_var_0d_real32(file, varname, decomp, buf) result(ierr)
+
+        use iso_c_binding, only : c_float, c_char, c_loc, c_ptr, c_null_ptr, c_null_char
+
+        implicit none
+
+        ! Arguments
+        type(SMIOLf_file), target :: file
+        character(len=*), intent(in) :: varname
+        type(SMIOLf_decomp), pointer :: decomp
+        real(kind=c_float), pointer :: buf
+
+        ! Return status code
+        integer :: ierr
+
+        ! Local variables
+        integer :: i
+        character(kind=c_char), dimension(:), pointer :: c_varname
+        type (c_ptr) :: c_file
+        type (c_ptr) :: c_decomp
+        type (c_ptr) :: c_buf
+
+
+        !
+        ! file is a target, so no need to check that it is associated
+        !
+        c_file = c_loc(file)
+
+        !
+        ! decomp may be an unassociated pointer if the corresponding field is
+        ! not decomposed
+        !
+        if (associated(decomp)) then
+            c_decomp = c_loc(decomp)
+        else
+            c_decomp = c_null_ptr
+        end if
+
+        !
+        ! Convert variable name string
+        !
+        allocate(c_varname(len_trim(varname) + 1))
+        do i=1,len_trim(varname)
+            c_varname(i) = varname(i:i)
+        end do
+        c_varname(i) = c_null_char
+
+        !
+        ! buf may be an unassociated pointer if the calling task does not read
+        ! or write any elements of the field
+        !
+        if (associated(buf)) then
+
+            c_buf = c_loc(buf)
+        else
+            c_buf = c_null_ptr
+        end if
+
+        ierr = SMIOL_put_var(c_file, c_varname, c_decomp, c_buf)
+
+
+        deallocate(c_varname)
+
+    end function SMIOLf_put_var_0d_real32
+
+
+    !-----------------------------------------------------------------------
+    !  routine SMIOLf_get_var_d0_real32
+    !
+    !> \brief Reads a 0-d real32 variable from a file.
+    !> \details
+    !>  Given a SMIOL file and the name of a variable previously defined in the file,
+    !>  this routine will read the contents of the variable into buf according to
+    !>  the decomposition described by decomp.
+    !>
+    !>  If decomp is an associated pointer, the variable is assumed to be decomposed
+    !>  across MPI ranks, and all ranks with non-zero-sized partitions of the variable
+    !>  must provide a valid buffer. For decomposed variables, all MPI ranks must provide
+    !>  an associated decomp pointer, regardless of whether a rank has a non-zero-sized
+    !>  partition of the variable.
+    !>
+    !>  If the variable is not decomposed -- that is, all ranks load identical
+    !>  values for the entire variable -- all MPI ranks must provide an unassociated
+    !>  pointer for the decomp argument.
+    !>
+    !>  If the variable has been successfully read from the file, SMIOL_SUCCESS will
+    !>  be returned. Otherwise, an error code indicating the nature of the failure
+    !>  will be returned.
+    !
+    !-----------------------------------------------------------------------
+    function SMIOLf_get_var_0d_real32(file, varname, decomp, buf) result(ierr)
+
+        use iso_c_binding, only : c_float, c_char, c_loc, c_ptr, c_null_ptr, c_null_char
+
+        implicit none
+
+        ! Arguments
+        type(SMIOLf_file), target :: file
+        character(len=*), intent(in) :: varname
+        type(SMIOLf_decomp), pointer :: decomp
+        real(kind=c_float), pointer :: buf
+
+        ! Return status code
+        integer :: ierr
+
+        ! Local variables
+        integer :: i
+        character(kind=c_char), dimension(:), pointer :: c_varname
+        type (c_ptr) :: c_file
+        type (c_ptr) :: c_decomp
+        type (c_ptr) :: c_buf
+
+
+        !
+        ! file is a target, so no need to check that it is associated
+        !
+        c_file = c_loc(file)
+
+        !
+        ! decomp may be an unassociated pointer if the corresponding field is
+        ! not decomposed
+        !
+        if (associated(decomp)) then
+            c_decomp = c_loc(decomp)
+        else
+            c_decomp = c_null_ptr
+        end if
+
+        !
+        ! Convert variable name string
+        !
+        allocate(c_varname(len_trim(varname) + 1))
+        do i=1,len_trim(varname)
+            c_varname(i) = varname(i:i)
+        end do
+        c_varname(i) = c_null_char
+
+        !
+        ! buf may be an unassociated pointer if the calling task does not read
+        ! or write any elements of the field
+        !
+        if (associated(buf)) then
+
+            c_buf = c_loc(buf)
+        else
+            c_buf = c_null_ptr
+        end if
+
+        ierr = SMIOL_get_var(c_file, c_varname, c_decomp, c_buf)
+
+
+        deallocate(c_varname)
+
+    end function SMIOLf_get_var_0d_real32
+
+
+    !-----------------------------------------------------------------------
+    !  routine SMIOLf_put_var_d0_real64
+    !
+    !> \brief Writes a 0-d real64 variable to a file.
+    !> \details
+    !>  Given a SMIOL file that was previously opened with write access and the name
+    !>  of a variable previously defined in the file with a call to SMIOLf_define_var,
+    !>  this routine will write the contents of buf to the variable according to
+    !>  the decomposition described by decomp.
+    !>
+    !>  If decomp is an associated pointer, the variable is assumed to be decomposed
+    !>  across MPI ranks, and all ranks with non-zero-sized partitions of the variable
+    !>  must provide a valid buffer. For decomposed variables, all MPI ranks must provide
+    !>  an associated decomp pointer, regardless of whether a rank has a non-zero-sized
+    !>  partition of the variable.
+    !>
+    !>  If the variable is not decomposed -- that is, all ranks store identical
+    !>  values for the entire variable -- all MPI ranks must provide an unassociated
+    !>  pointer for the decomp argument. As currently implemented, this routine will write
+    !>  the buffer for MPI rank 0 to the variable; however, this behavior should not
+    !>  be relied on.
+    !>
+    !>  If the variable has been successfully written to the file, SMIOL_SUCCESS will
+    !>  be returned. Otherwise, an error code indicating the nature of the failure
+    !>  will be returned.
+    !
+    !-----------------------------------------------------------------------
+    function SMIOLf_put_var_0d_real64(file, varname, decomp, buf) result(ierr)
+
+        use iso_c_binding, only : c_double, c_char, c_loc, c_ptr, c_null_ptr, c_null_char
+
+        implicit none
+
+        ! Arguments
+        type(SMIOLf_file), target :: file
+        character(len=*), intent(in) :: varname
+        type(SMIOLf_decomp), pointer :: decomp
+        real(kind=c_double), pointer :: buf
+
+        ! Return status code
+        integer :: ierr
+
+        ! Local variables
+        integer :: i
+        character(kind=c_char), dimension(:), pointer :: c_varname
+        type (c_ptr) :: c_file
+        type (c_ptr) :: c_decomp
+        type (c_ptr) :: c_buf
+
+
+        !
+        ! file is a target, so no need to check that it is associated
+        !
+        c_file = c_loc(file)
+
+        !
+        ! decomp may be an unassociated pointer if the corresponding field is
+        ! not decomposed
+        !
+        if (associated(decomp)) then
+            c_decomp = c_loc(decomp)
+        else
+            c_decomp = c_null_ptr
+        end if
+
+        !
+        ! Convert variable name string
+        !
+        allocate(c_varname(len_trim(varname) + 1))
+        do i=1,len_trim(varname)
+            c_varname(i) = varname(i:i)
+        end do
+        c_varname(i) = c_null_char
+
+        !
+        ! buf may be an unassociated pointer if the calling task does not read
+        ! or write any elements of the field
+        !
+        if (associated(buf)) then
+
+            c_buf = c_loc(buf)
+        else
+            c_buf = c_null_ptr
+        end if
+
+        ierr = SMIOL_put_var(c_file, c_varname, c_decomp, c_buf)
+
+
+        deallocate(c_varname)
+
+    end function SMIOLf_put_var_0d_real64
+
+
+    !-----------------------------------------------------------------------
+    !  routine SMIOLf_get_var_d0_real64
+    !
+    !> \brief Reads a 0-d real64 variable from a file.
+    !> \details
+    !>  Given a SMIOL file and the name of a variable previously defined in the file,
+    !>  this routine will read the contents of the variable into buf according to
+    !>  the decomposition described by decomp.
+    !>
+    !>  If decomp is an associated pointer, the variable is assumed to be decomposed
+    !>  across MPI ranks, and all ranks with non-zero-sized partitions of the variable
+    !>  must provide a valid buffer. For decomposed variables, all MPI ranks must provide
+    !>  an associated decomp pointer, regardless of whether a rank has a non-zero-sized
+    !>  partition of the variable.
+    !>
+    !>  If the variable is not decomposed -- that is, all ranks load identical
+    !>  values for the entire variable -- all MPI ranks must provide an unassociated
+    !>  pointer for the decomp argument.
+    !>
+    !>  If the variable has been successfully read from the file, SMIOL_SUCCESS will
+    !>  be returned. Otherwise, an error code indicating the nature of the failure
+    !>  will be returned.
+    !
+    !-----------------------------------------------------------------------
+    function SMIOLf_get_var_0d_real64(file, varname, decomp, buf) result(ierr)
+
+        use iso_c_binding, only : c_double, c_char, c_loc, c_ptr, c_null_ptr, c_null_char
+
+        implicit none
+
+        ! Arguments
+        type(SMIOLf_file), target :: file
+        character(len=*), intent(in) :: varname
+        type(SMIOLf_decomp), pointer :: decomp
+        real(kind=c_double), pointer :: buf
+
+        ! Return status code
+        integer :: ierr
+
+        ! Local variables
+        integer :: i
+        character(kind=c_char), dimension(:), pointer :: c_varname
+        type (c_ptr) :: c_file
+        type (c_ptr) :: c_decomp
+        type (c_ptr) :: c_buf
+
+
+        !
+        ! file is a target, so no need to check that it is associated
+        !
+        c_file = c_loc(file)
+
+        !
+        ! decomp may be an unassociated pointer if the corresponding field is
+        ! not decomposed
+        !
+        if (associated(decomp)) then
+            c_decomp = c_loc(decomp)
+        else
+            c_decomp = c_null_ptr
+        end if
+
+        !
+        ! Convert variable name string
+        !
+        allocate(c_varname(len_trim(varname) + 1))
+        do i=1,len_trim(varname)
+            c_varname(i) = varname(i:i)
+        end do
+        c_varname(i) = c_null_char
+
+        !
+        ! buf may be an unassociated pointer if the calling task does not read
+        ! or write any elements of the field
+        !
+        if (associated(buf)) then
+
+            c_buf = c_loc(buf)
+        else
+            c_buf = c_null_ptr
+        end if
+
+        ierr = SMIOL_get_var(c_file, c_varname, c_decomp, c_buf)
+
+
+        deallocate(c_varname)
+
+    end function SMIOLf_get_var_0d_real64
+
+
+    !-----------------------------------------------------------------------
+    !  routine SMIOLf_put_var_d0_int32
+    !
+    !> \brief Writes a 0-d int32 variable to a file.
+    !> \details
+    !>  Given a SMIOL file that was previously opened with write access and the name
+    !>  of a variable previously defined in the file with a call to SMIOLf_define_var,
+    !>  this routine will write the contents of buf to the variable according to
+    !>  the decomposition described by decomp.
+    !>
+    !>  If decomp is an associated pointer, the variable is assumed to be decomposed
+    !>  across MPI ranks, and all ranks with non-zero-sized partitions of the variable
+    !>  must provide a valid buffer. For decomposed variables, all MPI ranks must provide
+    !>  an associated decomp pointer, regardless of whether a rank has a non-zero-sized
+    !>  partition of the variable.
+    !>
+    !>  If the variable is not decomposed -- that is, all ranks store identical
+    !>  values for the entire variable -- all MPI ranks must provide an unassociated
+    !>  pointer for the decomp argument. As currently implemented, this routine will write
+    !>  the buffer for MPI rank 0 to the variable; however, this behavior should not
+    !>  be relied on.
+    !>
+    !>  If the variable has been successfully written to the file, SMIOL_SUCCESS will
+    !>  be returned. Otherwise, an error code indicating the nature of the failure
+    !>  will be returned.
+    !
+    !-----------------------------------------------------------------------
+    function SMIOLf_put_var_0d_int32(file, varname, decomp, buf) result(ierr)
+
+        use iso_c_binding, only : c_int, c_char, c_loc, c_ptr, c_null_ptr, c_null_char
+
+        implicit none
+
+        ! Arguments
+        type(SMIOLf_file), target :: file
+        character(len=*), intent(in) :: varname
+        type(SMIOLf_decomp), pointer :: decomp
+        integer(kind=c_int), pointer :: buf
+
+        ! Return status code
+        integer :: ierr
+
+        ! Local variables
+        integer :: i
+        character(kind=c_char), dimension(:), pointer :: c_varname
+        type (c_ptr) :: c_file
+        type (c_ptr) :: c_decomp
+        type (c_ptr) :: c_buf
+
+
+        !
+        ! file is a target, so no need to check that it is associated
+        !
+        c_file = c_loc(file)
+
+        !
+        ! decomp may be an unassociated pointer if the corresponding field is
+        ! not decomposed
+        !
+        if (associated(decomp)) then
+            c_decomp = c_loc(decomp)
+        else
+            c_decomp = c_null_ptr
+        end if
+
+        !
+        ! Convert variable name string
+        !
+        allocate(c_varname(len_trim(varname) + 1))
+        do i=1,len_trim(varname)
+            c_varname(i) = varname(i:i)
+        end do
+        c_varname(i) = c_null_char
+
+        !
+        ! buf may be an unassociated pointer if the calling task does not read
+        ! or write any elements of the field
+        !
+        if (associated(buf)) then
+
+            c_buf = c_loc(buf)
+        else
+            c_buf = c_null_ptr
+        end if
+
+        ierr = SMIOL_put_var(c_file, c_varname, c_decomp, c_buf)
+
+
+        deallocate(c_varname)
+
+    end function SMIOLf_put_var_0d_int32
+
+
+    !-----------------------------------------------------------------------
+    !  routine SMIOLf_get_var_d0_int32
+    !
+    !> \brief Reads a 0-d int32 variable from a file.
+    !> \details
+    !>  Given a SMIOL file and the name of a variable previously defined in the file,
+    !>  this routine will read the contents of the variable into buf according to
+    !>  the decomposition described by decomp.
+    !>
+    !>  If decomp is an associated pointer, the variable is assumed to be decomposed
+    !>  across MPI ranks, and all ranks with non-zero-sized partitions of the variable
+    !>  must provide a valid buffer. For decomposed variables, all MPI ranks must provide
+    !>  an associated decomp pointer, regardless of whether a rank has a non-zero-sized
+    !>  partition of the variable.
+    !>
+    !>  If the variable is not decomposed -- that is, all ranks load identical
+    !>  values for the entire variable -- all MPI ranks must provide an unassociated
+    !>  pointer for the decomp argument.
+    !>
+    !>  If the variable has been successfully read from the file, SMIOL_SUCCESS will
+    !>  be returned. Otherwise, an error code indicating the nature of the failure
+    !>  will be returned.
+    !
+    !-----------------------------------------------------------------------
+    function SMIOLf_get_var_0d_int32(file, varname, decomp, buf) result(ierr)
+
+        use iso_c_binding, only : c_int, c_char, c_loc, c_ptr, c_null_ptr, c_null_char
+
+        implicit none
+
+        ! Arguments
+        type(SMIOLf_file), target :: file
+        character(len=*), intent(in) :: varname
+        type(SMIOLf_decomp), pointer :: decomp
+        integer(kind=c_int), pointer :: buf
+
+        ! Return status code
+        integer :: ierr
+
+        ! Local variables
+        integer :: i
+        character(kind=c_char), dimension(:), pointer :: c_varname
+        type (c_ptr) :: c_file
+        type (c_ptr) :: c_decomp
+        type (c_ptr) :: c_buf
+
+
+        !
+        ! file is a target, so no need to check that it is associated
+        !
+        c_file = c_loc(file)
+
+        !
+        ! decomp may be an unassociated pointer if the corresponding field is
+        ! not decomposed
+        !
+        if (associated(decomp)) then
+            c_decomp = c_loc(decomp)
+        else
+            c_decomp = c_null_ptr
+        end if
+
+        !
+        ! Convert variable name string
+        !
+        allocate(c_varname(len_trim(varname) + 1))
+        do i=1,len_trim(varname)
+            c_varname(i) = varname(i:i)
+        end do
+        c_varname(i) = c_null_char
+
+        !
+        ! buf may be an unassociated pointer if the calling task does not read
+        ! or write any elements of the field
+        !
+        if (associated(buf)) then
+
+            c_buf = c_loc(buf)
+        else
+            c_buf = c_null_ptr
+        end if
+
+        ierr = SMIOL_get_var(c_file, c_varname, c_decomp, c_buf)
+
+
+        deallocate(c_varname)
+
+    end function SMIOLf_get_var_0d_int32
+
+
+    !-----------------------------------------------------------------------
+    !  routine c_loc_assumed_shape_1d_real32
+    !
+    !> \brief Returns a C_PTR for an array with given dimensions
+    !> \details
+    !>  The Fortran 2003 standard does not permit the use of C_LOC with
+    !>  assumed shape arrays. This routine may be used to obtain a C_PTR for
+    !>  an assumed shape array by invoking the routine with the first actual
+    !>  argument as the assumed-shape array, and subsequent actual arguments
+    !>  as, e.g., SIZE(a,DIM=1).
+    !>
+    !>  Internally, the first dummy argument of this routine can be declared
+    !>  as an explicit shape array, which can then be used as an argument to
+    !>  C_LOC.
+    !>
+    !>  Upon success, a C_PTR for the array argument is returned.
+    !>
+    !>  Note: The actual array argument must not be a zero-sized array.
+    !>        Section 15.1.2.5 of the Fortran 2003 standard specifies that
+    !>        the argument to C_LOC '...is not an array of zero size...'.
+    !
+    !-----------------------------------------------------------------------
+    function c_loc_assumed_shape_1d_real32(a, d1) result(a_ptr)
+
+        use iso_c_binding, only : c_ptr, c_loc, c_float
+
+        implicit none
+
+        ! Arguments
+        integer, intent(in) :: d1
+        real(kind=c_float), dimension(d1), target, intent(in) :: a
+
+        ! Return value
+        type (c_ptr) :: a_ptr
+
+        a_ptr = c_loc(a)
+
+    end function c_loc_assumed_shape_1d_real32
+
+
+    !-----------------------------------------------------------------------
+    !  routine SMIOLf_put_var_d1_real32
+    !
+    !> \brief Writes a 1-d real32 variable to a file.
+    !> \details
+    !>  Given a SMIOL file that was previously opened with write access and the name
+    !>  of a variable previously defined in the file with a call to SMIOLf_define_var,
+    !>  this routine will write the contents of buf to the variable according to
+    !>  the decomposition described by decomp.
+    !>
+    !>  If decomp is an associated pointer, the variable is assumed to be decomposed
+    !>  across MPI ranks, and all ranks with non-zero-sized partitions of the variable
+    !>  must provide a valid buffer. For decomposed variables, all MPI ranks must provide
+    !>  an associated decomp pointer, regardless of whether a rank has a non-zero-sized
+    !>  partition of the variable.
+    !>
+    !>  If the variable is not decomposed -- that is, all ranks store identical
+    !>  values for the entire variable -- all MPI ranks must provide an unassociated
+    !>  pointer for the decomp argument. As currently implemented, this routine will write
+    !>  the buffer for MPI rank 0 to the variable; however, this behavior should not
+    !>  be relied on.
+    !>
+    !>  If the variable has been successfully written to the file, SMIOL_SUCCESS will
+    !>  be returned. Otherwise, an error code indicating the nature of the failure
+    !>  will be returned.
+    !
+    !-----------------------------------------------------------------------
+    function SMIOLf_put_var_1d_real32(file, varname, decomp, buf) result(ierr)
+
+        use iso_c_binding, only : c_float, c_char, c_loc, c_ptr, c_null_ptr, c_null_char
+
+        implicit none
+
+        ! Arguments
+        type(SMIOLf_file), target :: file
+        character(len=*), intent(in) :: varname
+        type(SMIOLf_decomp), pointer :: decomp
+        real(kind=c_float), dimension(:), pointer :: buf
+
+        ! Return status code
+        integer :: ierr
+
+        ! Local variables
+        integer :: i
+        character(kind=c_char), dimension(:), pointer :: c_varname
+        type (c_ptr) :: c_file
+        type (c_ptr) :: c_decomp
+        type (c_ptr) :: c_buf
+
+
+        !
+        ! file is a target, so no need to check that it is associated
+        !
+        c_file = c_loc(file)
+
+        !
+        ! decomp may be an unassociated pointer if the corresponding field is
+        ! not decomposed
+        !
+        if (associated(decomp)) then
+            c_decomp = c_loc(decomp)
+        else
+            c_decomp = c_null_ptr
+        end if
+
+        !
+        ! Convert variable name string
+        !
+        allocate(c_varname(len_trim(varname) + 1))
+        do i=1,len_trim(varname)
+            c_varname(i) = varname(i:i)
+        end do
+        c_varname(i) = c_null_char
+
+        !
+        ! buf may be an unassociated pointer if the calling task does not read
+        ! or write any elements of the field
+        !
+        if (associated(buf)) then
+
+            !
+            ! Invoke a Fortran 2003-compliant function to get the c_ptr
+            ! of the assumed shape array buf
+            !
+            c_buf = c_loc_assumed_shape_1d_real32(buf, size(buf,dim=1))
+        else
+            c_buf = c_null_ptr
+        end if
+
+        ierr = SMIOL_put_var(c_file, c_varname, c_decomp, c_buf)
+
+
+        deallocate(c_varname)
+
+    end function SMIOLf_put_var_1d_real32
+
+
+    !-----------------------------------------------------------------------
+    !  routine SMIOLf_get_var_d1_real32
+    !
+    !> \brief Reads a 1-d real32 variable from a file.
+    !> \details
+    !>  Given a SMIOL file and the name of a variable previously defined in the file,
+    !>  this routine will read the contents of the variable into buf according to
+    !>  the decomposition described by decomp.
+    !>
+    !>  If decomp is an associated pointer, the variable is assumed to be decomposed
+    !>  across MPI ranks, and all ranks with non-zero-sized partitions of the variable
+    !>  must provide a valid buffer. For decomposed variables, all MPI ranks must provide
+    !>  an associated decomp pointer, regardless of whether a rank has a non-zero-sized
+    !>  partition of the variable.
+    !>
+    !>  If the variable is not decomposed -- that is, all ranks load identical
+    !>  values for the entire variable -- all MPI ranks must provide an unassociated
+    !>  pointer for the decomp argument.
+    !>
+    !>  If the variable has been successfully read from the file, SMIOL_SUCCESS will
+    !>  be returned. Otherwise, an error code indicating the nature of the failure
+    !>  will be returned.
+    !
+    !-----------------------------------------------------------------------
+    function SMIOLf_get_var_1d_real32(file, varname, decomp, buf) result(ierr)
+
+        use iso_c_binding, only : c_float, c_char, c_loc, c_ptr, c_null_ptr, c_null_char
+
+        implicit none
+
+        ! Arguments
+        type(SMIOLf_file), target :: file
+        character(len=*), intent(in) :: varname
+        type(SMIOLf_decomp), pointer :: decomp
+        real(kind=c_float), dimension(:), pointer :: buf
+
+        ! Return status code
+        integer :: ierr
+
+        ! Local variables
+        integer :: i
+        character(kind=c_char), dimension(:), pointer :: c_varname
+        type (c_ptr) :: c_file
+        type (c_ptr) :: c_decomp
+        type (c_ptr) :: c_buf
+
+
+        !
+        ! file is a target, so no need to check that it is associated
+        !
+        c_file = c_loc(file)
+
+        !
+        ! decomp may be an unassociated pointer if the corresponding field is
+        ! not decomposed
+        !
+        if (associated(decomp)) then
+            c_decomp = c_loc(decomp)
+        else
+            c_decomp = c_null_ptr
+        end if
+
+        !
+        ! Convert variable name string
+        !
+        allocate(c_varname(len_trim(varname) + 1))
+        do i=1,len_trim(varname)
+            c_varname(i) = varname(i:i)
+        end do
+        c_varname(i) = c_null_char
+
+        !
+        ! buf may be an unassociated pointer if the calling task does not read
+        ! or write any elements of the field
+        !
+        if (associated(buf)) then
+
+            !
+            ! Invoke a Fortran 2003-compliant function to get the c_ptr
+            ! of the assumed shape array buf
+            !
+            c_buf = c_loc_assumed_shape_1d_real32(buf, size(buf,dim=1))
+        else
+            c_buf = c_null_ptr
+        end if
+
+        ierr = SMIOL_get_var(c_file, c_varname, c_decomp, c_buf)
+
+
+        deallocate(c_varname)
+
+    end function SMIOLf_get_var_1d_real32
+
+
+    !-----------------------------------------------------------------------
+    !  routine c_loc_assumed_shape_1d_real64
+    !
+    !> \brief Returns a C_PTR for an array with given dimensions
+    !> \details
+    !>  The Fortran 2003 standard does not permit the use of C_LOC with
+    !>  assumed shape arrays. This routine may be used to obtain a C_PTR for
+    !>  an assumed shape array by invoking the routine with the first actual
+    !>  argument as the assumed-shape array, and subsequent actual arguments
+    !>  as, e.g., SIZE(a,DIM=1).
+    !>
+    !>  Internally, the first dummy argument of this routine can be declared
+    !>  as an explicit shape array, which can then be used as an argument to
+    !>  C_LOC.
+    !>
+    !>  Upon success, a C_PTR for the array argument is returned.
+    !>
+    !>  Note: The actual array argument must not be a zero-sized array.
+    !>        Section 15.1.2.5 of the Fortran 2003 standard specifies that
+    !>        the argument to C_LOC '...is not an array of zero size...'.
+    !
+    !-----------------------------------------------------------------------
+    function c_loc_assumed_shape_1d_real64(a, d1) result(a_ptr)
+
+        use iso_c_binding, only : c_ptr, c_loc, c_double
+
+        implicit none
+
+        ! Arguments
+        integer, intent(in) :: d1
+        real(kind=c_double), dimension(d1), target, intent(in) :: a
+
+        ! Return value
+        type (c_ptr) :: a_ptr
+
+        a_ptr = c_loc(a)
+
+    end function c_loc_assumed_shape_1d_real64
+
+
+    !-----------------------------------------------------------------------
+    !  routine SMIOLf_put_var_d1_real64
+    !
+    !> \brief Writes a 1-d real64 variable to a file.
+    !> \details
+    !>  Given a SMIOL file that was previously opened with write access and the name
+    !>  of a variable previously defined in the file with a call to SMIOLf_define_var,
+    !>  this routine will write the contents of buf to the variable according to
+    !>  the decomposition described by decomp.
+    !>
+    !>  If decomp is an associated pointer, the variable is assumed to be decomposed
+    !>  across MPI ranks, and all ranks with non-zero-sized partitions of the variable
+    !>  must provide a valid buffer. For decomposed variables, all MPI ranks must provide
+    !>  an associated decomp pointer, regardless of whether a rank has a non-zero-sized
+    !>  partition of the variable.
+    !>
+    !>  If the variable is not decomposed -- that is, all ranks store identical
+    !>  values for the entire variable -- all MPI ranks must provide an unassociated
+    !>  pointer for the decomp argument. As currently implemented, this routine will write
+    !>  the buffer for MPI rank 0 to the variable; however, this behavior should not
+    !>  be relied on.
+    !>
+    !>  If the variable has been successfully written to the file, SMIOL_SUCCESS will
+    !>  be returned. Otherwise, an error code indicating the nature of the failure
+    !>  will be returned.
+    !
+    !-----------------------------------------------------------------------
+    function SMIOLf_put_var_1d_real64(file, varname, decomp, buf) result(ierr)
+
+        use iso_c_binding, only : c_double, c_char, c_loc, c_ptr, c_null_ptr, c_null_char
+
+        implicit none
+
+        ! Arguments
+        type(SMIOLf_file), target :: file
+        character(len=*), intent(in) :: varname
+        type(SMIOLf_decomp), pointer :: decomp
+        real(kind=c_double), dimension(:), pointer :: buf
+
+        ! Return status code
+        integer :: ierr
+
+        ! Local variables
+        integer :: i
+        character(kind=c_char), dimension(:), pointer :: c_varname
+        type (c_ptr) :: c_file
+        type (c_ptr) :: c_decomp
+        type (c_ptr) :: c_buf
+
+
+        !
+        ! file is a target, so no need to check that it is associated
+        !
+        c_file = c_loc(file)
+
+        !
+        ! decomp may be an unassociated pointer if the corresponding field is
+        ! not decomposed
+        !
+        if (associated(decomp)) then
+            c_decomp = c_loc(decomp)
+        else
+            c_decomp = c_null_ptr
+        end if
+
+        !
+        ! Convert variable name string
+        !
+        allocate(c_varname(len_trim(varname) + 1))
+        do i=1,len_trim(varname)
+            c_varname(i) = varname(i:i)
+        end do
+        c_varname(i) = c_null_char
+
+        !
+        ! buf may be an unassociated pointer if the calling task does not read
+        ! or write any elements of the field
+        !
+        if (associated(buf)) then
+
+            !
+            ! Invoke a Fortran 2003-compliant function to get the c_ptr
+            ! of the assumed shape array buf
+            !
+            c_buf = c_loc_assumed_shape_1d_real64(buf, size(buf,dim=1))
+        else
+            c_buf = c_null_ptr
+        end if
+
+        ierr = SMIOL_put_var(c_file, c_varname, c_decomp, c_buf)
+
+
+        deallocate(c_varname)
+
+    end function SMIOLf_put_var_1d_real64
+
+
+    !-----------------------------------------------------------------------
+    !  routine SMIOLf_get_var_d1_real64
+    !
+    !> \brief Reads a 1-d real64 variable from a file.
+    !> \details
+    !>  Given a SMIOL file and the name of a variable previously defined in the file,
+    !>  this routine will read the contents of the variable into buf according to
+    !>  the decomposition described by decomp.
+    !>
+    !>  If decomp is an associated pointer, the variable is assumed to be decomposed
+    !>  across MPI ranks, and all ranks with non-zero-sized partitions of the variable
+    !>  must provide a valid buffer. For decomposed variables, all MPI ranks must provide
+    !>  an associated decomp pointer, regardless of whether a rank has a non-zero-sized
+    !>  partition of the variable.
+    !>
+    !>  If the variable is not decomposed -- that is, all ranks load identical
+    !>  values for the entire variable -- all MPI ranks must provide an unassociated
+    !>  pointer for the decomp argument.
+    !>
+    !>  If the variable has been successfully read from the file, SMIOL_SUCCESS will
+    !>  be returned. Otherwise, an error code indicating the nature of the failure
+    !>  will be returned.
+    !
+    !-----------------------------------------------------------------------
+    function SMIOLf_get_var_1d_real64(file, varname, decomp, buf) result(ierr)
+
+        use iso_c_binding, only : c_double, c_char, c_loc, c_ptr, c_null_ptr, c_null_char
+
+        implicit none
+
+        ! Arguments
+        type(SMIOLf_file), target :: file
+        character(len=*), intent(in) :: varname
+        type(SMIOLf_decomp), pointer :: decomp
+        real(kind=c_double), dimension(:), pointer :: buf
+
+        ! Return status code
+        integer :: ierr
+
+        ! Local variables
+        integer :: i
+        character(kind=c_char), dimension(:), pointer :: c_varname
+        type (c_ptr) :: c_file
+        type (c_ptr) :: c_decomp
+        type (c_ptr) :: c_buf
+
+
+        !
+        ! file is a target, so no need to check that it is associated
+        !
+        c_file = c_loc(file)
+
+        !
+        ! decomp may be an unassociated pointer if the corresponding field is
+        ! not decomposed
+        !
+        if (associated(decomp)) then
+            c_decomp = c_loc(decomp)
+        else
+            c_decomp = c_null_ptr
+        end if
+
+        !
+        ! Convert variable name string
+        !
+        allocate(c_varname(len_trim(varname) + 1))
+        do i=1,len_trim(varname)
+            c_varname(i) = varname(i:i)
+        end do
+        c_varname(i) = c_null_char
+
+        !
+        ! buf may be an unassociated pointer if the calling task does not read
+        ! or write any elements of the field
+        !
+        if (associated(buf)) then
+
+            !
+            ! Invoke a Fortran 2003-compliant function to get the c_ptr
+            ! of the assumed shape array buf
+            !
+            c_buf = c_loc_assumed_shape_1d_real64(buf, size(buf,dim=1))
+        else
+            c_buf = c_null_ptr
+        end if
+
+        ierr = SMIOL_get_var(c_file, c_varname, c_decomp, c_buf)
+
+
+        deallocate(c_varname)
+
+    end function SMIOLf_get_var_1d_real64
+
+
+    !-----------------------------------------------------------------------
+    !  routine c_loc_assumed_shape_1d_int32
+    !
+    !> \brief Returns a C_PTR for an array with given dimensions
+    !> \details
+    !>  The Fortran 2003 standard does not permit the use of C_LOC with
+    !>  assumed shape arrays. This routine may be used to obtain a C_PTR for
+    !>  an assumed shape array by invoking the routine with the first actual
+    !>  argument as the assumed-shape array, and subsequent actual arguments
+    !>  as, e.g., SIZE(a,DIM=1).
+    !>
+    !>  Internally, the first dummy argument of this routine can be declared
+    !>  as an explicit shape array, which can then be used as an argument to
+    !>  C_LOC.
+    !>
+    !>  Upon success, a C_PTR for the array argument is returned.
+    !>
+    !>  Note: The actual array argument must not be a zero-sized array.
+    !>        Section 15.1.2.5 of the Fortran 2003 standard specifies that
+    !>        the argument to C_LOC '...is not an array of zero size...'.
+    !
+    !-----------------------------------------------------------------------
+    function c_loc_assumed_shape_1d_int32(a, d1) result(a_ptr)
+
+        use iso_c_binding, only : c_ptr, c_loc, c_int
+
+        implicit none
+
+        ! Arguments
+        integer, intent(in) :: d1
+        integer(kind=c_int), dimension(d1), target, intent(in) :: a
+
+        ! Return value
+        type (c_ptr) :: a_ptr
+
+        a_ptr = c_loc(a)
+
+    end function c_loc_assumed_shape_1d_int32
+
+
+    !-----------------------------------------------------------------------
+    !  routine SMIOLf_put_var_d1_int32
+    !
+    !> \brief Writes a 1-d int32 variable to a file.
+    !> \details
+    !>  Given a SMIOL file that was previously opened with write access and the name
+    !>  of a variable previously defined in the file with a call to SMIOLf_define_var,
+    !>  this routine will write the contents of buf to the variable according to
+    !>  the decomposition described by decomp.
+    !>
+    !>  If decomp is an associated pointer, the variable is assumed to be decomposed
+    !>  across MPI ranks, and all ranks with non-zero-sized partitions of the variable
+    !>  must provide a valid buffer. For decomposed variables, all MPI ranks must provide
+    !>  an associated decomp pointer, regardless of whether a rank has a non-zero-sized
+    !>  partition of the variable.
+    !>
+    !>  If the variable is not decomposed -- that is, all ranks store identical
+    !>  values for the entire variable -- all MPI ranks must provide an unassociated
+    !>  pointer for the decomp argument. As currently implemented, this routine will write
+    !>  the buffer for MPI rank 0 to the variable; however, this behavior should not
+    !>  be relied on.
+    !>
+    !>  If the variable has been successfully written to the file, SMIOL_SUCCESS will
+    !>  be returned. Otherwise, an error code indicating the nature of the failure
+    !>  will be returned.
+    !
+    !-----------------------------------------------------------------------
+    function SMIOLf_put_var_1d_int32(file, varname, decomp, buf) result(ierr)
+
+        use iso_c_binding, only : c_int, c_char, c_loc, c_ptr, c_null_ptr, c_null_char
+
+        implicit none
+
+        ! Arguments
+        type(SMIOLf_file), target :: file
+        character(len=*), intent(in) :: varname
+        type(SMIOLf_decomp), pointer :: decomp
+        integer(kind=c_int), dimension(:), pointer :: buf
+
+        ! Return status code
+        integer :: ierr
+
+        ! Local variables
+        integer :: i
+        character(kind=c_char), dimension(:), pointer :: c_varname
+        type (c_ptr) :: c_file
+        type (c_ptr) :: c_decomp
+        type (c_ptr) :: c_buf
+
+
+        !
+        ! file is a target, so no need to check that it is associated
+        !
+        c_file = c_loc(file)
+
+        !
+        ! decomp may be an unassociated pointer if the corresponding field is
+        ! not decomposed
+        !
+        if (associated(decomp)) then
+            c_decomp = c_loc(decomp)
+        else
+            c_decomp = c_null_ptr
+        end if
+
+        !
+        ! Convert variable name string
+        !
+        allocate(c_varname(len_trim(varname) + 1))
+        do i=1,len_trim(varname)
+            c_varname(i) = varname(i:i)
+        end do
+        c_varname(i) = c_null_char
+
+        !
+        ! buf may be an unassociated pointer if the calling task does not read
+        ! or write any elements of the field
+        !
+        if (associated(buf)) then
+
+            !
+            ! Invoke a Fortran 2003-compliant function to get the c_ptr
+            ! of the assumed shape array buf
+            !
+            c_buf = c_loc_assumed_shape_1d_int32(buf, size(buf,dim=1))
+        else
+            c_buf = c_null_ptr
+        end if
+
+        ierr = SMIOL_put_var(c_file, c_varname, c_decomp, c_buf)
+
+
+        deallocate(c_varname)
+
+    end function SMIOLf_put_var_1d_int32
+
+
+    !-----------------------------------------------------------------------
+    !  routine SMIOLf_get_var_d1_int32
+    !
+    !> \brief Reads a 1-d int32 variable from a file.
+    !> \details
+    !>  Given a SMIOL file and the name of a variable previously defined in the file,
+    !>  this routine will read the contents of the variable into buf according to
+    !>  the decomposition described by decomp.
+    !>
+    !>  If decomp is an associated pointer, the variable is assumed to be decomposed
+    !>  across MPI ranks, and all ranks with non-zero-sized partitions of the variable
+    !>  must provide a valid buffer. For decomposed variables, all MPI ranks must provide
+    !>  an associated decomp pointer, regardless of whether a rank has a non-zero-sized
+    !>  partition of the variable.
+    !>
+    !>  If the variable is not decomposed -- that is, all ranks load identical
+    !>  values for the entire variable -- all MPI ranks must provide an unassociated
+    !>  pointer for the decomp argument.
+    !>
+    !>  If the variable has been successfully read from the file, SMIOL_SUCCESS will
+    !>  be returned. Otherwise, an error code indicating the nature of the failure
+    !>  will be returned.
+    !
+    !-----------------------------------------------------------------------
+    function SMIOLf_get_var_1d_int32(file, varname, decomp, buf) result(ierr)
+
+        use iso_c_binding, only : c_int, c_char, c_loc, c_ptr, c_null_ptr, c_null_char
+
+        implicit none
+
+        ! Arguments
+        type(SMIOLf_file), target :: file
+        character(len=*), intent(in) :: varname
+        type(SMIOLf_decomp), pointer :: decomp
+        integer(kind=c_int), dimension(:), pointer :: buf
+
+        ! Return status code
+        integer :: ierr
+
+        ! Local variables
+        integer :: i
+        character(kind=c_char), dimension(:), pointer :: c_varname
+        type (c_ptr) :: c_file
+        type (c_ptr) :: c_decomp
+        type (c_ptr) :: c_buf
+
+
+        !
+        ! file is a target, so no need to check that it is associated
+        !
+        c_file = c_loc(file)
+
+        !
+        ! decomp may be an unassociated pointer if the corresponding field is
+        ! not decomposed
+        !
+        if (associated(decomp)) then
+            c_decomp = c_loc(decomp)
+        else
+            c_decomp = c_null_ptr
+        end if
+
+        !
+        ! Convert variable name string
+        !
+        allocate(c_varname(len_trim(varname) + 1))
+        do i=1,len_trim(varname)
+            c_varname(i) = varname(i:i)
+        end do
+        c_varname(i) = c_null_char
+
+        !
+        ! buf may be an unassociated pointer if the calling task does not read
+        ! or write any elements of the field
+        !
+        if (associated(buf)) then
+
+            !
+            ! Invoke a Fortran 2003-compliant function to get the c_ptr
+            ! of the assumed shape array buf
+            !
+            c_buf = c_loc_assumed_shape_1d_int32(buf, size(buf,dim=1))
+        else
+            c_buf = c_null_ptr
+        end if
+
+        ierr = SMIOL_get_var(c_file, c_varname, c_decomp, c_buf)
+
+
+        deallocate(c_varname)
+
+    end function SMIOLf_get_var_1d_int32
+
+
+    !-----------------------------------------------------------------------
+    !  routine c_loc_assumed_shape_2d_real32
+    !
+    !> \brief Returns a C_PTR for an array with given dimensions
+    !> \details
+    !>  The Fortran 2003 standard does not permit the use of C_LOC with
+    !>  assumed shape arrays. This routine may be used to obtain a C_PTR for
+    !>  an assumed shape array by invoking the routine with the first actual
+    !>  argument as the assumed-shape array, and subsequent actual arguments
+    !>  as, e.g., SIZE(a,DIM=1).
+    !>
+    !>  Internally, the first dummy argument of this routine can be declared
+    !>  as an explicit shape array, which can then be used as an argument to
+    !>  C_LOC.
+    !>
+    !>  Upon success, a C_PTR for the array argument is returned.
+    !>
+    !>  Note: The actual array argument must not be a zero-sized array.
+    !>        Section 15.1.2.5 of the Fortran 2003 standard specifies that
+    !>        the argument to C_LOC '...is not an array of zero size...'.
+    !
+    !-----------------------------------------------------------------------
+    function c_loc_assumed_shape_2d_real32(a, d1, d2) result(a_ptr)
+
+        use iso_c_binding, only : c_ptr, c_loc, c_float
+
+        implicit none
+
+        ! Arguments
+        integer, intent(in) :: d1, d2
+        real(kind=c_float), dimension(d1,d2), target, intent(in) :: a
+
+        ! Return value
+        type (c_ptr) :: a_ptr
+
+        a_ptr = c_loc(a)
+
+    end function c_loc_assumed_shape_2d_real32
+
+
+    !-----------------------------------------------------------------------
+    !  routine SMIOLf_put_var_d2_real32
+    !
+    !> \brief Writes a 2-d real32 variable to a file.
+    !> \details
+    !>  Given a SMIOL file that was previously opened with write access and the name
+    !>  of a variable previously defined in the file with a call to SMIOLf_define_var,
+    !>  this routine will write the contents of buf to the variable according to
+    !>  the decomposition described by decomp.
+    !>
+    !>  If decomp is an associated pointer, the variable is assumed to be decomposed
+    !>  across MPI ranks, and all ranks with non-zero-sized partitions of the variable
+    !>  must provide a valid buffer. For decomposed variables, all MPI ranks must provide
+    !>  an associated decomp pointer, regardless of whether a rank has a non-zero-sized
+    !>  partition of the variable.
+    !>
+    !>  If the variable is not decomposed -- that is, all ranks store identical
+    !>  values for the entire variable -- all MPI ranks must provide an unassociated
+    !>  pointer for the decomp argument. As currently implemented, this routine will write
+    !>  the buffer for MPI rank 0 to the variable; however, this behavior should not
+    !>  be relied on.
+    !>
+    !>  If the variable has been successfully written to the file, SMIOL_SUCCESS will
+    !>  be returned. Otherwise, an error code indicating the nature of the failure
+    !>  will be returned.
+    !
+    !-----------------------------------------------------------------------
+    function SMIOLf_put_var_2d_real32(file, varname, decomp, buf) result(ierr)
+
+        use iso_c_binding, only : c_float, c_char, c_loc, c_ptr, c_null_ptr, c_null_char
+
+        implicit none
+
+        ! Arguments
+        type(SMIOLf_file), target :: file
+        character(len=*), intent(in) :: varname
+        type(SMIOLf_decomp), pointer :: decomp
+        real(kind=c_float), dimension(:,:), pointer :: buf
+
+        ! Return status code
+        integer :: ierr
+
+        ! Local variables
+        integer :: i
+        character(kind=c_char), dimension(:), pointer :: c_varname
+        type (c_ptr) :: c_file
+        type (c_ptr) :: c_decomp
+        type (c_ptr) :: c_buf
+
+
+        !
+        ! file is a target, so no need to check that it is associated
+        !
+        c_file = c_loc(file)
+
+        !
+        ! decomp may be an unassociated pointer if the corresponding field is
+        ! not decomposed
+        !
+        if (associated(decomp)) then
+            c_decomp = c_loc(decomp)
+        else
+            c_decomp = c_null_ptr
+        end if
+
+        !
+        ! Convert variable name string
+        !
+        allocate(c_varname(len_trim(varname) + 1))
+        do i=1,len_trim(varname)
+            c_varname(i) = varname(i:i)
+        end do
+        c_varname(i) = c_null_char
+
+        !
+        ! buf may be an unassociated pointer if the calling task does not read
+        ! or write any elements of the field
+        !
+        if (associated(buf)) then
+
+            !
+            ! Invoke a Fortran 2003-compliant function to get the c_ptr
+            ! of the assumed shape array buf
+            !
+            c_buf = c_loc_assumed_shape_2d_real32(buf, size(buf,dim=1), size(buf,dim=2))
+        else
+            c_buf = c_null_ptr
+        end if
+
+        ierr = SMIOL_put_var(c_file, c_varname, c_decomp, c_buf)
+
+
+        deallocate(c_varname)
+
+    end function SMIOLf_put_var_2d_real32
+
+
+    !-----------------------------------------------------------------------
+    !  routine SMIOLf_get_var_d2_real32
+    !
+    !> \brief Reads a 2-d real32 variable from a file.
+    !> \details
+    !>  Given a SMIOL file and the name of a variable previously defined in the file,
+    !>  this routine will read the contents of the variable into buf according to
+    !>  the decomposition described by decomp.
+    !>
+    !>  If decomp is an associated pointer, the variable is assumed to be decomposed
+    !>  across MPI ranks, and all ranks with non-zero-sized partitions of the variable
+    !>  must provide a valid buffer. For decomposed variables, all MPI ranks must provide
+    !>  an associated decomp pointer, regardless of whether a rank has a non-zero-sized
+    !>  partition of the variable.
+    !>
+    !>  If the variable is not decomposed -- that is, all ranks load identical
+    !>  values for the entire variable -- all MPI ranks must provide an unassociated
+    !>  pointer for the decomp argument.
+    !>
+    !>  If the variable has been successfully read from the file, SMIOL_SUCCESS will
+    !>  be returned. Otherwise, an error code indicating the nature of the failure
+    !>  will be returned.
+    !
+    !-----------------------------------------------------------------------
+    function SMIOLf_get_var_2d_real32(file, varname, decomp, buf) result(ierr)
+
+        use iso_c_binding, only : c_float, c_char, c_loc, c_ptr, c_null_ptr, c_null_char
+
+        implicit none
+
+        ! Arguments
+        type(SMIOLf_file), target :: file
+        character(len=*), intent(in) :: varname
+        type(SMIOLf_decomp), pointer :: decomp
+        real(kind=c_float), dimension(:,:), pointer :: buf
+
+        ! Return status code
+        integer :: ierr
+
+        ! Local variables
+        integer :: i
+        character(kind=c_char), dimension(:), pointer :: c_varname
+        type (c_ptr) :: c_file
+        type (c_ptr) :: c_decomp
+        type (c_ptr) :: c_buf
+
+
+        !
+        ! file is a target, so no need to check that it is associated
+        !
+        c_file = c_loc(file)
+
+        !
+        ! decomp may be an unassociated pointer if the corresponding field is
+        ! not decomposed
+        !
+        if (associated(decomp)) then
+            c_decomp = c_loc(decomp)
+        else
+            c_decomp = c_null_ptr
+        end if
+
+        !
+        ! Convert variable name string
+        !
+        allocate(c_varname(len_trim(varname) + 1))
+        do i=1,len_trim(varname)
+            c_varname(i) = varname(i:i)
+        end do
+        c_varname(i) = c_null_char
+
+        !
+        ! buf may be an unassociated pointer if the calling task does not read
+        ! or write any elements of the field
+        !
+        if (associated(buf)) then
+
+            !
+            ! Invoke a Fortran 2003-compliant function to get the c_ptr
+            ! of the assumed shape array buf
+            !
+            c_buf = c_loc_assumed_shape_2d_real32(buf, size(buf,dim=1), size(buf,dim=2))
+        else
+            c_buf = c_null_ptr
+        end if
+
+        ierr = SMIOL_get_var(c_file, c_varname, c_decomp, c_buf)
+
+
+        deallocate(c_varname)
+
+    end function SMIOLf_get_var_2d_real32
+
+
+    !-----------------------------------------------------------------------
+    !  routine c_loc_assumed_shape_2d_real64
+    !
+    !> \brief Returns a C_PTR for an array with given dimensions
+    !> \details
+    !>  The Fortran 2003 standard does not permit the use of C_LOC with
+    !>  assumed shape arrays. This routine may be used to obtain a C_PTR for
+    !>  an assumed shape array by invoking the routine with the first actual
+    !>  argument as the assumed-shape array, and subsequent actual arguments
+    !>  as, e.g., SIZE(a,DIM=1).
+    !>
+    !>  Internally, the first dummy argument of this routine can be declared
+    !>  as an explicit shape array, which can then be used as an argument to
+    !>  C_LOC.
+    !>
+    !>  Upon success, a C_PTR for the array argument is returned.
+    !>
+    !>  Note: The actual array argument must not be a zero-sized array.
+    !>        Section 15.1.2.5 of the Fortran 2003 standard specifies that
+    !>        the argument to C_LOC '...is not an array of zero size...'.
+    !
+    !-----------------------------------------------------------------------
+    function c_loc_assumed_shape_2d_real64(a, d1, d2) result(a_ptr)
+
+        use iso_c_binding, only : c_ptr, c_loc, c_double
+
+        implicit none
+
+        ! Arguments
+        integer, intent(in) :: d1, d2
+        real(kind=c_double), dimension(d1,d2), target, intent(in) :: a
+
+        ! Return value
+        type (c_ptr) :: a_ptr
+
+        a_ptr = c_loc(a)
+
+    end function c_loc_assumed_shape_2d_real64
+
+
+    !-----------------------------------------------------------------------
+    !  routine SMIOLf_put_var_d2_real64
+    !
+    !> \brief Writes a 2-d real64 variable to a file.
+    !> \details
+    !>  Given a SMIOL file that was previously opened with write access and the name
+    !>  of a variable previously defined in the file with a call to SMIOLf_define_var,
+    !>  this routine will write the contents of buf to the variable according to
+    !>  the decomposition described by decomp.
+    !>
+    !>  If decomp is an associated pointer, the variable is assumed to be decomposed
+    !>  across MPI ranks, and all ranks with non-zero-sized partitions of the variable
+    !>  must provide a valid buffer. For decomposed variables, all MPI ranks must provide
+    !>  an associated decomp pointer, regardless of whether a rank has a non-zero-sized
+    !>  partition of the variable.
+    !>
+    !>  If the variable is not decomposed -- that is, all ranks store identical
+    !>  values for the entire variable -- all MPI ranks must provide an unassociated
+    !>  pointer for the decomp argument. As currently implemented, this routine will write
+    !>  the buffer for MPI rank 0 to the variable; however, this behavior should not
+    !>  be relied on.
+    !>
+    !>  If the variable has been successfully written to the file, SMIOL_SUCCESS will
+    !>  be returned. Otherwise, an error code indicating the nature of the failure
+    !>  will be returned.
+    !
+    !-----------------------------------------------------------------------
+    function SMIOLf_put_var_2d_real64(file, varname, decomp, buf) result(ierr)
+
+        use iso_c_binding, only : c_double, c_char, c_loc, c_ptr, c_null_ptr, c_null_char
+
+        implicit none
+
+        ! Arguments
+        type(SMIOLf_file), target :: file
+        character(len=*), intent(in) :: varname
+        type(SMIOLf_decomp), pointer :: decomp
+        real(kind=c_double), dimension(:,:), pointer :: buf
+
+        ! Return status code
+        integer :: ierr
+
+        ! Local variables
+        integer :: i
+        character(kind=c_char), dimension(:), pointer :: c_varname
+        type (c_ptr) :: c_file
+        type (c_ptr) :: c_decomp
+        type (c_ptr) :: c_buf
+
+
+        !
+        ! file is a target, so no need to check that it is associated
+        !
+        c_file = c_loc(file)
+
+        !
+        ! decomp may be an unassociated pointer if the corresponding field is
+        ! not decomposed
+        !
+        if (associated(decomp)) then
+            c_decomp = c_loc(decomp)
+        else
+            c_decomp = c_null_ptr
+        end if
+
+        !
+        ! Convert variable name string
+        !
+        allocate(c_varname(len_trim(varname) + 1))
+        do i=1,len_trim(varname)
+            c_varname(i) = varname(i:i)
+        end do
+        c_varname(i) = c_null_char
+
+        !
+        ! buf may be an unassociated pointer if the calling task does not read
+        ! or write any elements of the field
+        !
+        if (associated(buf)) then
+
+            !
+            ! Invoke a Fortran 2003-compliant function to get the c_ptr
+            ! of the assumed shape array buf
+            !
+            c_buf = c_loc_assumed_shape_2d_real64(buf, size(buf,dim=1), size(buf,dim=2))
+        else
+            c_buf = c_null_ptr
+        end if
+
+        ierr = SMIOL_put_var(c_file, c_varname, c_decomp, c_buf)
+
+
+        deallocate(c_varname)
+
+    end function SMIOLf_put_var_2d_real64
+
+
+    !-----------------------------------------------------------------------
+    !  routine SMIOLf_get_var_d2_real64
+    !
+    !> \brief Reads a 2-d real64 variable from a file.
+    !> \details
+    !>  Given a SMIOL file and the name of a variable previously defined in the file,
+    !>  this routine will read the contents of the variable into buf according to
+    !>  the decomposition described by decomp.
+    !>
+    !>  If decomp is an associated pointer, the variable is assumed to be decomposed
+    !>  across MPI ranks, and all ranks with non-zero-sized partitions of the variable
+    !>  must provide a valid buffer. For decomposed variables, all MPI ranks must provide
+    !>  an associated decomp pointer, regardless of whether a rank has a non-zero-sized
+    !>  partition of the variable.
+    !>
+    !>  If the variable is not decomposed -- that is, all ranks load identical
+    !>  values for the entire variable -- all MPI ranks must provide an unassociated
+    !>  pointer for the decomp argument.
+    !>
+    !>  If the variable has been successfully read from the file, SMIOL_SUCCESS will
+    !>  be returned. Otherwise, an error code indicating the nature of the failure
+    !>  will be returned.
+    !
+    !-----------------------------------------------------------------------
+    function SMIOLf_get_var_2d_real64(file, varname, decomp, buf) result(ierr)
+
+        use iso_c_binding, only : c_double, c_char, c_loc, c_ptr, c_null_ptr, c_null_char
+
+        implicit none
+
+        ! Arguments
+        type(SMIOLf_file), target :: file
+        character(len=*), intent(in) :: varname
+        type(SMIOLf_decomp), pointer :: decomp
+        real(kind=c_double), dimension(:,:), pointer :: buf
+
+        ! Return status code
+        integer :: ierr
+
+        ! Local variables
+        integer :: i
+        character(kind=c_char), dimension(:), pointer :: c_varname
+        type (c_ptr) :: c_file
+        type (c_ptr) :: c_decomp
+        type (c_ptr) :: c_buf
+
+
+        !
+        ! file is a target, so no need to check that it is associated
+        !
+        c_file = c_loc(file)
+
+        !
+        ! decomp may be an unassociated pointer if the corresponding field is
+        ! not decomposed
+        !
+        if (associated(decomp)) then
+            c_decomp = c_loc(decomp)
+        else
+            c_decomp = c_null_ptr
+        end if
+
+        !
+        ! Convert variable name string
+        !
+        allocate(c_varname(len_trim(varname) + 1))
+        do i=1,len_trim(varname)
+            c_varname(i) = varname(i:i)
+        end do
+        c_varname(i) = c_null_char
+
+        !
+        ! buf may be an unassociated pointer if the calling task does not read
+        ! or write any elements of the field
+        !
+        if (associated(buf)) then
+
+            !
+            ! Invoke a Fortran 2003-compliant function to get the c_ptr
+            ! of the assumed shape array buf
+            !
+            c_buf = c_loc_assumed_shape_2d_real64(buf, size(buf,dim=1), size(buf,dim=2))
+        else
+            c_buf = c_null_ptr
+        end if
+
+        ierr = SMIOL_get_var(c_file, c_varname, c_decomp, c_buf)
+
+
+        deallocate(c_varname)
+
+    end function SMIOLf_get_var_2d_real64
+
+
+    !-----------------------------------------------------------------------
+    !  routine c_loc_assumed_shape_2d_int32
+    !
+    !> \brief Returns a C_PTR for an array with given dimensions
+    !> \details
+    !>  The Fortran 2003 standard does not permit the use of C_LOC with
+    !>  assumed shape arrays. This routine may be used to obtain a C_PTR for
+    !>  an assumed shape array by invoking the routine with the first actual
+    !>  argument as the assumed-shape array, and subsequent actual arguments
+    !>  as, e.g., SIZE(a,DIM=1).
+    !>
+    !>  Internally, the first dummy argument of this routine can be declared
+    !>  as an explicit shape array, which can then be used as an argument to
+    !>  C_LOC.
+    !>
+    !>  Upon success, a C_PTR for the array argument is returned.
+    !>
+    !>  Note: The actual array argument must not be a zero-sized array.
+    !>        Section 15.1.2.5 of the Fortran 2003 standard specifies that
+    !>        the argument to C_LOC '...is not an array of zero size...'.
+    !
+    !-----------------------------------------------------------------------
+    function c_loc_assumed_shape_2d_int32(a, d1, d2) result(a_ptr)
+
+        use iso_c_binding, only : c_ptr, c_loc, c_int
+
+        implicit none
+
+        ! Arguments
+        integer, intent(in) :: d1, d2
+        integer(kind=c_int), dimension(d1,d2), target, intent(in) :: a
+
+        ! Return value
+        type (c_ptr) :: a_ptr
+
+        a_ptr = c_loc(a)
+
+    end function c_loc_assumed_shape_2d_int32
+
+
+    !-----------------------------------------------------------------------
+    !  routine SMIOLf_put_var_d2_int32
+    !
+    !> \brief Writes a 2-d int32 variable to a file.
+    !> \details
+    !>  Given a SMIOL file that was previously opened with write access and the name
+    !>  of a variable previously defined in the file with a call to SMIOLf_define_var,
+    !>  this routine will write the contents of buf to the variable according to
+    !>  the decomposition described by decomp.
+    !>
+    !>  If decomp is an associated pointer, the variable is assumed to be decomposed
+    !>  across MPI ranks, and all ranks with non-zero-sized partitions of the variable
+    !>  must provide a valid buffer. For decomposed variables, all MPI ranks must provide
+    !>  an associated decomp pointer, regardless of whether a rank has a non-zero-sized
+    !>  partition of the variable.
+    !>
+    !>  If the variable is not decomposed -- that is, all ranks store identical
+    !>  values for the entire variable -- all MPI ranks must provide an unassociated
+    !>  pointer for the decomp argument. As currently implemented, this routine will write
+    !>  the buffer for MPI rank 0 to the variable; however, this behavior should not
+    !>  be relied on.
+    !>
+    !>  If the variable has been successfully written to the file, SMIOL_SUCCESS will
+    !>  be returned. Otherwise, an error code indicating the nature of the failure
+    !>  will be returned.
+    !
+    !-----------------------------------------------------------------------
+    function SMIOLf_put_var_2d_int32(file, varname, decomp, buf) result(ierr)
+
+        use iso_c_binding, only : c_int, c_char, c_loc, c_ptr, c_null_ptr, c_null_char
+
+        implicit none
+
+        ! Arguments
+        type(SMIOLf_file), target :: file
+        character(len=*), intent(in) :: varname
+        type(SMIOLf_decomp), pointer :: decomp
+        integer(kind=c_int), dimension(:,:), pointer :: buf
+
+        ! Return status code
+        integer :: ierr
+
+        ! Local variables
+        integer :: i
+        character(kind=c_char), dimension(:), pointer :: c_varname
+        type (c_ptr) :: c_file
+        type (c_ptr) :: c_decomp
+        type (c_ptr) :: c_buf
+
+
+        !
+        ! file is a target, so no need to check that it is associated
+        !
+        c_file = c_loc(file)
+
+        !
+        ! decomp may be an unassociated pointer if the corresponding field is
+        ! not decomposed
+        !
+        if (associated(decomp)) then
+            c_decomp = c_loc(decomp)
+        else
+            c_decomp = c_null_ptr
+        end if
+
+        !
+        ! Convert variable name string
+        !
+        allocate(c_varname(len_trim(varname) + 1))
+        do i=1,len_trim(varname)
+            c_varname(i) = varname(i:i)
+        end do
+        c_varname(i) = c_null_char
+
+        !
+        ! buf may be an unassociated pointer if the calling task does not read
+        ! or write any elements of the field
+        !
+        if (associated(buf)) then
+
+            !
+            ! Invoke a Fortran 2003-compliant function to get the c_ptr
+            ! of the assumed shape array buf
+            !
+            c_buf = c_loc_assumed_shape_2d_int32(buf, size(buf,dim=1), size(buf,dim=2))
+        else
+            c_buf = c_null_ptr
+        end if
+
+        ierr = SMIOL_put_var(c_file, c_varname, c_decomp, c_buf)
+
+
+        deallocate(c_varname)
+
+    end function SMIOLf_put_var_2d_int32
+
+
+    !-----------------------------------------------------------------------
+    !  routine SMIOLf_get_var_d2_int32
+    !
+    !> \brief Reads a 2-d int32 variable from a file.
+    !> \details
+    !>  Given a SMIOL file and the name of a variable previously defined in the file,
+    !>  this routine will read the contents of the variable into buf according to
+    !>  the decomposition described by decomp.
+    !>
+    !>  If decomp is an associated pointer, the variable is assumed to be decomposed
+    !>  across MPI ranks, and all ranks with non-zero-sized partitions of the variable
+    !>  must provide a valid buffer. For decomposed variables, all MPI ranks must provide
+    !>  an associated decomp pointer, regardless of whether a rank has a non-zero-sized
+    !>  partition of the variable.
+    !>
+    !>  If the variable is not decomposed -- that is, all ranks load identical
+    !>  values for the entire variable -- all MPI ranks must provide an unassociated
+    !>  pointer for the decomp argument.
+    !>
+    !>  If the variable has been successfully read from the file, SMIOL_SUCCESS will
+    !>  be returned. Otherwise, an error code indicating the nature of the failure
+    !>  will be returned.
+    !
+    !-----------------------------------------------------------------------
+    function SMIOLf_get_var_2d_int32(file, varname, decomp, buf) result(ierr)
+
+        use iso_c_binding, only : c_int, c_char, c_loc, c_ptr, c_null_ptr, c_null_char
+
+        implicit none
+
+        ! Arguments
+        type(SMIOLf_file), target :: file
+        character(len=*), intent(in) :: varname
+        type(SMIOLf_decomp), pointer :: decomp
+        integer(kind=c_int), dimension(:,:), pointer :: buf
+
+        ! Return status code
+        integer :: ierr
+
+        ! Local variables
+        integer :: i
+        character(kind=c_char), dimension(:), pointer :: c_varname
+        type (c_ptr) :: c_file
+        type (c_ptr) :: c_decomp
+        type (c_ptr) :: c_buf
+
+
+        !
+        ! file is a target, so no need to check that it is associated
+        !
+        c_file = c_loc(file)
+
+        !
+        ! decomp may be an unassociated pointer if the corresponding field is
+        ! not decomposed
+        !
+        if (associated(decomp)) then
+            c_decomp = c_loc(decomp)
+        else
+            c_decomp = c_null_ptr
+        end if
+
+        !
+        ! Convert variable name string
+        !
+        allocate(c_varname(len_trim(varname) + 1))
+        do i=1,len_trim(varname)
+            c_varname(i) = varname(i:i)
+        end do
+        c_varname(i) = c_null_char
+
+        !
+        ! buf may be an unassociated pointer if the calling task does not read
+        ! or write any elements of the field
+        !
+        if (associated(buf)) then
+
+            !
+            ! Invoke a Fortran 2003-compliant function to get the c_ptr
+            ! of the assumed shape array buf
+            !
+            c_buf = c_loc_assumed_shape_2d_int32(buf, size(buf,dim=1), size(buf,dim=2))
+        else
+            c_buf = c_null_ptr
+        end if
+
+        ierr = SMIOL_get_var(c_file, c_varname, c_decomp, c_buf)
+
+
+        deallocate(c_varname)
+
+    end function SMIOLf_get_var_2d_int32
+
+
+    !-----------------------------------------------------------------------
+    !  routine c_loc_assumed_shape_3d_real32
+    !
+    !> \brief Returns a C_PTR for an array with given dimensions
+    !> \details
+    !>  The Fortran 2003 standard does not permit the use of C_LOC with
+    !>  assumed shape arrays. This routine may be used to obtain a C_PTR for
+    !>  an assumed shape array by invoking the routine with the first actual
+    !>  argument as the assumed-shape array, and subsequent actual arguments
+    !>  as, e.g., SIZE(a,DIM=1).
+    !>
+    !>  Internally, the first dummy argument of this routine can be declared
+    !>  as an explicit shape array, which can then be used as an argument to
+    !>  C_LOC.
+    !>
+    !>  Upon success, a C_PTR for the array argument is returned.
+    !>
+    !>  Note: The actual array argument must not be a zero-sized array.
+    !>        Section 15.1.2.5 of the Fortran 2003 standard specifies that
+    !>        the argument to C_LOC '...is not an array of zero size...'.
+    !
+    !-----------------------------------------------------------------------
+    function c_loc_assumed_shape_3d_real32(a, d1, d2, d3) result(a_ptr)
+
+        use iso_c_binding, only : c_ptr, c_loc, c_float
+
+        implicit none
+
+        ! Arguments
+        integer, intent(in) :: d1, d2, d3
+        real(kind=c_float), dimension(d1,d2,d3), target, intent(in) :: a
+
+        ! Return value
+        type (c_ptr) :: a_ptr
+
+        a_ptr = c_loc(a)
+
+    end function c_loc_assumed_shape_3d_real32
+
+
+    !-----------------------------------------------------------------------
+    !  routine SMIOLf_put_var_d3_real32
+    !
+    !> \brief Writes a 3-d real32 variable to a file.
+    !> \details
+    !>  Given a SMIOL file that was previously opened with write access and the name
+    !>  of a variable previously defined in the file with a call to SMIOLf_define_var,
+    !>  this routine will write the contents of buf to the variable according to
+    !>  the decomposition described by decomp.
+    !>
+    !>  If decomp is an associated pointer, the variable is assumed to be decomposed
+    !>  across MPI ranks, and all ranks with non-zero-sized partitions of the variable
+    !>  must provide a valid buffer. For decomposed variables, all MPI ranks must provide
+    !>  an associated decomp pointer, regardless of whether a rank has a non-zero-sized
+    !>  partition of the variable.
+    !>
+    !>  If the variable is not decomposed -- that is, all ranks store identical
+    !>  values for the entire variable -- all MPI ranks must provide an unassociated
+    !>  pointer for the decomp argument. As currently implemented, this routine will write
+    !>  the buffer for MPI rank 0 to the variable; however, this behavior should not
+    !>  be relied on.
+    !>
+    !>  If the variable has been successfully written to the file, SMIOL_SUCCESS will
+    !>  be returned. Otherwise, an error code indicating the nature of the failure
+    !>  will be returned.
+    !
+    !-----------------------------------------------------------------------
+    function SMIOLf_put_var_3d_real32(file, varname, decomp, buf) result(ierr)
+
+        use iso_c_binding, only : c_float, c_char, c_loc, c_ptr, c_null_ptr, c_null_char
+
+        implicit none
+
+        ! Arguments
+        type(SMIOLf_file), target :: file
+        character(len=*), intent(in) :: varname
+        type(SMIOLf_decomp), pointer :: decomp
+        real(kind=c_float), dimension(:,:,:), pointer :: buf
+
+        ! Return status code
+        integer :: ierr
+
+        ! Local variables
+        integer :: i
+        character(kind=c_char), dimension(:), pointer :: c_varname
+        type (c_ptr) :: c_file
+        type (c_ptr) :: c_decomp
+        type (c_ptr) :: c_buf
+
+
+        !
+        ! file is a target, so no need to check that it is associated
+        !
+        c_file = c_loc(file)
+
+        !
+        ! decomp may be an unassociated pointer if the corresponding field is
+        ! not decomposed
+        !
+        if (associated(decomp)) then
+            c_decomp = c_loc(decomp)
+        else
+            c_decomp = c_null_ptr
+        end if
+
+        !
+        ! Convert variable name string
+        !
+        allocate(c_varname(len_trim(varname) + 1))
+        do i=1,len_trim(varname)
+            c_varname(i) = varname(i:i)
+        end do
+        c_varname(i) = c_null_char
+
+        !
+        ! buf may be an unassociated pointer if the calling task does not read
+        ! or write any elements of the field
+        !
+        if (associated(buf)) then
+
+            !
+            ! Invoke a Fortran 2003-compliant function to get the c_ptr
+            ! of the assumed shape array buf
+            !
+            c_buf = c_loc_assumed_shape_3d_real32(buf, size(buf,dim=1), size(buf,dim=2), size(buf,dim=3))
+        else
+            c_buf = c_null_ptr
+        end if
+
+        ierr = SMIOL_put_var(c_file, c_varname, c_decomp, c_buf)
+
+
+        deallocate(c_varname)
+
+    end function SMIOLf_put_var_3d_real32
+
+
+    !-----------------------------------------------------------------------
+    !  routine SMIOLf_get_var_d3_real32
+    !
+    !> \brief Reads a 3-d real32 variable from a file.
+    !> \details
+    !>  Given a SMIOL file and the name of a variable previously defined in the file,
+    !>  this routine will read the contents of the variable into buf according to
+    !>  the decomposition described by decomp.
+    !>
+    !>  If decomp is an associated pointer, the variable is assumed to be decomposed
+    !>  across MPI ranks, and all ranks with non-zero-sized partitions of the variable
+    !>  must provide a valid buffer. For decomposed variables, all MPI ranks must provide
+    !>  an associated decomp pointer, regardless of whether a rank has a non-zero-sized
+    !>  partition of the variable.
+    !>
+    !>  If the variable is not decomposed -- that is, all ranks load identical
+    !>  values for the entire variable -- all MPI ranks must provide an unassociated
+    !>  pointer for the decomp argument.
+    !>
+    !>  If the variable has been successfully read from the file, SMIOL_SUCCESS will
+    !>  be returned. Otherwise, an error code indicating the nature of the failure
+    !>  will be returned.
+    !
+    !-----------------------------------------------------------------------
+    function SMIOLf_get_var_3d_real32(file, varname, decomp, buf) result(ierr)
+
+        use iso_c_binding, only : c_float, c_char, c_loc, c_ptr, c_null_ptr, c_null_char
+
+        implicit none
+
+        ! Arguments
+        type(SMIOLf_file), target :: file
+        character(len=*), intent(in) :: varname
+        type(SMIOLf_decomp), pointer :: decomp
+        real(kind=c_float), dimension(:,:,:), pointer :: buf
+
+        ! Return status code
+        integer :: ierr
+
+        ! Local variables
+        integer :: i
+        character(kind=c_char), dimension(:), pointer :: c_varname
+        type (c_ptr) :: c_file
+        type (c_ptr) :: c_decomp
+        type (c_ptr) :: c_buf
+
+
+        !
+        ! file is a target, so no need to check that it is associated
+        !
+        c_file = c_loc(file)
+
+        !
+        ! decomp may be an unassociated pointer if the corresponding field is
+        ! not decomposed
+        !
+        if (associated(decomp)) then
+            c_decomp = c_loc(decomp)
+        else
+            c_decomp = c_null_ptr
+        end if
+
+        !
+        ! Convert variable name string
+        !
+        allocate(c_varname(len_trim(varname) + 1))
+        do i=1,len_trim(varname)
+            c_varname(i) = varname(i:i)
+        end do
+        c_varname(i) = c_null_char
+
+        !
+        ! buf may be an unassociated pointer if the calling task does not read
+        ! or write any elements of the field
+        !
+        if (associated(buf)) then
+
+            !
+            ! Invoke a Fortran 2003-compliant function to get the c_ptr
+            ! of the assumed shape array buf
+            !
+            c_buf = c_loc_assumed_shape_3d_real32(buf, size(buf,dim=1), size(buf,dim=2), size(buf,dim=3))
+        else
+            c_buf = c_null_ptr
+        end if
+
+        ierr = SMIOL_get_var(c_file, c_varname, c_decomp, c_buf)
+
+
+        deallocate(c_varname)
+
+    end function SMIOLf_get_var_3d_real32
+
+
+    !-----------------------------------------------------------------------
+    !  routine c_loc_assumed_shape_3d_real64
+    !
+    !> \brief Returns a C_PTR for an array with given dimensions
+    !> \details
+    !>  The Fortran 2003 standard does not permit the use of C_LOC with
+    !>  assumed shape arrays. This routine may be used to obtain a C_PTR for
+    !>  an assumed shape array by invoking the routine with the first actual
+    !>  argument as the assumed-shape array, and subsequent actual arguments
+    !>  as, e.g., SIZE(a,DIM=1).
+    !>
+    !>  Internally, the first dummy argument of this routine can be declared
+    !>  as an explicit shape array, which can then be used as an argument to
+    !>  C_LOC.
+    !>
+    !>  Upon success, a C_PTR for the array argument is returned.
+    !>
+    !>  Note: The actual array argument must not be a zero-sized array.
+    !>        Section 15.1.2.5 of the Fortran 2003 standard specifies that
+    !>        the argument to C_LOC '...is not an array of zero size...'.
+    !
+    !-----------------------------------------------------------------------
+    function c_loc_assumed_shape_3d_real64(a, d1, d2, d3) result(a_ptr)
+
+        use iso_c_binding, only : c_ptr, c_loc, c_double
+
+        implicit none
+
+        ! Arguments
+        integer, intent(in) :: d1, d2, d3
+        real(kind=c_double), dimension(d1,d2,d3), target, intent(in) :: a
+
+        ! Return value
+        type (c_ptr) :: a_ptr
+
+        a_ptr = c_loc(a)
+
+    end function c_loc_assumed_shape_3d_real64
+
+
+    !-----------------------------------------------------------------------
+    !  routine SMIOLf_put_var_d3_real64
+    !
+    !> \brief Writes a 3-d real64 variable to a file.
+    !> \details
+    !>  Given a SMIOL file that was previously opened with write access and the name
+    !>  of a variable previously defined in the file with a call to SMIOLf_define_var,
+    !>  this routine will write the contents of buf to the variable according to
+    !>  the decomposition described by decomp.
+    !>
+    !>  If decomp is an associated pointer, the variable is assumed to be decomposed
+    !>  across MPI ranks, and all ranks with non-zero-sized partitions of the variable
+    !>  must provide a valid buffer. For decomposed variables, all MPI ranks must provide
+    !>  an associated decomp pointer, regardless of whether a rank has a non-zero-sized
+    !>  partition of the variable.
+    !>
+    !>  If the variable is not decomposed -- that is, all ranks store identical
+    !>  values for the entire variable -- all MPI ranks must provide an unassociated
+    !>  pointer for the decomp argument. As currently implemented, this routine will write
+    !>  the buffer for MPI rank 0 to the variable; however, this behavior should not
+    !>  be relied on.
+    !>
+    !>  If the variable has been successfully written to the file, SMIOL_SUCCESS will
+    !>  be returned. Otherwise, an error code indicating the nature of the failure
+    !>  will be returned.
+    !
+    !-----------------------------------------------------------------------
+    function SMIOLf_put_var_3d_real64(file, varname, decomp, buf) result(ierr)
+
+        use iso_c_binding, only : c_double, c_char, c_loc, c_ptr, c_null_ptr, c_null_char
+
+        implicit none
+
+        ! Arguments
+        type(SMIOLf_file), target :: file
+        character(len=*), intent(in) :: varname
+        type(SMIOLf_decomp), pointer :: decomp
+        real(kind=c_double), dimension(:,:,:), pointer :: buf
+
+        ! Return status code
+        integer :: ierr
+
+        ! Local variables
+        integer :: i
+        character(kind=c_char), dimension(:), pointer :: c_varname
+        type (c_ptr) :: c_file
+        type (c_ptr) :: c_decomp
+        type (c_ptr) :: c_buf
+
+
+        !
+        ! file is a target, so no need to check that it is associated
+        !
+        c_file = c_loc(file)
+
+        !
+        ! decomp may be an unassociated pointer if the corresponding field is
+        ! not decomposed
+        !
+        if (associated(decomp)) then
+            c_decomp = c_loc(decomp)
+        else
+            c_decomp = c_null_ptr
+        end if
+
+        !
+        ! Convert variable name string
+        !
+        allocate(c_varname(len_trim(varname) + 1))
+        do i=1,len_trim(varname)
+            c_varname(i) = varname(i:i)
+        end do
+        c_varname(i) = c_null_char
+
+        !
+        ! buf may be an unassociated pointer if the calling task does not read
+        ! or write any elements of the field
+        !
+        if (associated(buf)) then
+
+            !
+            ! Invoke a Fortran 2003-compliant function to get the c_ptr
+            ! of the assumed shape array buf
+            !
+            c_buf = c_loc_assumed_shape_3d_real64(buf, size(buf,dim=1), size(buf,dim=2), size(buf,dim=3))
+        else
+            c_buf = c_null_ptr
+        end if
+
+        ierr = SMIOL_put_var(c_file, c_varname, c_decomp, c_buf)
+
+
+        deallocate(c_varname)
+
+    end function SMIOLf_put_var_3d_real64
+
+
+    !-----------------------------------------------------------------------
+    !  routine SMIOLf_get_var_d3_real64
+    !
+    !> \brief Reads a 3-d real64 variable from a file.
+    !> \details
+    !>  Given a SMIOL file and the name of a variable previously defined in the file,
+    !>  this routine will read the contents of the variable into buf according to
+    !>  the decomposition described by decomp.
+    !>
+    !>  If decomp is an associated pointer, the variable is assumed to be decomposed
+    !>  across MPI ranks, and all ranks with non-zero-sized partitions of the variable
+    !>  must provide a valid buffer. For decomposed variables, all MPI ranks must provide
+    !>  an associated decomp pointer, regardless of whether a rank has a non-zero-sized
+    !>  partition of the variable.
+    !>
+    !>  If the variable is not decomposed -- that is, all ranks load identical
+    !>  values for the entire variable -- all MPI ranks must provide an unassociated
+    !>  pointer for the decomp argument.
+    !>
+    !>  If the variable has been successfully read from the file, SMIOL_SUCCESS will
+    !>  be returned. Otherwise, an error code indicating the nature of the failure
+    !>  will be returned.
+    !
+    !-----------------------------------------------------------------------
+    function SMIOLf_get_var_3d_real64(file, varname, decomp, buf) result(ierr)
+
+        use iso_c_binding, only : c_double, c_char, c_loc, c_ptr, c_null_ptr, c_null_char
+
+        implicit none
+
+        ! Arguments
+        type(SMIOLf_file), target :: file
+        character(len=*), intent(in) :: varname
+        type(SMIOLf_decomp), pointer :: decomp
+        real(kind=c_double), dimension(:,:,:), pointer :: buf
+
+        ! Return status code
+        integer :: ierr
+
+        ! Local variables
+        integer :: i
+        character(kind=c_char), dimension(:), pointer :: c_varname
+        type (c_ptr) :: c_file
+        type (c_ptr) :: c_decomp
+        type (c_ptr) :: c_buf
+
+
+        !
+        ! file is a target, so no need to check that it is associated
+        !
+        c_file = c_loc(file)
+
+        !
+        ! decomp may be an unassociated pointer if the corresponding field is
+        ! not decomposed
+        !
+        if (associated(decomp)) then
+            c_decomp = c_loc(decomp)
+        else
+            c_decomp = c_null_ptr
+        end if
+
+        !
+        ! Convert variable name string
+        !
+        allocate(c_varname(len_trim(varname) + 1))
+        do i=1,len_trim(varname)
+            c_varname(i) = varname(i:i)
+        end do
+        c_varname(i) = c_null_char
+
+        !
+        ! buf may be an unassociated pointer if the calling task does not read
+        ! or write any elements of the field
+        !
+        if (associated(buf)) then
+
+            !
+            ! Invoke a Fortran 2003-compliant function to get the c_ptr
+            ! of the assumed shape array buf
+            !
+            c_buf = c_loc_assumed_shape_3d_real64(buf, size(buf,dim=1), size(buf,dim=2), size(buf,dim=3))
+        else
+            c_buf = c_null_ptr
+        end if
+
+        ierr = SMIOL_get_var(c_file, c_varname, c_decomp, c_buf)
+
+
+        deallocate(c_varname)
+
+    end function SMIOLf_get_var_3d_real64
+
+
+    !-----------------------------------------------------------------------
+    !  routine c_loc_assumed_shape_3d_int32
+    !
+    !> \brief Returns a C_PTR for an array with given dimensions
+    !> \details
+    !>  The Fortran 2003 standard does not permit the use of C_LOC with
+    !>  assumed shape arrays. This routine may be used to obtain a C_PTR for
+    !>  an assumed shape array by invoking the routine with the first actual
+    !>  argument as the assumed-shape array, and subsequent actual arguments
+    !>  as, e.g., SIZE(a,DIM=1).
+    !>
+    !>  Internally, the first dummy argument of this routine can be declared
+    !>  as an explicit shape array, which can then be used as an argument to
+    !>  C_LOC.
+    !>
+    !>  Upon success, a C_PTR for the array argument is returned.
+    !>
+    !>  Note: The actual array argument must not be a zero-sized array.
+    !>        Section 15.1.2.5 of the Fortran 2003 standard specifies that
+    !>        the argument to C_LOC '...is not an array of zero size...'.
+    !
+    !-----------------------------------------------------------------------
+    function c_loc_assumed_shape_3d_int32(a, d1, d2, d3) result(a_ptr)
+
+        use iso_c_binding, only : c_ptr, c_loc, c_int
+
+        implicit none
+
+        ! Arguments
+        integer, intent(in) :: d1, d2, d3
+        integer(kind=c_int), dimension(d1,d2,d3), target, intent(in) :: a
+
+        ! Return value
+        type (c_ptr) :: a_ptr
+
+        a_ptr = c_loc(a)
+
+    end function c_loc_assumed_shape_3d_int32
+
+
+    !-----------------------------------------------------------------------
+    !  routine SMIOLf_put_var_d3_int32
+    !
+    !> \brief Writes a 3-d int32 variable to a file.
+    !> \details
+    !>  Given a SMIOL file that was previously opened with write access and the name
+    !>  of a variable previously defined in the file with a call to SMIOLf_define_var,
+    !>  this routine will write the contents of buf to the variable according to
+    !>  the decomposition described by decomp.
+    !>
+    !>  If decomp is an associated pointer, the variable is assumed to be decomposed
+    !>  across MPI ranks, and all ranks with non-zero-sized partitions of the variable
+    !>  must provide a valid buffer. For decomposed variables, all MPI ranks must provide
+    !>  an associated decomp pointer, regardless of whether a rank has a non-zero-sized
+    !>  partition of the variable.
+    !>
+    !>  If the variable is not decomposed -- that is, all ranks store identical
+    !>  values for the entire variable -- all MPI ranks must provide an unassociated
+    !>  pointer for the decomp argument. As currently implemented, this routine will write
+    !>  the buffer for MPI rank 0 to the variable; however, this behavior should not
+    !>  be relied on.
+    !>
+    !>  If the variable has been successfully written to the file, SMIOL_SUCCESS will
+    !>  be returned. Otherwise, an error code indicating the nature of the failure
+    !>  will be returned.
+    !
+    !-----------------------------------------------------------------------
+    function SMIOLf_put_var_3d_int32(file, varname, decomp, buf) result(ierr)
+
+        use iso_c_binding, only : c_int, c_char, c_loc, c_ptr, c_null_ptr, c_null_char
+
+        implicit none
+
+        ! Arguments
+        type(SMIOLf_file), target :: file
+        character(len=*), intent(in) :: varname
+        type(SMIOLf_decomp), pointer :: decomp
+        integer(kind=c_int), dimension(:,:,:), pointer :: buf
+
+        ! Return status code
+        integer :: ierr
+
+        ! Local variables
+        integer :: i
+        character(kind=c_char), dimension(:), pointer :: c_varname
+        type (c_ptr) :: c_file
+        type (c_ptr) :: c_decomp
+        type (c_ptr) :: c_buf
+
+
+        !
+        ! file is a target, so no need to check that it is associated
+        !
+        c_file = c_loc(file)
+
+        !
+        ! decomp may be an unassociated pointer if the corresponding field is
+        ! not decomposed
+        !
+        if (associated(decomp)) then
+            c_decomp = c_loc(decomp)
+        else
+            c_decomp = c_null_ptr
+        end if
+
+        !
+        ! Convert variable name string
+        !
+        allocate(c_varname(len_trim(varname) + 1))
+        do i=1,len_trim(varname)
+            c_varname(i) = varname(i:i)
+        end do
+        c_varname(i) = c_null_char
+
+        !
+        ! buf may be an unassociated pointer if the calling task does not read
+        ! or write any elements of the field
+        !
+        if (associated(buf)) then
+
+            !
+            ! Invoke a Fortran 2003-compliant function to get the c_ptr
+            ! of the assumed shape array buf
+            !
+            c_buf = c_loc_assumed_shape_3d_int32(buf, size(buf,dim=1), size(buf,dim=2), size(buf,dim=3))
+        else
+            c_buf = c_null_ptr
+        end if
+
+        ierr = SMIOL_put_var(c_file, c_varname, c_decomp, c_buf)
+
+
+        deallocate(c_varname)
+
+    end function SMIOLf_put_var_3d_int32
+
+
+    !-----------------------------------------------------------------------
+    !  routine SMIOLf_get_var_d3_int32
+    !
+    !> \brief Reads a 3-d int32 variable from a file.
+    !> \details
+    !>  Given a SMIOL file and the name of a variable previously defined in the file,
+    !>  this routine will read the contents of the variable into buf according to
+    !>  the decomposition described by decomp.
+    !>
+    !>  If decomp is an associated pointer, the variable is assumed to be decomposed
+    !>  across MPI ranks, and all ranks with non-zero-sized partitions of the variable
+    !>  must provide a valid buffer. For decomposed variables, all MPI ranks must provide
+    !>  an associated decomp pointer, regardless of whether a rank has a non-zero-sized
+    !>  partition of the variable.
+    !>
+    !>  If the variable is not decomposed -- that is, all ranks load identical
+    !>  values for the entire variable -- all MPI ranks must provide an unassociated
+    !>  pointer for the decomp argument.
+    !>
+    !>  If the variable has been successfully read from the file, SMIOL_SUCCESS will
+    !>  be returned. Otherwise, an error code indicating the nature of the failure
+    !>  will be returned.
+    !
+    !-----------------------------------------------------------------------
+    function SMIOLf_get_var_3d_int32(file, varname, decomp, buf) result(ierr)
+
+        use iso_c_binding, only : c_int, c_char, c_loc, c_ptr, c_null_ptr, c_null_char
+
+        implicit none
+
+        ! Arguments
+        type(SMIOLf_file), target :: file
+        character(len=*), intent(in) :: varname
+        type(SMIOLf_decomp), pointer :: decomp
+        integer(kind=c_int), dimension(:,:,:), pointer :: buf
+
+        ! Return status code
+        integer :: ierr
+
+        ! Local variables
+        integer :: i
+        character(kind=c_char), dimension(:), pointer :: c_varname
+        type (c_ptr) :: c_file
+        type (c_ptr) :: c_decomp
+        type (c_ptr) :: c_buf
+
+
+        !
+        ! file is a target, so no need to check that it is associated
+        !
+        c_file = c_loc(file)
+
+        !
+        ! decomp may be an unassociated pointer if the corresponding field is
+        ! not decomposed
+        !
+        if (associated(decomp)) then
+            c_decomp = c_loc(decomp)
+        else
+            c_decomp = c_null_ptr
+        end if
+
+        !
+        ! Convert variable name string
+        !
+        allocate(c_varname(len_trim(varname) + 1))
+        do i=1,len_trim(varname)
+            c_varname(i) = varname(i:i)
+        end do
+        c_varname(i) = c_null_char
+
+        !
+        ! buf may be an unassociated pointer if the calling task does not read
+        ! or write any elements of the field
+        !
+        if (associated(buf)) then
+
+            !
+            ! Invoke a Fortran 2003-compliant function to get the c_ptr
+            ! of the assumed shape array buf
+            !
+            c_buf = c_loc_assumed_shape_3d_int32(buf, size(buf,dim=1), size(buf,dim=2), size(buf,dim=3))
+        else
+            c_buf = c_null_ptr
+        end if
+
+        ierr = SMIOL_get_var(c_file, c_varname, c_decomp, c_buf)
+
+
+        deallocate(c_varname)
+
+    end function SMIOLf_get_var_3d_int32
+
+
+    !-----------------------------------------------------------------------
+    !  routine c_loc_assumed_shape_4d_real32
+    !
+    !> \brief Returns a C_PTR for an array with given dimensions
+    !> \details
+    !>  The Fortran 2003 standard does not permit the use of C_LOC with
+    !>  assumed shape arrays. This routine may be used to obtain a C_PTR for
+    !>  an assumed shape array by invoking the routine with the first actual
+    !>  argument as the assumed-shape array, and subsequent actual arguments
+    !>  as, e.g., SIZE(a,DIM=1).
+    !>
+    !>  Internally, the first dummy argument of this routine can be declared
+    !>  as an explicit shape array, which can then be used as an argument to
+    !>  C_LOC.
+    !>
+    !>  Upon success, a C_PTR for the array argument is returned.
+    !>
+    !>  Note: The actual array argument must not be a zero-sized array.
+    !>        Section 15.1.2.5 of the Fortran 2003 standard specifies that
+    !>        the argument to C_LOC '...is not an array of zero size...'.
+    !
+    !-----------------------------------------------------------------------
+    function c_loc_assumed_shape_4d_real32(a, d1, d2, d3, d4) result(a_ptr)
+
+        use iso_c_binding, only : c_ptr, c_loc, c_float
+
+        implicit none
+
+        ! Arguments
+        integer, intent(in) :: d1, d2, d3, d4
+        real(kind=c_float), dimension(d1,d2,d3,d4), target, intent(in) :: a
+
+        ! Return value
+        type (c_ptr) :: a_ptr
+
+        a_ptr = c_loc(a)
+
+    end function c_loc_assumed_shape_4d_real32
+
+
+    !-----------------------------------------------------------------------
+    !  routine SMIOLf_put_var_d4_real32
+    !
+    !> \brief Writes a 4-d real32 variable to a file.
+    !> \details
+    !>  Given a SMIOL file that was previously opened with write access and the name
+    !>  of a variable previously defined in the file with a call to SMIOLf_define_var,
+    !>  this routine will write the contents of buf to the variable according to
+    !>  the decomposition described by decomp.
+    !>
+    !>  If decomp is an associated pointer, the variable is assumed to be decomposed
+    !>  across MPI ranks, and all ranks with non-zero-sized partitions of the variable
+    !>  must provide a valid buffer. For decomposed variables, all MPI ranks must provide
+    !>  an associated decomp pointer, regardless of whether a rank has a non-zero-sized
+    !>  partition of the variable.
+    !>
+    !>  If the variable is not decomposed -- that is, all ranks store identical
+    !>  values for the entire variable -- all MPI ranks must provide an unassociated
+    !>  pointer for the decomp argument. As currently implemented, this routine will write
+    !>  the buffer for MPI rank 0 to the variable; however, this behavior should not
+    !>  be relied on.
+    !>
+    !>  If the variable has been successfully written to the file, SMIOL_SUCCESS will
+    !>  be returned. Otherwise, an error code indicating the nature of the failure
+    !>  will be returned.
+    !
+    !-----------------------------------------------------------------------
+    function SMIOLf_put_var_4d_real32(file, varname, decomp, buf) result(ierr)
+
+        use iso_c_binding, only : c_float, c_char, c_loc, c_ptr, c_null_ptr, c_null_char
+
+        implicit none
+
+        ! Arguments
+        type(SMIOLf_file), target :: file
+        character(len=*), intent(in) :: varname
+        type(SMIOLf_decomp), pointer :: decomp
+        real(kind=c_float), dimension(:,:,:,:), pointer :: buf
+
+        ! Return status code
+        integer :: ierr
+
+        ! Local variables
+        integer :: i
+        character(kind=c_char), dimension(:), pointer :: c_varname
+        type (c_ptr) :: c_file
+        type (c_ptr) :: c_decomp
+        type (c_ptr) :: c_buf
+
+
+        !
+        ! file is a target, so no need to check that it is associated
+        !
+        c_file = c_loc(file)
+
+        !
+        ! decomp may be an unassociated pointer if the corresponding field is
+        ! not decomposed
+        !
+        if (associated(decomp)) then
+            c_decomp = c_loc(decomp)
+        else
+            c_decomp = c_null_ptr
+        end if
+
+        !
+        ! Convert variable name string
+        !
+        allocate(c_varname(len_trim(varname) + 1))
+        do i=1,len_trim(varname)
+            c_varname(i) = varname(i:i)
+        end do
+        c_varname(i) = c_null_char
+
+        !
+        ! buf may be an unassociated pointer if the calling task does not read
+        ! or write any elements of the field
+        !
+        if (associated(buf)) then
+
+            !
+            ! Invoke a Fortran 2003-compliant function to get the c_ptr
+            ! of the assumed shape array buf
+            !
+            c_buf = c_loc_assumed_shape_4d_real32(buf, size(buf,dim=1), size(buf,dim=2), size(buf,dim=3), &
+                                           size(buf,dim=4))
+        else
+            c_buf = c_null_ptr
+        end if
+
+        ierr = SMIOL_put_var(c_file, c_varname, c_decomp, c_buf)
+
+
+        deallocate(c_varname)
+
+    end function SMIOLf_put_var_4d_real32
+
+
+    !-----------------------------------------------------------------------
+    !  routine SMIOLf_get_var_d4_real32
+    !
+    !> \brief Reads a 4-d real32 variable from a file.
+    !> \details
+    !>  Given a SMIOL file and the name of a variable previously defined in the file,
+    !>  this routine will read the contents of the variable into buf according to
+    !>  the decomposition described by decomp.
+    !>
+    !>  If decomp is an associated pointer, the variable is assumed to be decomposed
+    !>  across MPI ranks, and all ranks with non-zero-sized partitions of the variable
+    !>  must provide a valid buffer. For decomposed variables, all MPI ranks must provide
+    !>  an associated decomp pointer, regardless of whether a rank has a non-zero-sized
+    !>  partition of the variable.
+    !>
+    !>  If the variable is not decomposed -- that is, all ranks load identical
+    !>  values for the entire variable -- all MPI ranks must provide an unassociated
+    !>  pointer for the decomp argument.
+    !>
+    !>  If the variable has been successfully read from the file, SMIOL_SUCCESS will
+    !>  be returned. Otherwise, an error code indicating the nature of the failure
+    !>  will be returned.
+    !
+    !-----------------------------------------------------------------------
+    function SMIOLf_get_var_4d_real32(file, varname, decomp, buf) result(ierr)
+
+        use iso_c_binding, only : c_float, c_char, c_loc, c_ptr, c_null_ptr, c_null_char
+
+        implicit none
+
+        ! Arguments
+        type(SMIOLf_file), target :: file
+        character(len=*), intent(in) :: varname
+        type(SMIOLf_decomp), pointer :: decomp
+        real(kind=c_float), dimension(:,:,:,:), pointer :: buf
+
+        ! Return status code
+        integer :: ierr
+
+        ! Local variables
+        integer :: i
+        character(kind=c_char), dimension(:), pointer :: c_varname
+        type (c_ptr) :: c_file
+        type (c_ptr) :: c_decomp
+        type (c_ptr) :: c_buf
+
+
+        !
+        ! file is a target, so no need to check that it is associated
+        !
+        c_file = c_loc(file)
+
+        !
+        ! decomp may be an unassociated pointer if the corresponding field is
+        ! not decomposed
+        !
+        if (associated(decomp)) then
+            c_decomp = c_loc(decomp)
+        else
+            c_decomp = c_null_ptr
+        end if
+
+        !
+        ! Convert variable name string
+        !
+        allocate(c_varname(len_trim(varname) + 1))
+        do i=1,len_trim(varname)
+            c_varname(i) = varname(i:i)
+        end do
+        c_varname(i) = c_null_char
+
+        !
+        ! buf may be an unassociated pointer if the calling task does not read
+        ! or write any elements of the field
+        !
+        if (associated(buf)) then
+
+            !
+            ! Invoke a Fortran 2003-compliant function to get the c_ptr
+            ! of the assumed shape array buf
+            !
+            c_buf = c_loc_assumed_shape_4d_real32(buf, size(buf,dim=1), size(buf,dim=2), size(buf,dim=3), &
+                                           size(buf,dim=4))
+        else
+            c_buf = c_null_ptr
+        end if
+
+        ierr = SMIOL_get_var(c_file, c_varname, c_decomp, c_buf)
+
+
+        deallocate(c_varname)
+
+    end function SMIOLf_get_var_4d_real32
+
+
+    !-----------------------------------------------------------------------
+    !  routine c_loc_assumed_shape_4d_real64
+    !
+    !> \brief Returns a C_PTR for an array with given dimensions
+    !> \details
+    !>  The Fortran 2003 standard does not permit the use of C_LOC with
+    !>  assumed shape arrays. This routine may be used to obtain a C_PTR for
+    !>  an assumed shape array by invoking the routine with the first actual
+    !>  argument as the assumed-shape array, and subsequent actual arguments
+    !>  as, e.g., SIZE(a,DIM=1).
+    !>
+    !>  Internally, the first dummy argument of this routine can be declared
+    !>  as an explicit shape array, which can then be used as an argument to
+    !>  C_LOC.
+    !>
+    !>  Upon success, a C_PTR for the array argument is returned.
+    !>
+    !>  Note: The actual array argument must not be a zero-sized array.
+    !>        Section 15.1.2.5 of the Fortran 2003 standard specifies that
+    !>        the argument to C_LOC '...is not an array of zero size...'.
+    !
+    !-----------------------------------------------------------------------
+    function c_loc_assumed_shape_4d_real64(a, d1, d2, d3, d4) result(a_ptr)
+
+        use iso_c_binding, only : c_ptr, c_loc, c_double
+
+        implicit none
+
+        ! Arguments
+        integer, intent(in) :: d1, d2, d3, d4
+        real(kind=c_double), dimension(d1,d2,d3,d4), target, intent(in) :: a
+
+        ! Return value
+        type (c_ptr) :: a_ptr
+
+        a_ptr = c_loc(a)
+
+    end function c_loc_assumed_shape_4d_real64
+
+
+    !-----------------------------------------------------------------------
+    !  routine SMIOLf_put_var_d4_real64
+    !
+    !> \brief Writes a 4-d real64 variable to a file.
+    !> \details
+    !>  Given a SMIOL file that was previously opened with write access and the name
+    !>  of a variable previously defined in the file with a call to SMIOLf_define_var,
+    !>  this routine will write the contents of buf to the variable according to
+    !>  the decomposition described by decomp.
+    !>
+    !>  If decomp is an associated pointer, the variable is assumed to be decomposed
+    !>  across MPI ranks, and all ranks with non-zero-sized partitions of the variable
+    !>  must provide a valid buffer. For decomposed variables, all MPI ranks must provide
+    !>  an associated decomp pointer, regardless of whether a rank has a non-zero-sized
+    !>  partition of the variable.
+    !>
+    !>  If the variable is not decomposed -- that is, all ranks store identical
+    !>  values for the entire variable -- all MPI ranks must provide an unassociated
+    !>  pointer for the decomp argument. As currently implemented, this routine will write
+    !>  the buffer for MPI rank 0 to the variable; however, this behavior should not
+    !>  be relied on.
+    !>
+    !>  If the variable has been successfully written to the file, SMIOL_SUCCESS will
+    !>  be returned. Otherwise, an error code indicating the nature of the failure
+    !>  will be returned.
+    !
+    !-----------------------------------------------------------------------
+    function SMIOLf_put_var_4d_real64(file, varname, decomp, buf) result(ierr)
+
+        use iso_c_binding, only : c_double, c_char, c_loc, c_ptr, c_null_ptr, c_null_char
+
+        implicit none
+
+        ! Arguments
+        type(SMIOLf_file), target :: file
+        character(len=*), intent(in) :: varname
+        type(SMIOLf_decomp), pointer :: decomp
+        real(kind=c_double), dimension(:,:,:,:), pointer :: buf
+
+        ! Return status code
+        integer :: ierr
+
+        ! Local variables
+        integer :: i
+        character(kind=c_char), dimension(:), pointer :: c_varname
+        type (c_ptr) :: c_file
+        type (c_ptr) :: c_decomp
+        type (c_ptr) :: c_buf
+
+
+        !
+        ! file is a target, so no need to check that it is associated
+        !
+        c_file = c_loc(file)
+
+        !
+        ! decomp may be an unassociated pointer if the corresponding field is
+        ! not decomposed
+        !
+        if (associated(decomp)) then
+            c_decomp = c_loc(decomp)
+        else
+            c_decomp = c_null_ptr
+        end if
+
+        !
+        ! Convert variable name string
+        !
+        allocate(c_varname(len_trim(varname) + 1))
+        do i=1,len_trim(varname)
+            c_varname(i) = varname(i:i)
+        end do
+        c_varname(i) = c_null_char
+
+        !
+        ! buf may be an unassociated pointer if the calling task does not read
+        ! or write any elements of the field
+        !
+        if (associated(buf)) then
+
+            !
+            ! Invoke a Fortran 2003-compliant function to get the c_ptr
+            ! of the assumed shape array buf
+            !
+            c_buf = c_loc_assumed_shape_4d_real64(buf, size(buf,dim=1), size(buf,dim=2), size(buf,dim=3), &
+                                           size(buf,dim=4))
+        else
+            c_buf = c_null_ptr
+        end if
+
+        ierr = SMIOL_put_var(c_file, c_varname, c_decomp, c_buf)
+
+
+        deallocate(c_varname)
+
+    end function SMIOLf_put_var_4d_real64
+
+
+    !-----------------------------------------------------------------------
+    !  routine SMIOLf_get_var_d4_real64
+    !
+    !> \brief Reads a 4-d real64 variable from a file.
+    !> \details
+    !>  Given a SMIOL file and the name of a variable previously defined in the file,
+    !>  this routine will read the contents of the variable into buf according to
+    !>  the decomposition described by decomp.
+    !>
+    !>  If decomp is an associated pointer, the variable is assumed to be decomposed
+    !>  across MPI ranks, and all ranks with non-zero-sized partitions of the variable
+    !>  must provide a valid buffer. For decomposed variables, all MPI ranks must provide
+    !>  an associated decomp pointer, regardless of whether a rank has a non-zero-sized
+    !>  partition of the variable.
+    !>
+    !>  If the variable is not decomposed -- that is, all ranks load identical
+    !>  values for the entire variable -- all MPI ranks must provide an unassociated
+    !>  pointer for the decomp argument.
+    !>
+    !>  If the variable has been successfully read from the file, SMIOL_SUCCESS will
+    !>  be returned. Otherwise, an error code indicating the nature of the failure
+    !>  will be returned.
+    !
+    !-----------------------------------------------------------------------
+    function SMIOLf_get_var_4d_real64(file, varname, decomp, buf) result(ierr)
+
+        use iso_c_binding, only : c_double, c_char, c_loc, c_ptr, c_null_ptr, c_null_char
+
+        implicit none
+
+        ! Arguments
+        type(SMIOLf_file), target :: file
+        character(len=*), intent(in) :: varname
+        type(SMIOLf_decomp), pointer :: decomp
+        real(kind=c_double), dimension(:,:,:,:), pointer :: buf
+
+        ! Return status code
+        integer :: ierr
+
+        ! Local variables
+        integer :: i
+        character(kind=c_char), dimension(:), pointer :: c_varname
+        type (c_ptr) :: c_file
+        type (c_ptr) :: c_decomp
+        type (c_ptr) :: c_buf
+
+
+        !
+        ! file is a target, so no need to check that it is associated
+        !
+        c_file = c_loc(file)
+
+        !
+        ! decomp may be an unassociated pointer if the corresponding field is
+        ! not decomposed
+        !
+        if (associated(decomp)) then
+            c_decomp = c_loc(decomp)
+        else
+            c_decomp = c_null_ptr
+        end if
+
+        !
+        ! Convert variable name string
+        !
+        allocate(c_varname(len_trim(varname) + 1))
+        do i=1,len_trim(varname)
+            c_varname(i) = varname(i:i)
+        end do
+        c_varname(i) = c_null_char
+
+        !
+        ! buf may be an unassociated pointer if the calling task does not read
+        ! or write any elements of the field
+        !
+        if (associated(buf)) then
+
+            !
+            ! Invoke a Fortran 2003-compliant function to get the c_ptr
+            ! of the assumed shape array buf
+            !
+            c_buf = c_loc_assumed_shape_4d_real64(buf, size(buf,dim=1), size(buf,dim=2), size(buf,dim=3), &
+                                           size(buf,dim=4))
+        else
+            c_buf = c_null_ptr
+        end if
+
+        ierr = SMIOL_get_var(c_file, c_varname, c_decomp, c_buf)
+
+
+        deallocate(c_varname)
+
+    end function SMIOLf_get_var_4d_real64
+
+
+    !-----------------------------------------------------------------------
+    !  routine c_loc_assumed_shape_4d_int32
+    !
+    !> \brief Returns a C_PTR for an array with given dimensions
+    !> \details
+    !>  The Fortran 2003 standard does not permit the use of C_LOC with
+    !>  assumed shape arrays. This routine may be used to obtain a C_PTR for
+    !>  an assumed shape array by invoking the routine with the first actual
+    !>  argument as the assumed-shape array, and subsequent actual arguments
+    !>  as, e.g., SIZE(a,DIM=1).
+    !>
+    !>  Internally, the first dummy argument of this routine can be declared
+    !>  as an explicit shape array, which can then be used as an argument to
+    !>  C_LOC.
+    !>
+    !>  Upon success, a C_PTR for the array argument is returned.
+    !>
+    !>  Note: The actual array argument must not be a zero-sized array.
+    !>        Section 15.1.2.5 of the Fortran 2003 standard specifies that
+    !>        the argument to C_LOC '...is not an array of zero size...'.
+    !
+    !-----------------------------------------------------------------------
+    function c_loc_assumed_shape_4d_int32(a, d1, d2, d3, d4) result(a_ptr)
+
+        use iso_c_binding, only : c_ptr, c_loc, c_int
+
+        implicit none
+
+        ! Arguments
+        integer, intent(in) :: d1, d2, d3, d4
+        integer(kind=c_int), dimension(d1,d2,d3,d4), target, intent(in) :: a
+
+        ! Return value
+        type (c_ptr) :: a_ptr
+
+        a_ptr = c_loc(a)
+
+    end function c_loc_assumed_shape_4d_int32
+
+
+    !-----------------------------------------------------------------------
+    !  routine SMIOLf_put_var_d4_int32
+    !
+    !> \brief Writes a 4-d int32 variable to a file.
+    !> \details
+    !>  Given a SMIOL file that was previously opened with write access and the name
+    !>  of a variable previously defined in the file with a call to SMIOLf_define_var,
+    !>  this routine will write the contents of buf to the variable according to
+    !>  the decomposition described by decomp.
+    !>
+    !>  If decomp is an associated pointer, the variable is assumed to be decomposed
+    !>  across MPI ranks, and all ranks with non-zero-sized partitions of the variable
+    !>  must provide a valid buffer. For decomposed variables, all MPI ranks must provide
+    !>  an associated decomp pointer, regardless of whether a rank has a non-zero-sized
+    !>  partition of the variable.
+    !>
+    !>  If the variable is not decomposed -- that is, all ranks store identical
+    !>  values for the entire variable -- all MPI ranks must provide an unassociated
+    !>  pointer for the decomp argument. As currently implemented, this routine will write
+    !>  the buffer for MPI rank 0 to the variable; however, this behavior should not
+    !>  be relied on.
+    !>
+    !>  If the variable has been successfully written to the file, SMIOL_SUCCESS will
+    !>  be returned. Otherwise, an error code indicating the nature of the failure
+    !>  will be returned.
+    !
+    !-----------------------------------------------------------------------
+    function SMIOLf_put_var_4d_int32(file, varname, decomp, buf) result(ierr)
+
+        use iso_c_binding, only : c_int, c_char, c_loc, c_ptr, c_null_ptr, c_null_char
+
+        implicit none
+
+        ! Arguments
+        type(SMIOLf_file), target :: file
+        character(len=*), intent(in) :: varname
+        type(SMIOLf_decomp), pointer :: decomp
+        integer(kind=c_int), dimension(:,:,:,:), pointer :: buf
+
+        ! Return status code
+        integer :: ierr
+
+        ! Local variables
+        integer :: i
+        character(kind=c_char), dimension(:), pointer :: c_varname
+        type (c_ptr) :: c_file
+        type (c_ptr) :: c_decomp
+        type (c_ptr) :: c_buf
+
+
+        !
+        ! file is a target, so no need to check that it is associated
+        !
+        c_file = c_loc(file)
+
+        !
+        ! decomp may be an unassociated pointer if the corresponding field is
+        ! not decomposed
+        !
+        if (associated(decomp)) then
+            c_decomp = c_loc(decomp)
+        else
+            c_decomp = c_null_ptr
+        end if
+
+        !
+        ! Convert variable name string
+        !
+        allocate(c_varname(len_trim(varname) + 1))
+        do i=1,len_trim(varname)
+            c_varname(i) = varname(i:i)
+        end do
+        c_varname(i) = c_null_char
+
+        !
+        ! buf may be an unassociated pointer if the calling task does not read
+        ! or write any elements of the field
+        !
+        if (associated(buf)) then
+
+            !
+            ! Invoke a Fortran 2003-compliant function to get the c_ptr
+            ! of the assumed shape array buf
+            !
+            c_buf = c_loc_assumed_shape_4d_int32(buf, size(buf,dim=1), size(buf,dim=2), size(buf,dim=3), &
+                                           size(buf,dim=4))
+        else
+            c_buf = c_null_ptr
+        end if
+
+        ierr = SMIOL_put_var(c_file, c_varname, c_decomp, c_buf)
+
+
+        deallocate(c_varname)
+
+    end function SMIOLf_put_var_4d_int32
+
+
+    !-----------------------------------------------------------------------
+    !  routine SMIOLf_get_var_d4_int32
+    !
+    !> \brief Reads a 4-d int32 variable from a file.
+    !> \details
+    !>  Given a SMIOL file and the name of a variable previously defined in the file,
+    !>  this routine will read the contents of the variable into buf according to
+    !>  the decomposition described by decomp.
+    !>
+    !>  If decomp is an associated pointer, the variable is assumed to be decomposed
+    !>  across MPI ranks, and all ranks with non-zero-sized partitions of the variable
+    !>  must provide a valid buffer. For decomposed variables, all MPI ranks must provide
+    !>  an associated decomp pointer, regardless of whether a rank has a non-zero-sized
+    !>  partition of the variable.
+    !>
+    !>  If the variable is not decomposed -- that is, all ranks load identical
+    !>  values for the entire variable -- all MPI ranks must provide an unassociated
+    !>  pointer for the decomp argument.
+    !>
+    !>  If the variable has been successfully read from the file, SMIOL_SUCCESS will
+    !>  be returned. Otherwise, an error code indicating the nature of the failure
+    !>  will be returned.
+    !
+    !-----------------------------------------------------------------------
+    function SMIOLf_get_var_4d_int32(file, varname, decomp, buf) result(ierr)
+
+        use iso_c_binding, only : c_int, c_char, c_loc, c_ptr, c_null_ptr, c_null_char
+
+        implicit none
+
+        ! Arguments
+        type(SMIOLf_file), target :: file
+        character(len=*), intent(in) :: varname
+        type(SMIOLf_decomp), pointer :: decomp
+        integer(kind=c_int), dimension(:,:,:,:), pointer :: buf
+
+        ! Return status code
+        integer :: ierr
+
+        ! Local variables
+        integer :: i
+        character(kind=c_char), dimension(:), pointer :: c_varname
+        type (c_ptr) :: c_file
+        type (c_ptr) :: c_decomp
+        type (c_ptr) :: c_buf
+
+
+        !
+        ! file is a target, so no need to check that it is associated
+        !
+        c_file = c_loc(file)
+
+        !
+        ! decomp may be an unassociated pointer if the corresponding field is
+        ! not decomposed
+        !
+        if (associated(decomp)) then
+            c_decomp = c_loc(decomp)
+        else
+            c_decomp = c_null_ptr
+        end if
+
+        !
+        ! Convert variable name string
+        !
+        allocate(c_varname(len_trim(varname) + 1))
+        do i=1,len_trim(varname)
+            c_varname(i) = varname(i:i)
+        end do
+        c_varname(i) = c_null_char
+
+        !
+        ! buf may be an unassociated pointer if the calling task does not read
+        ! or write any elements of the field
+        !
+        if (associated(buf)) then
+
+            !
+            ! Invoke a Fortran 2003-compliant function to get the c_ptr
+            ! of the assumed shape array buf
+            !
+            c_buf = c_loc_assumed_shape_4d_int32(buf, size(buf,dim=1), size(buf,dim=2), size(buf,dim=3), &
+                                           size(buf,dim=4))
+        else
+            c_buf = c_null_ptr
+        end if
+
+        ierr = SMIOL_get_var(c_file, c_varname, c_decomp, c_buf)
+
+
+        deallocate(c_varname)
+
+    end function SMIOLf_get_var_4d_int32
+
+
+    !-----------------------------------------------------------------------
+    !  routine c_loc_assumed_shape_5d_real32
+    !
+    !> \brief Returns a C_PTR for an array with given dimensions
+    !> \details
+    !>  The Fortran 2003 standard does not permit the use of C_LOC with
+    !>  assumed shape arrays. This routine may be used to obtain a C_PTR for
+    !>  an assumed shape array by invoking the routine with the first actual
+    !>  argument as the assumed-shape array, and subsequent actual arguments
+    !>  as, e.g., SIZE(a,DIM=1).
+    !>
+    !>  Internally, the first dummy argument of this routine can be declared
+    !>  as an explicit shape array, which can then be used as an argument to
+    !>  C_LOC.
+    !>
+    !>  Upon success, a C_PTR for the array argument is returned.
+    !>
+    !>  Note: The actual array argument must not be a zero-sized array.
+    !>        Section 15.1.2.5 of the Fortran 2003 standard specifies that
+    !>        the argument to C_LOC '...is not an array of zero size...'.
+    !
+    !-----------------------------------------------------------------------
+    function c_loc_assumed_shape_5d_real32(a, d1, d2, d3, d4, d5) result(a_ptr)
+
+        use iso_c_binding, only : c_ptr, c_loc, c_float
+
+        implicit none
+
+        ! Arguments
+        integer, intent(in) :: d1, d2, d3, d4, d5
+        real(kind=c_float), dimension(d1,d2,d3,d4,d5), target, intent(in) :: a
+
+        ! Return value
+        type (c_ptr) :: a_ptr
+
+        a_ptr = c_loc(a)
+
+    end function c_loc_assumed_shape_5d_real32
+
+
+    !-----------------------------------------------------------------------
+    !  routine SMIOLf_put_var_d5_real32
+    !
+    !> \brief Writes a 5-d real32 variable to a file.
+    !> \details
+    !>  Given a SMIOL file that was previously opened with write access and the name
+    !>  of a variable previously defined in the file with a call to SMIOLf_define_var,
+    !>  this routine will write the contents of buf to the variable according to
+    !>  the decomposition described by decomp.
+    !>
+    !>  If decomp is an associated pointer, the variable is assumed to be decomposed
+    !>  across MPI ranks, and all ranks with non-zero-sized partitions of the variable
+    !>  must provide a valid buffer. For decomposed variables, all MPI ranks must provide
+    !>  an associated decomp pointer, regardless of whether a rank has a non-zero-sized
+    !>  partition of the variable.
+    !>
+    !>  If the variable is not decomposed -- that is, all ranks store identical
+    !>  values for the entire variable -- all MPI ranks must provide an unassociated
+    !>  pointer for the decomp argument. As currently implemented, this routine will write
+    !>  the buffer for MPI rank 0 to the variable; however, this behavior should not
+    !>  be relied on.
+    !>
+    !>  If the variable has been successfully written to the file, SMIOL_SUCCESS will
+    !>  be returned. Otherwise, an error code indicating the nature of the failure
+    !>  will be returned.
+    !
+    !-----------------------------------------------------------------------
+    function SMIOLf_put_var_5d_real32(file, varname, decomp, buf) result(ierr)
+
+        use iso_c_binding, only : c_float, c_char, c_loc, c_ptr, c_null_ptr, c_null_char
+
+        implicit none
+
+        ! Arguments
+        type(SMIOLf_file), target :: file
+        character(len=*), intent(in) :: varname
+        type(SMIOLf_decomp), pointer :: decomp
+        real(kind=c_float), dimension(:,:,:,:,:), pointer :: buf
+
+        ! Return status code
+        integer :: ierr
+
+        ! Local variables
+        integer :: i
+        character(kind=c_char), dimension(:), pointer :: c_varname
+        type (c_ptr) :: c_file
+        type (c_ptr) :: c_decomp
+        type (c_ptr) :: c_buf
+
+
+        !
+        ! file is a target, so no need to check that it is associated
+        !
+        c_file = c_loc(file)
+
+        !
+        ! decomp may be an unassociated pointer if the corresponding field is
+        ! not decomposed
+        !
+        if (associated(decomp)) then
+            c_decomp = c_loc(decomp)
+        else
+            c_decomp = c_null_ptr
+        end if
+
+        !
+        ! Convert variable name string
+        !
+        allocate(c_varname(len_trim(varname) + 1))
+        do i=1,len_trim(varname)
+            c_varname(i) = varname(i:i)
+        end do
+        c_varname(i) = c_null_char
+
+        !
+        ! buf may be an unassociated pointer if the calling task does not read
+        ! or write any elements of the field
+        !
+        if (associated(buf)) then
+
+            !
+            ! Invoke a Fortran 2003-compliant function to get the c_ptr
+            ! of the assumed shape array buf
+            !
+            c_buf = c_loc_assumed_shape_5d_real32(buf, size(buf,dim=1), size(buf,dim=2), size(buf,dim=3), &
+                                           size(buf,dim=4), size(buf,dim=5))
+        else
+            c_buf = c_null_ptr
+        end if
+
+        ierr = SMIOL_put_var(c_file, c_varname, c_decomp, c_buf)
+
+
+        deallocate(c_varname)
+
+    end function SMIOLf_put_var_5d_real32
+
+
+    !-----------------------------------------------------------------------
+    !  routine SMIOLf_get_var_d5_real32
+    !
+    !> \brief Reads a 5-d real32 variable from a file.
+    !> \details
+    !>  Given a SMIOL file and the name of a variable previously defined in the file,
+    !>  this routine will read the contents of the variable into buf according to
+    !>  the decomposition described by decomp.
+    !>
+    !>  If decomp is an associated pointer, the variable is assumed to be decomposed
+    !>  across MPI ranks, and all ranks with non-zero-sized partitions of the variable
+    !>  must provide a valid buffer. For decomposed variables, all MPI ranks must provide
+    !>  an associated decomp pointer, regardless of whether a rank has a non-zero-sized
+    !>  partition of the variable.
+    !>
+    !>  If the variable is not decomposed -- that is, all ranks load identical
+    !>  values for the entire variable -- all MPI ranks must provide an unassociated
+    !>  pointer for the decomp argument.
+    !>
+    !>  If the variable has been successfully read from the file, SMIOL_SUCCESS will
+    !>  be returned. Otherwise, an error code indicating the nature of the failure
+    !>  will be returned.
+    !
+    !-----------------------------------------------------------------------
+    function SMIOLf_get_var_5d_real32(file, varname, decomp, buf) result(ierr)
+
+        use iso_c_binding, only : c_float, c_char, c_loc, c_ptr, c_null_ptr, c_null_char
+
+        implicit none
+
+        ! Arguments
+        type(SMIOLf_file), target :: file
+        character(len=*), intent(in) :: varname
+        type(SMIOLf_decomp), pointer :: decomp
+        real(kind=c_float), dimension(:,:,:,:,:), pointer :: buf
+
+        ! Return status code
+        integer :: ierr
+
+        ! Local variables
+        integer :: i
+        character(kind=c_char), dimension(:), pointer :: c_varname
+        type (c_ptr) :: c_file
+        type (c_ptr) :: c_decomp
+        type (c_ptr) :: c_buf
+
+
+        !
+        ! file is a target, so no need to check that it is associated
+        !
+        c_file = c_loc(file)
+
+        !
+        ! decomp may be an unassociated pointer if the corresponding field is
+        ! not decomposed
+        !
+        if (associated(decomp)) then
+            c_decomp = c_loc(decomp)
+        else
+            c_decomp = c_null_ptr
+        end if
+
+        !
+        ! Convert variable name string
+        !
+        allocate(c_varname(len_trim(varname) + 1))
+        do i=1,len_trim(varname)
+            c_varname(i) = varname(i:i)
+        end do
+        c_varname(i) = c_null_char
+
+        !
+        ! buf may be an unassociated pointer if the calling task does not read
+        ! or write any elements of the field
+        !
+        if (associated(buf)) then
+
+            !
+            ! Invoke a Fortran 2003-compliant function to get the c_ptr
+            ! of the assumed shape array buf
+            !
+            c_buf = c_loc_assumed_shape_5d_real32(buf, size(buf,dim=1), size(buf,dim=2), size(buf,dim=3), &
+                                           size(buf,dim=4), size(buf,dim=5))
+        else
+            c_buf = c_null_ptr
+        end if
+
+        ierr = SMIOL_get_var(c_file, c_varname, c_decomp, c_buf)
+
+
+        deallocate(c_varname)
+
+    end function SMIOLf_get_var_5d_real32
+
+
+    !-----------------------------------------------------------------------
+    !  routine c_loc_assumed_shape_5d_real64
+    !
+    !> \brief Returns a C_PTR for an array with given dimensions
+    !> \details
+    !>  The Fortran 2003 standard does not permit the use of C_LOC with
+    !>  assumed shape arrays. This routine may be used to obtain a C_PTR for
+    !>  an assumed shape array by invoking the routine with the first actual
+    !>  argument as the assumed-shape array, and subsequent actual arguments
+    !>  as, e.g., SIZE(a,DIM=1).
+    !>
+    !>  Internally, the first dummy argument of this routine can be declared
+    !>  as an explicit shape array, which can then be used as an argument to
+    !>  C_LOC.
+    !>
+    !>  Upon success, a C_PTR for the array argument is returned.
+    !>
+    !>  Note: The actual array argument must not be a zero-sized array.
+    !>        Section 15.1.2.5 of the Fortran 2003 standard specifies that
+    !>        the argument to C_LOC '...is not an array of zero size...'.
+    !
+    !-----------------------------------------------------------------------
+    function c_loc_assumed_shape_5d_real64(a, d1, d2, d3, d4, d5) result(a_ptr)
+
+        use iso_c_binding, only : c_ptr, c_loc, c_double
+
+        implicit none
+
+        ! Arguments
+        integer, intent(in) :: d1, d2, d3, d4, d5
+        real(kind=c_double), dimension(d1,d2,d3,d4,d5), target, intent(in) :: a
+
+        ! Return value
+        type (c_ptr) :: a_ptr
+
+        a_ptr = c_loc(a)
+
+    end function c_loc_assumed_shape_5d_real64
+
+
+    !-----------------------------------------------------------------------
+    !  routine SMIOLf_put_var_d5_real64
+    !
+    !> \brief Writes a 5-d real64 variable to a file.
+    !> \details
+    !>  Given a SMIOL file that was previously opened with write access and the name
+    !>  of a variable previously defined in the file with a call to SMIOLf_define_var,
+    !>  this routine will write the contents of buf to the variable according to
+    !>  the decomposition described by decomp.
+    !>
+    !>  If decomp is an associated pointer, the variable is assumed to be decomposed
+    !>  across MPI ranks, and all ranks with non-zero-sized partitions of the variable
+    !>  must provide a valid buffer. For decomposed variables, all MPI ranks must provide
+    !>  an associated decomp pointer, regardless of whether a rank has a non-zero-sized
+    !>  partition of the variable.
+    !>
+    !>  If the variable is not decomposed -- that is, all ranks store identical
+    !>  values for the entire variable -- all MPI ranks must provide an unassociated
+    !>  pointer for the decomp argument. As currently implemented, this routine will write
+    !>  the buffer for MPI rank 0 to the variable; however, this behavior should not
+    !>  be relied on.
+    !>
+    !>  If the variable has been successfully written to the file, SMIOL_SUCCESS will
+    !>  be returned. Otherwise, an error code indicating the nature of the failure
+    !>  will be returned.
+    !
+    !-----------------------------------------------------------------------
+    function SMIOLf_put_var_5d_real64(file, varname, decomp, buf) result(ierr)
+
+        use iso_c_binding, only : c_double, c_char, c_loc, c_ptr, c_null_ptr, c_null_char
+
+        implicit none
+
+        ! Arguments
+        type(SMIOLf_file), target :: file
+        character(len=*), intent(in) :: varname
+        type(SMIOLf_decomp), pointer :: decomp
+        real(kind=c_double), dimension(:,:,:,:,:), pointer :: buf
+
+        ! Return status code
+        integer :: ierr
+
+        ! Local variables
+        integer :: i
+        character(kind=c_char), dimension(:), pointer :: c_varname
+        type (c_ptr) :: c_file
+        type (c_ptr) :: c_decomp
+        type (c_ptr) :: c_buf
+
+
+        !
+        ! file is a target, so no need to check that it is associated
+        !
+        c_file = c_loc(file)
+
+        !
+        ! decomp may be an unassociated pointer if the corresponding field is
+        ! not decomposed
+        !
+        if (associated(decomp)) then
+            c_decomp = c_loc(decomp)
+        else
+            c_decomp = c_null_ptr
+        end if
+
+        !
+        ! Convert variable name string
+        !
+        allocate(c_varname(len_trim(varname) + 1))
+        do i=1,len_trim(varname)
+            c_varname(i) = varname(i:i)
+        end do
+        c_varname(i) = c_null_char
+
+        !
+        ! buf may be an unassociated pointer if the calling task does not read
+        ! or write any elements of the field
+        !
+        if (associated(buf)) then
+
+            !
+            ! Invoke a Fortran 2003-compliant function to get the c_ptr
+            ! of the assumed shape array buf
+            !
+            c_buf = c_loc_assumed_shape_5d_real64(buf, size(buf,dim=1), size(buf,dim=2), size(buf,dim=3), &
+                                           size(buf,dim=4), size(buf,dim=5))
+        else
+            c_buf = c_null_ptr
+        end if
+
+        ierr = SMIOL_put_var(c_file, c_varname, c_decomp, c_buf)
+
+
+        deallocate(c_varname)
+
+    end function SMIOLf_put_var_5d_real64
+
+
+    !-----------------------------------------------------------------------
+    !  routine SMIOLf_get_var_d5_real64
+    !
+    !> \brief Reads a 5-d real64 variable from a file.
+    !> \details
+    !>  Given a SMIOL file and the name of a variable previously defined in the file,
+    !>  this routine will read the contents of the variable into buf according to
+    !>  the decomposition described by decomp.
+    !>
+    !>  If decomp is an associated pointer, the variable is assumed to be decomposed
+    !>  across MPI ranks, and all ranks with non-zero-sized partitions of the variable
+    !>  must provide a valid buffer. For decomposed variables, all MPI ranks must provide
+    !>  an associated decomp pointer, regardless of whether a rank has a non-zero-sized
+    !>  partition of the variable.
+    !>
+    !>  If the variable is not decomposed -- that is, all ranks load identical
+    !>  values for the entire variable -- all MPI ranks must provide an unassociated
+    !>  pointer for the decomp argument.
+    !>
+    !>  If the variable has been successfully read from the file, SMIOL_SUCCESS will
+    !>  be returned. Otherwise, an error code indicating the nature of the failure
+    !>  will be returned.
+    !
+    !-----------------------------------------------------------------------
+    function SMIOLf_get_var_5d_real64(file, varname, decomp, buf) result(ierr)
+
+        use iso_c_binding, only : c_double, c_char, c_loc, c_ptr, c_null_ptr, c_null_char
+
+        implicit none
+
+        ! Arguments
+        type(SMIOLf_file), target :: file
+        character(len=*), intent(in) :: varname
+        type(SMIOLf_decomp), pointer :: decomp
+        real(kind=c_double), dimension(:,:,:,:,:), pointer :: buf
+
+        ! Return status code
+        integer :: ierr
+
+        ! Local variables
+        integer :: i
+        character(kind=c_char), dimension(:), pointer :: c_varname
+        type (c_ptr) :: c_file
+        type (c_ptr) :: c_decomp
+        type (c_ptr) :: c_buf
+
+
+        !
+        ! file is a target, so no need to check that it is associated
+        !
+        c_file = c_loc(file)
+
+        !
+        ! decomp may be an unassociated pointer if the corresponding field is
+        ! not decomposed
+        !
+        if (associated(decomp)) then
+            c_decomp = c_loc(decomp)
+        else
+            c_decomp = c_null_ptr
+        end if
+
+        !
+        ! Convert variable name string
+        !
+        allocate(c_varname(len_trim(varname) + 1))
+        do i=1,len_trim(varname)
+            c_varname(i) = varname(i:i)
+        end do
+        c_varname(i) = c_null_char
+
+        !
+        ! buf may be an unassociated pointer if the calling task does not read
+        ! or write any elements of the field
+        !
+        if (associated(buf)) then
+
+            !
+            ! Invoke a Fortran 2003-compliant function to get the c_ptr
+            ! of the assumed shape array buf
+            !
+            c_buf = c_loc_assumed_shape_5d_real64(buf, size(buf,dim=1), size(buf,dim=2), size(buf,dim=3), &
+                                           size(buf,dim=4), size(buf,dim=5))
+        else
+            c_buf = c_null_ptr
+        end if
+
+        ierr = SMIOL_get_var(c_file, c_varname, c_decomp, c_buf)
+
+
+        deallocate(c_varname)
+
+    end function SMIOLf_get_var_5d_real64
+
+


### PR DESCRIPTION
This merge implements Fortran interfaces to the C `SMIOL_put_var` and
`SMIOL_get_var` routines. The SMIOL Fortran module provides these interfaces via
the generic interfaces `SMIOLf_put_var` and `SMIOLf_get_var`, which have field type- 
and dimension-specific implementation in a separate file. The specific
implementations are all generated by a shell script, which is not run at compile
time, but must be manually run in order to re-generate the Fortran routines.

Also included in this merge are several unit tests for a subset of the new
Fortran routines.