### PR TITLE
Initialize char_buf in SMIOLf_get_var_0d_char to avoid returning garbage

### DIFF
--- a/src/gen_put_get.sh
+++ b/src/gen_put_get.sh
@@ -54,7 +54,14 @@ gen_put_get_var()
 
         else
 
-            char_copyin="            allocate(char_buf(len(buf)))"
+            char_copyin="            allocate(char_buf(len(buf)))
+
+            ! In case buf contains more characters than will be read from the file,
+            ! initialize char_buf with the contents of buf to preserve un-read
+            ! characters during the copy of char_buf back into buf later on
+            do i=1,len(buf)
+                char_buf(i) = buf(i:i)
+            end do"
 
             char_copyout="        if (associated(buf)) then
             do i=1,len(buf)

--- a/src/smiolf_put_get_var.inc
+++ b/src/smiolf_put_get_var.inc
@@ -173,6 +173,13 @@
         !
         if (associated(buf)) then
             allocate(char_buf(len(buf)))
+
+            ! In case buf contains more characters than will be read from the file,
+            ! initialize char_buf with the contents of buf to preserve un-read
+            ! characters during the copy of char_buf back into buf later on
+            do i=1,len(buf)
+                char_buf(i) = buf(i:i)
+            end do
             c_buf = c_loc(char_buf)
         else
             c_buf = c_null_ptr


### PR DESCRIPTION
This merge initializes the char_buf array in SMIOLf_get_var_0d_char to avoid
potentially returning trailing garbage characters.

The SMIOLf_get_var_0d_char routine internally allocates a character array,
char_buf, into which the requested variable is read; char_buf is then
transferred to the actual output argument, which is a Fortran string.

In cases where the actual argument supplied by the caller is longer than
the size of the variable read from a file, trailing bytes in char_buf would be
uninitialized, and would therefore result in trailing garbage being returned to
the caller even if the caller had initialized the actual argument before
the call to SMIOLf_get_var_0d_char.

This merge adds a loop to initialize char_buf with the contents of buf in
the SMIOLf_get_var_0d_char routine immediately after char_buf has been allocated,
so that any un-read bytes will be preserved with their value just before the call
to SMIOLf_get_var_0d_char.