### PR TITLE
Add file format argument to SMIOL_open_file

### DIFF
--- a/smiol_runner.F90
+++ b/smiol_runner.F90
@@ -349,6 +349,8 @@ program smiol_runner
                trim(SMIOLf_error_string(SMIOL_WRONG_ARG_TYPE))
     write(test_log,'(a)') "Testing SMIOL_error_string 'argument is of insufficient size': ", &
                trim(SMIOLf_error_string(SMIOL_INSUFFICIENT_ARG))
+    write(test_log,'(a)') "Testing SMIOL_error_string 'invalid format for file creation': ", &
+               trim(SMIOLf_error_string(SMIOL_INVALID_FORMAT))
 
     if (SMIOLf_finalize(context) /= SMIOL_SUCCESS) then
         write(test_log,'(a)') "ERROR: 'SMIOLf_finalize' was not called successfully"

--- a/smiol_runner.F90
+++ b/smiol_runner.F90
@@ -505,6 +505,58 @@ contains
             ierrcount = ierrcount + 1
         end if
 
+        ! Try to create a file with an invalid format
+        write(test_log,'(a)', advance='no') 'Try to create a file with an invalid file format: '
+        nullify(file)
+        ierr = SMIOLf_open_file(context, 'smiolf_invalid_frmt.nc', &
+                                SMIOL_FILE_CREATE, file, &
+                                fformat=not(ior(SMIOL_FORMAT_CDF2, SMIOL_FORMAT_CDF5)))
+        if (ierr == SMIOL_INVALID_FORMAT .and. .not. associated(file)) then
+            write(test_log,'(a)') 'PASS'
+        else
+            write(test_log, '(a)') 'FAIL - expected error code of SMIOL_INVALID_FORMT not returned, or file handle is associated'
+            ierrcount = ierrcount + 1
+        end if
+
+        ! Try to create the file with the other, optional file format that needs to be requested
+        write(test_log,'(a)', advance='no') 'Try to create a file with CDF2 file format: '
+        nullify(file)
+        ierr = SMIOLf_open_file(context, 'smiolf_cdf2.nc', &
+                                SMIOL_FILE_CREATE, file, &
+                                fformat=SMIOL_FORMAT_CDF2)
+        if (ierr == SMIOL_SUCCESS .and. associated(file)) then
+            ierr = SMIOLf_close_file(file)
+            if (ierr == SMIOL_SUCCESS) then
+               write(test_log,'(a)') 'PASS'
+            else
+               write(test_log,'(a)') 'FAIL - unable to close newly created CDF2 format file'
+               ierrcount = ierrcount + 1
+            end if
+        else
+            write(test_log, '(a)') 'FAIL - unable to create file of CDF2 format'
+            ierrcount = ierrcount + 1
+        end if
+
+        ! Try to open a file with an invalid file format (ensure fformat is ignored for opening files)
+        write(test_log,'(a)', advance='no') 'Try to open a file with an ignored invalid file format: '
+        nullify(file)
+        ierr = SMIOLf_open_file(context, 'smiolf_cdf2.nc', &
+                                SMIOL_FILE_READ, file, &
+                                fformat=not(ior(SMIOL_FORMAT_CDF2, SMIOL_FORMAT_CDF5)))
+        if (ierr == SMIOL_SUCCESS .and. associated(file)) then
+            ierr = SMIOLf_close_file(file)
+            if (ierr == SMIOL_SUCCESS) then
+               write(test_log,'(a)') 'PASS'
+            else
+               write(test_log,'(a)') 'FAIL - unable to close file opened with an ignored invalid file format'
+               ierrcount = ierrcount + 1
+            end if
+        else
+            write(test_log,'(a)') 'FAIL - unable to open file with an ignored invalid file format'
+            ierrcount = ierrcount + 1
+        end if
+
+
 #ifdef SMIOL_PNETCDF
         ! Try to create a file for which we should not have sufficient permissions
         write(test_log,'(a)',advance='no') 'Try to create a file with insufficient permissions: '

