### PR TITLE
Make num_io_tasks and io_stride part of the SMIOL_context struct

### DIFF
--- a/src/smiol.h
+++ b/src/smiol.h
@@ -10,8 +10,10 @@
 /*
  * Library methods
  */
-int SMIOL_fortran_init(MPI_Fint comm, struct SMIOL_context **context);
-int SMIOL_init(MPI_Comm comm, struct SMIOL_context **context);
+int SMIOL_fortran_init(MPI_Fint comm, int num_io_tasks, int io_stride,
+                       struct SMIOL_context **context);
+int SMIOL_init(MPI_Comm comm, int num_io_tasks, int io_stride,
+               struct SMIOL_context **context);
 int SMIOL_finalize(struct SMIOL_context **context);
 int SMIOL_inquire(void);
 
@@ -63,7 +65,6 @@ int SMIOL_get_frame(struct SMIOL_file *file, SMIOL_Offset *frame);
  */
 int SMIOL_create_decomp(struct SMIOL_context *context,
                         size_t n_compute_elements, SMIOL_Offset *compute_elements,
-                        int num_io_tasks, int io_stride,
                         struct SMIOL_decomp **decomp);
 int SMIOL_free_decomp(struct SMIOL_decomp **decomp);
 

--- a/src/smiol_types.h
+++ b/src/smiol_types.h
@@ -19,12 +19,15 @@ typedef int64_t SMIOL_Offset;
  * Types
  */
 struct SMIOL_context {
-	MPI_Fint fcomm; /* Fortran handle to MPI communicator */
-	int comm_size;  /* Size of MPI communicator */
-	int comm_rank;  /* Rank within MPI communicator */
+	MPI_Fint fcomm;   /* Fortran handle to MPI communicator */
+	int comm_size;    /* Size of MPI communicator */
+	int comm_rank;    /* Rank within MPI communicator */
 
-	int lib_ierr;   /* Library-specific error code */
-	int lib_type;   /* From which library the error code originated */
+	int num_io_tasks; /* The number of I/O tasks */
+	int io_stride;    /* The stride between I/O tasks in the communicator */
+
+	int lib_ierr;     /* Library-specific error code */
+	int lib_type;     /* From which library the error code originated */
 };
 
 struct SMIOL_file {


### PR DESCRIPTION
This merge makes num_io_tasks and io_stride part of the SMIOL context,
so that all decompositions created within a context inherit these values
from the context.

Prior to this merge, values for num_io_tasks and io_stride were provided in
the call to SMIOL_create_decomp. This provided the flexibility to have different
sets of tasks reading from or writing to the same file when variables used
decompositions with different num_io_tasks and io_stride values.

In practice, however, all decompositions created by MPAS will use the same
num_io_tasks and io_stride values. Furthermore, being able to guarantee that all
variables in a file are read or written with the same set of I/O tasks may
provide opportunities for optimization.