### PR TITLE
Add aggregate_list utility function, along with unit tests

### DIFF
--- a/src/smiol_utils.h
+++ b/src/smiol_utils.h
@@ -24,6 +24,10 @@ SMIOL_Offset *search_triplet_array(SMIOL_Offset key,
 int transfer_field(const struct SMIOL_decomp *decomp, int dir,
                    size_t element_size, const void *in_field, void *out_field);
 
+int aggregate_list(MPI_Comm comm, int root, size_t n_in, SMIOL_Offset *in_list,
+                   size_t *n_out, SMIOL_Offset **out_list,
+                   int **counts, int **displs);
+
 /*
  * Field decomposition
  */


### PR DESCRIPTION
This PR adds a new utility function, `aggregate_list`, that may be used to
gather arbitrarily sized lists of `SMIOL_Offset` values from all ranks in
a communicator onto a chosen root task in the communicator.