--- a/smiol_runner.c
+++ b/smiol_runner.c
@@ -491,6 +491,8 @@ int main(int argc, char **argv)
 		SMIOL_error_string(SMIOL_WRONG_ARG_TYPE));
 	fprintf(test_log, "SMIOL_error_string test 'argument is of insufficient size': %s\n",
 		SMIOL_error_string(SMIOL_INSUFFICIENT_ARG));
+	fprintf(test_log, "SMIOL_error_string test 'invalid format for file creation': %s\n",
+		SMIOL_error_string(SMIOL_INVALID_FORMAT));
 
 	if ((ierr = SMIOL_finalize(&context)) != SMIOL_SUCCESS) {
 		fprintf(test_log, "ERROR: SMIOL_finalize: %s ", SMIOL_error_string(ierr));

--- a/smiol_runner.c
+++ b/smiol_runner.c
@@ -671,6 +671,57 @@ int test_open_close(FILE *test_log)
 		errcount++;
 	}
 
+	/* Try to create a file with an invalid file format */
+	fprintf(test_log, "Try to create a file with an invalid file format: ");
+	file = NULL;
+	ierr = SMIOL_open_file(context, "smiol_invalid_fformat.nc", SMIOL_FILE_CREATE, &file, (size_t)64000000, ~(SMIOL_FORMAT_CDF2 | SMIOL_FORMAT_CDF5));
+	if (ierr == SMIOL_INVALID_FORMAT && file == NULL){
+		fprintf(test_log, "PASS\n");
+	}
+	else {
+		fprintf(test_log, "FAIL - expected error code of SMIOL_INVALID_FORMAT not returned or file not NULL\n");
+		errcount++;
+	}
+
+	/* Try to create a file with the so far unused file format */
+	fprintf(test_log, "Try to create a file with CDF2 file format: ");
+	file = NULL;
+	ierr = SMIOL_open_file(context, "smiol_cdf2.nc", SMIOL_FILE_CREATE, &file, (size_t)64000000, SMIOL_FORMAT_CDF2);
+	if (ierr == SMIOL_SUCCESS && file != NULL){
+		ierr = SMIOL_close_file(&file);
+		if (ierr == SMIOL_SUCCESS){
+			fprintf(test_log, "PASS\n");
+		}
+		else {
+			fprintf(test_log, "FAIL - unable to close newly created CDF2 format file\n");
+			errcount++;
+		}
+	}
+	else {
+		fprintf(test_log, "FAIL - unable to create file of CDF2 format\n");
+		errcount++;
+	}
+
+	/* Try open a file with an invalid file format (ensure fformat is ignored for opening files) */
+	fprintf(test_log,"Try to open a file with an ignored invalid file format: ");
+	file = NULL;
+	ierr = SMIOL_open_file(context, "smiol_cdf2.nc", SMIOL_FILE_READ, &file, (size_t)64000000, ~(SMIOL_FORMAT_CDF2 | SMIOL_FORMAT_CDF5));
+	if (ierr == SMIOL_SUCCESS && file != NULL){
+		ierr = SMIOL_close_file(&file);
+		if (ierr == SMIOL_SUCCESS){
+			fprintf(test_log, "PASS\n");
+		}
+		else {
+			fprintf(test_log, "FAIL - unable to close file opened with an ignored invalid file format\n");
+			errcount++;
+		}
+	}
+	else {
+		fprintf(test_log, "FAIL - unable to open file with an ignored invalid file format\n");
+		errcount++;
+	}
+
+
 #ifdef SMIOL_PNETCDF
 	/* Try to create a file for which we should not have sufficient permissions */
 	fprintf(test_log, "Try to create a file with insufficient permissions: ");

--- a/smiol_runner.c
+++ b/smiol_runner.c
@@ -369,7 +369,8 @@ int main(int argc, char **argv)
 		return 1;
 	}
 
