### PR TITLE
Initialize contents of SMIOL_decomp struct after allocation in build_exchange

### DIFF
--- a/src/smiol_utils.c
+++ b/src/smiol_utils.c
@@ -712,7 +712,14 @@ int build_exchange(struct SMIOL_context *context,
 		return SMIOL_MALLOC_FAILURE;
 	}
 
+	/*
+	 * Initialize the SMIOL_decomp struct
+	 */
 	(*decomp)->context = context;
+	(*decomp)->comp_list = NULL;
+	(*decomp)->io_list = NULL;
+	(*decomp)->io_start = 0;
+	(*decomp)->io_count = 0;
 
 
 	/*


### PR DESCRIPTION
This merge adds code to initialize the contents of SMIOL_decomp structs that are
allocated by the build_exchange routine.

This initialization doesn't fix any known bugs, but it does provide a reference
point for initialization of any members of the SMIOL_decomp struct that might be
added in future.