-	if ((ierr = SMIOL_open_file(context, "blah.nc", SMIOL_FILE_CREATE, &file, (size_t)64000000)) != SMIOL_SUCCESS) {
+	if ((ierr = SMIOL_open_file(context, "blah.nc", SMIOL_FILE_CREATE, &file,
+	                            (size_t)64000000, SMIOL_FORMAT_CDF5)) != SMIOL_SUCCESS) {
 		fprintf(test_log, "ERROR: SMIOL_open_file: %s ",
 			SMIOL_error_string(ierr));
 		return 1;
@@ -661,7 +662,7 @@ int test_open_close(FILE *test_log)
 	/* Try to open a file with an invalid mode */
 	fprintf(test_log, "Try to open a file with an invalid mode: ");
 	file = NULL;
-	ierr = SMIOL_open_file(context, "smiol_invalid.nc", ~(SMIOL_FILE_CREATE | SMIOL_FILE_WRITE | SMIOL_FILE_READ), &file, (size_t)64000000);
+	ierr = SMIOL_open_file(context, "smiol_invalid.nc", ~(SMIOL_FILE_CREATE | SMIOL_FILE_WRITE | SMIOL_FILE_READ), &file, (size_t)64000000, SMIOL_FORMAT_CDF5);
 	if (ierr == SMIOL_INVALID_ARGUMENT && file == NULL) {
 		fprintf(test_log, "PASS\n");
 	}
@@ -674,7 +675,7 @@ int test_open_close(FILE *test_log)
 	/* Try to create a file for which we should not have sufficient permissions */
 	fprintf(test_log, "Try to create a file with insufficient permissions: ");
 	file = NULL;
-	ierr = SMIOL_open_file(context, "/smiol_test.nc", SMIOL_FILE_CREATE, &file, (size_t)64000000);
+	ierr = SMIOL_open_file(context, "/smiol_test.nc", SMIOL_FILE_CREATE, &file, (size_t)64000000, SMIOL_FORMAT_CDF5);
 	if (ierr == SMIOL_LIBRARY_ERROR && file == NULL) {
 		fprintf(test_log, "PASS (%s)\n", SMIOL_lib_error_string(context));
 	}
@@ -686,7 +687,7 @@ int test_open_close(FILE *test_log)
 	/* Try to open a file that does not exist */
 	fprintf(test_log, "Try to open a non-existent file: ");
 	file = NULL;
-	ierr = SMIOL_open_file(context, "/smiol_foobar.nc", SMIOL_FILE_READ, &file, (size_t)0);
+	ierr = SMIOL_open_file(context, "/smiol_foobar.nc", SMIOL_FILE_READ, &file, (size_t)0, SMIOL_FORMAT_CDF5);
 	if (ierr == SMIOL_LIBRARY_ERROR && file == NULL) {
 		fprintf(test_log, "PASS (%s)\n", SMIOL_lib_error_string(context));
 	}
@@ -721,7 +722,7 @@ int test_open_close(FILE *test_log)
 	/* Create a file to be closed and opened again */
 	fprintf(test_log, "Create a file to be closed and later re-opened: ");
 	file = NULL;
-	ierr = SMIOL_open_file(context, "pnetcdf_test_c.nc", SMIOL_FILE_CREATE, &file, (size_t)64000000);
+	ierr = SMIOL_open_file(context, "pnetcdf_test_c.nc", SMIOL_FILE_CREATE, &file, (size_t)64000000, SMIOL_FORMAT_CDF5);
 	if (ierr == SMIOL_SUCCESS && file != NULL) {
 		fprintf(test_log, "PASS\n");
 	}
@@ -744,7 +745,7 @@ int test_open_close(FILE *test_log)
 	/* Re-open the file with read access */
 	fprintf(test_log, "Re-open file with read access: ");
 	file = NULL;
-	ierr = SMIOL_open_file(context, "pnetcdf_test_c.nc", SMIOL_FILE_READ, &file, (size_t)0);
+	ierr = SMIOL_open_file(context, "pnetcdf_test_c.nc", SMIOL_FILE_READ, &file, (size_t)0, SMIOL_FORMAT_CDF5);
 	if (ierr == SMIOL_SUCCESS && file != NULL) {
 		fprintf(test_log, "PASS\n");
 	}
@@ -767,7 +768,7 @@ int test_open_close(FILE *test_log)
 	/* Re-open the file with write access */
 	fprintf(test_log, "Re-open file with write access: ");
 	file = NULL;
-	ierr = SMIOL_open_file(context, "pnetcdf_test_c.nc", SMIOL_FILE_WRITE, &file, (size_t)64000000);
+	ierr = SMIOL_open_file(context, "pnetcdf_test_c.nc", SMIOL_FILE_WRITE, &file, (size_t)64000000, SMIOL_FORMAT_CDF5);
 	if (ierr == SMIOL_SUCCESS && file != NULL) {
 		fprintf(test_log, "PASS\n");
 	}
@@ -791,7 +792,7 @@ int test_open_close(FILE *test_log)
 	/* Everything OK (SMIOL_open_file) */
 	fprintf(test_log, "Everything OK (SMIOL_open_file): ");
 	file = NULL;
-	ierr = SMIOL_open_file(context, "test.nc", SMIOL_FILE_CREATE, &file, (size_t)64000000);
+	ierr = SMIOL_open_file(context, "test.nc", SMIOL_FILE_CREATE, &file, (size_t)64000000, SMIOL_FORMAT_CDF5);
 	if (ierr == SMIOL_SUCCESS && file != NULL) {
 		fprintf(test_log, "PASS\n");
 	}
@@ -2083,7 +2084,7 @@ int test_dimensions(FILE *test_log)
 
 	/* Create a SMIOL file for testing dimension routines */
 	file = NULL;
-	ierr = SMIOL_open_file(context, "test_dims.nc", SMIOL_FILE_CREATE, &file, (size_t)64000000);
+	ierr = SMIOL_open_file(context, "test_dims.nc", SMIOL_FILE_CREATE, &file, (size_t)64000000, SMIOL_FORMAT_CDF5);
 	if (ierr != SMIOL_SUCCESS || file == NULL) {
 		fprintf(test_log, "Failed to create SMIOL file...\n");
 		return -1;
@@ -2310,7 +2311,7 @@ int test_dimensions(FILE *test_log)
 
 	/* Re-open the SMIOL file */
 	file = NULL;
-	ierr = SMIOL_open_file(context, "test_dims.nc", SMIOL_FILE_READ, &file, (size_t)0);
+	ierr = SMIOL_open_file(context, "test_dims.nc", SMIOL_FILE_READ, &file, (size_t)0, SMIOL_FORMAT_CDF5);
 	if (ierr != SMIOL_SUCCESS || file == NULL) {
 		fprintf(test_log, "Failed to open existing SMIOL file...\n");
 		return -1;
@@ -2443,7 +2444,7 @@ int test_variables(FILE *test_log)
 
 	/* Create a SMIOL file for testing variable routines */
 	file = NULL;
-	ierr = SMIOL_open_file(context, "test_vars.nc", SMIOL_FILE_CREATE, &file, (size_t)64000000);
+	ierr = SMIOL_open_file(context, "test_vars.nc", SMIOL_FILE_CREATE, &file, (size_t)64000000, SMIOL_FORMAT_CDF5);
 	if (ierr != SMIOL_SUCCESS || file == NULL) {
 		fprintf(test_log, "Failed to create SMIOL file...\n");
 		return -1;
@@ -2734,7 +2735,7 @@ int test_variables(FILE *test_log)
 
 	/* Re-open the SMIOL file */
 	file = NULL;
-	ierr = SMIOL_open_file(context, "test_vars.nc", SMIOL_FILE_READ, &file, (size_t)0);
+	ierr = SMIOL_open_file(context, "test_vars.nc", SMIOL_FILE_READ, &file, (size_t)0, SMIOL_FORMAT_CDF5);
 	if (ierr != SMIOL_SUCCESS || file == NULL) {
 		fprintf(test_log, "Failed to re-open SMIOL file...\n");
 		return -1;
@@ -2930,7 +2931,7 @@ int test_attributes(FILE *test_log)
 
 	/* Create a SMIOL file for testing attribute routines */
 	file = NULL;
-	ierr = SMIOL_open_file(context, "test_atts.nc", SMIOL_FILE_CREATE, &file, (size_t)64000000);
+	ierr = SMIOL_open_file(context, "test_atts.nc", SMIOL_FILE_CREATE, &file, (size_t)64000000, SMIOL_FORMAT_CDF5);
 	if (ierr != SMIOL_SUCCESS || file == NULL) {
 		fprintf(test_log, "Failed to create SMIOL file...\n");
 		return -1;
@@ -3165,7 +3166,7 @@ int test_attributes(FILE *test_log)
 
 	/* Re-open the SMIOL file */
 	file = NULL;
-	ierr = SMIOL_open_file(context, "test_atts.nc", SMIOL_FILE_READ, &file, (size_t)0);
+	ierr = SMIOL_open_file(context, "test_atts.nc", SMIOL_FILE_READ, &file, (size_t)0, SMIOL_FORMAT_CDF5);
 	if (ierr != SMIOL_SUCCESS || file == NULL) {
 		fprintf(test_log, "Failed to re-open SMIOL file...\n");
 		return -1;
@@ -3384,7 +3385,7 @@ int test_file_sync(FILE *test_log)
 	}
 
 	/* Open a file for syncing */
-	ierr = SMIOL_open_file(context, "smiol_sync_file.nc", SMIOL_FILE_CREATE, &file, (size_t)64000000);
+	ierr = SMIOL_open_file(context, "smiol_sync_file.nc", SMIOL_FILE_CREATE, &file, (size_t)64000000, SMIOL_FORMAT_CDF5);
 	if (ierr != SMIOL_SUCCESS || file == NULL) {
 		fprintf(test_log, "Failed to open `smiol_sycn_file.nc\n");
 		return -1;
@@ -3415,7 +3416,7 @@ int test_file_sync(FILE *test_log)
 
 
 	/* Testing SMIOL_sync_file on a file opened with SMIOL_FILE_WRITE */
-	ierr = SMIOL_open_file(context, "smiol_sync_file.nc", SMIOL_FILE_WRITE, &file, (size_t)64000000);
+	ierr = SMIOL_open_file(context, "smiol_sync_file.nc", SMIOL_FILE_WRITE, &file, (size_t)64000000, SMIOL_FORMAT_CDF5);
 	if (ierr != SMIOL_SUCCESS || file == NULL) {
 		fprintf(test_log, "Failed to open `smiol_sync_file.nc in write mode\n");
 		return -1;
@@ -3445,7 +3446,7 @@ int test_file_sync(FILE *test_log)
 	}
 
 	/* Testing SMIOL_sync_file on a file opened with SMIOL_FILE_READ*/
-	ierr = SMIOL_open_file(context, "smiol_sync_file.nc", SMIOL_FILE_READ, &file, (size_t)0);
+	ierr = SMIOL_open_file(context, "smiol_sync_file.nc", SMIOL_FILE_READ, &file, (size_t)0, SMIOL_FORMAT_CDF5);
 	if (ierr != SMIOL_SUCCESS || file == NULL) {
 		fprintf(test_log, "Failed to open `smiol_sync_file.nc with SMIOL_FILE_READ\n");
 		return -1;
@@ -4480,7 +4481,7 @@ int test_set_get_frame(FILE* test_log)
 	/* See if the frame is set correctly when opening a file */
 	fprintf(test_log, "Everything OK - Frame set correct on file open: ");
 	file = NULL;
-	ierr = SMIOL_open_file(context, "test_frame.nc", SMIOL_FILE_CREATE, &file, (size_t)64000000);
+	ierr = SMIOL_open_file(context, "test_frame.nc", SMIOL_FILE_CREATE, &file, (size_t)64000000, SMIOL_FORMAT_CDF5);
 	if (ierr != SMIOL_SUCCESS || file == NULL) {
 		fprintf(test_log, "Failed to create SMIOL file...\n");
 		return -1;
@@ -4695,7 +4696,7 @@ int test_put_get_vars(FILE *test_log)
 
 	/* Create a SMIOL file */
 	file = NULL;
-	ierr = SMIOL_open_file(context, "test_put_get_vars.nc", SMIOL_FILE_CREATE, &file, (size_t)64000000);
+	ierr = SMIOL_open_file(context, "test_put_get_vars.nc", SMIOL_FILE_CREATE, &file, (size_t)64000000, SMIOL_FORMAT_CDF5);
 	if (ierr != SMIOL_SUCCESS || file == NULL) {
 		fprintf(test_log, "Failed to create SMIOL file...\n");
 		return -1;
@@ -5078,7 +5079,7 @@ int test_put_get_vars(FILE *test_log)
 
 	/* Re-open the SMIOL file */
 	file = NULL;
-	ierr = SMIOL_open_file(context, "test_put_get_vars.nc", SMIOL_FILE_READ, &file, (size_t)0);
+	ierr = SMIOL_open_file(context, "test_put_get_vars.nc", SMIOL_FILE_READ, &file, (size_t)0, SMIOL_FORMAT_CDF5);
 	if (ierr != SMIOL_SUCCESS || file == NULL) {
 		fprintf(test_log, "Failed to create SMIOL file...\n");
 		return -1;
@@ -5580,7 +5581,7 @@ int test_io_aggregation(FILE *test_log)
 	 * Create a new file, to which we will write using all three of the decompositions from above
 	 */
 	file = NULL;
-	ierr = SMIOL_open_file(context, "test_agg.nc", SMIOL_FILE_CREATE, &file, (size_t)64000000);
+	ierr = SMIOL_open_file(context, "test_agg.nc", SMIOL_FILE_CREATE, &file, (size_t)64000000, SMIOL_FORMAT_CDF5);
 	if (ierr != SMIOL_SUCCESS || file == NULL) {
 		fprintf(test_log, "Failed to create a file for testing aggregation\n");
 		return -1;
@@ -5674,7 +5675,7 @@ int test_io_aggregation(FILE *test_log)
 	}
 
 	file = NULL;
-	ierr = SMIOL_open_file(context, "test_agg.nc", SMIOL_FILE_READ, &file, (size_t)0);
+	ierr = SMIOL_open_file(context, "test_agg.nc", SMIOL_FILE_READ, &file, (size_t)0, SMIOL_FORMAT_CDF5);
 	if (ierr != SMIOL_SUCCESS || file == NULL) {
 		fprintf(test_log, "Failed to open file that was created for testing aggregation\n");
 		return -1;
@@ -5887,7 +5888,7 @@ int test_buffered_io(FILE *test_log)
 		snprintf(filename, 64, "buffered_write_%dMB.nc", (int)(bufsize / 1024ul / 1024ul));
 
 		file = NULL;
-		ierr = SMIOL_open_file(context, filename, SMIOL_FILE_CREATE, &file, bufsize);
+		ierr = SMIOL_open_file(context, filename, SMIOL_FILE_CREATE, &file, bufsize, SMIOL_FORMAT_CDF5);
 		if (ierr != SMIOL_SUCCESS || file == NULL) {
 			fprintf(test_log, "Failed to create a file for testing buffered I/O\n");
 			return -1;

--- a/src/smiol.c
+++ b/src/smiol.c
@@ -1994,6 +1994,8 @@ const char *SMIOL_error_string(int errno)
 		return "argument is of the wrong type";
 	case SMIOL_INSUFFICIENT_ARG:
 		return "argument is of insufficient size";
+	case SMIOL_INVALID_FORMAT:
+		return "invalid format for file creation";
 	default:
 		return "Unknown error";
 	}

--- a/src/smiol.c
+++ b/src/smiol.c
@@ -200,6 +200,9 @@ int SMIOL_inquire(void)
  * blocking write interface, while a nonzero value enables the use of the
  * non-blocking, buffered interface for writing.
  *
+ * When a file is opened with a mode of SMIOL_FILE_CREATE, the fformat argument
+ * is used to set the file format. Otherwise fformat is ignored.
+ *
  * Upon successful completion, SMIOL_SUCCESS is returned, and the file handle
  * argument will point to a valid file handle and the current frame for the
  * file will be set to zero. Otherwise, the file handle is NULL and an error
@@ -207,7 +210,7 @@ int SMIOL_inquire(void)
  *
  ********************************************************************************/
 int SMIOL_open_file(struct SMIOL_context *context, const char *filename,
-                    int mode, struct SMIOL_file **file, size_t bufsize)
+                    int mode, struct SMIOL_file **file, size_t bufsize, int fformat)
 {
 	int io_group;
 	MPI_Comm io_file_comm;
@@ -290,8 +293,24 @@ int SMIOL_open_file(struct SMIOL_context *context, const char *filename,
 	if (mode & SMIOL_FILE_CREATE) {
 #ifdef SMIOL_PNETCDF
 		if ((*file)->io_task) {
+			/*
+			 * Convert fformat to a PNetCDF file creation mode
+			 */
+			int filecmode;
+			if (fformat == SMIOL_FORMAT_CDF2) {
+				filecmode = NC_64BIT_OFFSET;
+			} else if (fformat == SMIOL_FORMAT_CDF5) {
+				filecmode = NC_64BIT_DATA;
+			} else {
+				free((*file));
+				(*file) = NULL;
+				MPI_Comm_free(&io_file_comm);
+				MPI_Comm_free(&io_group_comm);
+				return SMIOL_INVALID_FORMAT;
+			}
+
 			ierr = ncmpi_create(io_file_comm, filename,
-			                    (NC_64BIT_DATA | NC_CLOBBER),
+			                    (filecmode | NC_CLOBBER),
 			                    MPI_INFO_NULL,
 			                    &((*file)->ncidp));
 		}

--- a/src/smiol.h
+++ b/src/smiol.h
@@ -21,7 +21,7 @@ int SMIOL_inquire(void);
  * File methods
  */
 int SMIOL_open_file(struct SMIOL_context *context, const char *filename,
-                    int mode, struct SMIOL_file **file, size_t bufsize);
+                    int mode, struct SMIOL_file **file, size_t bufsize, int fformat);
 int SMIOL_close_file(struct SMIOL_file **file);
 
 /*

--- a/src/smiol_codes.inc
+++ b/src/smiol_codes.inc
@@ -20,3 +20,6 @@
 #define SMIOL_INT32            (2002)
 #define SMIOL_CHAR             (2003)
 #define SMIOL_UNKNOWN_VAR_TYPE (2004)
+
+#define SMIOL_FORMAT_CDF2      (3000)
+#define SMIOL_FORMAT_CDF5      (3001)

--- a/src/smiol_codes.inc
+++ b/src/smiol_codes.inc
@@ -6,6 +6,7 @@
 #define SMIOL_LIBRARY_ERROR      (-5)
 #define SMIOL_WRONG_ARG_TYPE     (-6)
 #define SMIOL_INSUFFICIENT_ARG   (-7)
+#define SMIOL_INVALID_FORMAT     (-8)
 
 #define SMIOL_FILE_CREATE         (1)
 #define SMIOL_FILE_READ           (2)


### PR DESCRIPTION
This PR enhances SMIOL by adding the ability to create files of different formats.

For now there are only two defined corresponding to the CDF2 (NC_64BIT_OFFSET) and CDF5 (NC_64BIT_DATA) formats. This list can be expanded in the future.

As an example use case: if MPAS-A is restarted with a NC_64BIT_OFFSET restart file, that should be detected and output files created should be the same or compatible format. Before this change, SMIOL would not be able to use create files in any format besides NC_64BIT_DATA.